### PR TITLE
Defunct fix

### DIFF
--- a/Providers/PythonProvider.cpp
+++ b/Providers/PythonProvider.cpp
@@ -524,7 +524,7 @@ PythonProvider::forkExec ()
         {
             // socketpair succeeded
             SCX_BOOKEND_PRINT ("socketpair - succeeded");
-            int m_pid = fork ();
+            m_pid = fork ();
             if (0 == m_pid)
             {
                 // fork succeded, this is the child process


### PR DESCRIPTION
The m_pid member variable was not being updated (sometimes?  not sure why sometimes it works and sometimes it doesn't.  Could be Debug/Release related?) because it was declared as a local variable.