### PR TITLE
Avoid `make reg` error when OMI is a symlink

### DIFF
--- a/LCM/GNUmakefile
+++ b/LCM/GNUmakefile
@@ -33,6 +33,6 @@ deploydsc:
 	cp  -r $(TOP)/dsc/mof/MSFT_LogResource.schema.mof $(CONFIG_SYSCONFDIR)/dsc/configuration/schema/MSFT_LogResource
 	cp  -r $(TOP)/dsc/mof/MSFT_LogResource.registration.mof $(CONFIG_SYSCONFDIR)/dsc/configuration/registration/MSFT_LogResource
 	cp  $(TOP)/../Providers/Extras/Scripts/base_dsc.conf $(CONFIG_SYSCONFDIR)/dsc/dsc.conf
-	cp $(BINDIR)/ConsistencyInvoker $(CONFIG_BINDIR)/
+	test -L $(OMI) || cp $(BINDIR)/ConsistencyInvoker $(CONFIG_BINDIR)/
 	$(CONFIG_BINDIR)/omireg -n "root/Microsoft/DesiredStateConfiguration" $(LIBDIR)/libdsccore.so
 	ln -fs $(CONFIG_SYSCONFDIR)/omiregister/root-Microsoft-DesiredStateConfiguration $(CONFIG_SYSCONFDIR)/omiregister/root-Microsoft-Windows-DesiredStateConfiguration


### PR DESCRIPTION
In the special case of the `$(OMI)` directory being a symlink and DSC
being configured with `--local` (that is, a typical developer setup),
the `make reg` step would fail before registering `libdsccore` because
it attempted to copy a file from OMI to OMI, and in this case they're
the same directory.

Only attempt the copy if the OMI directory is not a symlink.