### PR TITLE
Python defunct fixes

### DIFF
--- a/Providers/PythonProvider.cpp
+++ b/Providers/PythonProvider.cpp
@@ -30,6 +30,7 @@
 #include <sstream>
 #include <sys/socket.h>
 #include <unistd.h>
+#include <sys/wait.h>
 
 
 namespace
@@ -235,6 +236,10 @@ PythonProvider::~PythonProvider ()
     {
         close (m_FD);
     }
+    if (m_pid != -2)
+    {
+	waitpid(m_pid, NULL, 0);
+    }
 }
 
 
@@ -419,8 +424,8 @@ PythonProvider::forkExec ()
         {
             // socketpair succeeded
             SCX_BOOKEND_PRINT ("socketpair - succeeded");
-            int pid = fork ();
-            if (0 == pid)
+            int m_pid = fork ();
+            if (0 == m_pid)
             {
                 // fork succeded, this is the child process
                 SCX_BOOKEND_PRINT ("fork - succeeded: this is the child");
@@ -447,7 +452,7 @@ PythonProvider::forkExec ()
                 strm.clear ();
                 rval = EXIT_FAILURE;
             }
-            else if (-1 != pid)
+            else if (-1 != m_pid)
             {
                 // fork succeeded, this is the parent process
                 SCX_BOOKEND_PRINT ("fork - succeeded: this is the parent");

--- a/Providers/PythonProvider.hpp
+++ b/Providers/PythonProvider.hpp
@@ -141,6 +141,7 @@ private:
 
     std::string const m_Name;
     int m_FD;
+    int m_pid;
 };
 
 
@@ -155,6 +156,7 @@ PythonProvider::PythonProvider (
     T const& name)
     : m_Name (name)
     , m_FD (PythonProvider::INVALID_SOCKET)
+    , m_pid (-2)
 {
     // empty
 }

--- a/Providers/Scripts/client.py
+++ b/Providers/Scripts/client.py
@@ -131,6 +131,8 @@ def handle_request (fd, req):
 
 
 def main (argv):
+    default_timeout_sec = 85
+    socket.setdefaulttimeout(default_timeout_sec)
     fd = socket.fromfd (int (argv[1]), socket.AF_UNIX, socket.SOCK_STREAM)
     read = 1
     out = ''


### PR DESCRIPTION
Adding a timeout for the client.py socket of 85 seconds (since OMI's is 90 seconds) and adding a call to waitpid on the python process on the unload of DSC resource provider.