### PR TITLE
Enable registration for omsconfig

### DIFF
--- a/LCM/dsc/engine/ConfigurationManager/LocalConfigManagerHelper.c
+++ b/LCM/dsc/engine/ConfigurationManager/LocalConfigManagerHelper.c
@@ -4035,7 +4035,12 @@ MI_Result DoRegistration(
 	    result = DeleteRegistrationKeyFromManagerInstance(lcmContext, &managerInstances->data[i], typeOfDownloadManagerInstance, cimErrorDetails);
 	    EH_CheckResult(result);
 	}
-
+#else
+	result = RegistrationManager_RunRequest(registrationManager, registrationRequest, cimErrorDetails);
+	EH_CheckResult(result);
+	
+	result = DeleteRegistrationKeyFromManagerInstance(lcmContext, &managerInstances->data[i], typeOfDownloadManagerInstance, cimErrorDetails);
+	EH_CheckResult(result);
 #endif
 
 	// TODO, insivara : Write events

--- a/LCM/dsc/engine/ConfigurationManager/LocalConfigManagerHelper.c
+++ b/LCM/dsc/engine/ConfigurationManager/LocalConfigManagerHelper.c
@@ -6239,6 +6239,11 @@ MI_Result MI_CALL LCM_Pull_Execute(
 
                 if (numModulesInstalled > 0)
                 {
+		    result = ModuleManager_Update(moduleManager, cimErrorDetails);
+		    if (result != MI_RESULT_OK)
+		    {
+			return result;
+		    }
                     system(OMI_RELOAD_COMMAND);
                 }
 

--- a/LCM/dsc/engine/ConfigurationManager/RegistrationManagerHelper.c
+++ b/LCM/dsc/engine/ConfigurationManager/RegistrationManagerHelper.c
@@ -108,17 +108,23 @@ MI_Result Register(
     MI_Uint32 getActionStatusCode;
     MI_Char* resultStatus = NULL;
     MI_Char* thumbprint = NULL;
+    MI_Value value;
     int systemResult = 0;
 
     if (cimErrorDetails)
     {
         *cimErrorDetails = NULL;
     }
-    
-#if defined(BUILD_OMS)
-    return MI_RESULT_OK;
-#endif
 
+#if defined(BUILD_OMS)
+    // Check if RegistrationKey is specified.  If so, allow registration for OMS. Otherwise, do not attempt to register.
+    result = MI_Instance_GetElement(registrationData, MSFT_RegistrationKey_Name, &value, NULL, NULL, NULL);
+    if (result != MI_RESULT_OK)
+    {
+	return MI_RESULT_OK;
+    }
+#endif
+    
     // Check the cache for a given serverUrl
     result = GetThumbprintForRegisteredServerURL(self, request->registrationData, &thumbprint, cimErrorDetails);
     if (thumbprint == NULL)

--- a/LCM/dsc/engine/ConfigurationManager/RegistrationManagerHelper.c
+++ b/LCM/dsc/engine/ConfigurationManager/RegistrationManagerHelper.c
@@ -118,7 +118,7 @@ MI_Result Register(
 
 #if defined(BUILD_OMS)
     // Check if RegistrationKey is specified.  If so, allow registration for OMS. Otherwise, do not attempt to register.
-    result = MI_Instance_GetElement(registrationData, MSFT_RegistrationKey_Name, &value, NULL, NULL, NULL);
+    result = MI_Instance_GetElement(request->registrationData, MSFT_RegistrationKey_Name, &value, NULL, NULL, NULL);
     if (result != MI_RESULT_OK)
     {
 	return MI_RESULT_OK;

--- a/LCM/dsc/engine/ConfigurationManager/RegistrationManagerHelper.c
+++ b/LCM/dsc/engine/ConfigurationManager/RegistrationManagerHelper.c
@@ -108,12 +108,22 @@ MI_Result Register(
     MI_Uint32 getActionStatusCode;
     MI_Char* resultStatus = NULL;
     MI_Char* thumbprint = NULL;
+    MI_Value value;
     int systemResult = 0;
 
     if (cimErrorDetails)
     {
         *cimErrorDetails = NULL;
     }
+
+#if defined(BUILD_OMS)
+    // Check if RegistrationKey is specified. If not specified, do not attempt to register.
+    result = MI_Instance_GetElement(request->registrationData, MSFT_RegistrationKey_Name, &value, NULL, NULL, NULL);
+    if (result != MI_RESULT_OK)
+    {
+	return MI_RESULT_OK;
+    }
+#endif
 
     // Check the cache for a given serverUrl
     result = GetThumbprintForRegisteredServerURL(self, request->registrationData, &thumbprint, cimErrorDetails);

--- a/LCM/dsc/engine/ConfigurationManager/RegistrationManagerHelper.c
+++ b/LCM/dsc/engine/ConfigurationManager/RegistrationManagerHelper.c
@@ -109,6 +109,7 @@ MI_Result Register(
     MI_Char* resultStatus = NULL;
     MI_Char* thumbprint = NULL;
     MI_Value value;
+    MI_Uint32 flags;
     int systemResult = 0;
 
     if (cimErrorDetails)
@@ -116,10 +117,11 @@ MI_Result Register(
         *cimErrorDetails = NULL;
     }
 
+
 #if defined(BUILD_OMS)
     // Check if RegistrationKey is specified. If not specified, do not attempt to register.
-    result = MI_Instance_GetElement(request->registrationData, MSFT_RegistrationKey_Name, &value, NULL, NULL, NULL);
-    if (result != MI_RESULT_OK)
+    result = MI_Instance_GetElement(request->registrationData, MSFT_RegistrationKey_Name, &value, NULL, &flags, NULL);
+    if (result != MI_RESULT_OK || flags & MI_FLAG_NULL || value.string == NULL || value.string[0] == '\0')
     {
 	return MI_RESULT_OK;
     }

--- a/LCM/dsc/engine/ConfigurationManager/RegistrationManagerHelper.c
+++ b/LCM/dsc/engine/ConfigurationManager/RegistrationManagerHelper.c
@@ -108,7 +108,6 @@ MI_Result Register(
     MI_Uint32 getActionStatusCode;
     MI_Char* resultStatus = NULL;
     MI_Char* thumbprint = NULL;
-    MI_Value value;
     int systemResult = 0;
 
     if (cimErrorDetails)
@@ -116,15 +115,6 @@ MI_Result Register(
         *cimErrorDetails = NULL;
     }
 
-#if defined(BUILD_OMS)
-    // Check if RegistrationKey is specified.  If so, allow registration for OMS. Otherwise, do not attempt to register.
-    result = MI_Instance_GetElement(request->registrationData, MSFT_RegistrationKey_Name, &value, NULL, NULL, NULL);
-    if (result != MI_RESULT_OK)
-    {
-	return MI_RESULT_OK;
-    }
-#endif
-    
     // Check the cache for a given serverUrl
     result = GetThumbprintForRegisteredServerURL(self, request->registrationData, &thumbprint, cimErrorDetails);
     if (thumbprint == NULL)

--- a/LCM/dsc/engine/EngineHelper/EngineHelperInternal.h
+++ b/LCM/dsc/engine/EngineHelper/EngineHelperInternal.h
@@ -459,7 +459,7 @@ typedef MI_InstancePtr* MI_InstancePtrPtr;
 #define OMI_CONSISTENCY_TASKSCHEDULE_NAME CONFIG_BINDIR PATH_SEPARATOR MI_T("OMSConsistencyInvoker")
 #define OAAS_KEYPATH MI_T("/etc/opt/microsoft/omsagent/certs/") OAAS_KEY
 #define OAAS_CERTPATH MI_T("/etc/opt/microsoft/omsagent/certs/") OAAS_CERT
-#define OAAS_THUMBPRINTPATH MI_T("/etc/opt/omi/conf/omsconfig/certs/") OAAS_THUMBPRINT
+#define OAAS_THUMBPRINTPATH MI_T("/etc/opt/microsoft/omsagent/certs/") OAAS_THUMBPRINT
 #else
 #define OAAS_KEY MI_T("oaas.key")
 #define OAAS_CERT MI_T("oaas.crt")

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ INSTALLBUILDER_DIR=installbuilder
 ifeq ($(BUILD_OMS),BUILD_OMS)
 CONFIG_SYSCONFDIR_DSC=omsconfig
 DSC_NAMESPACE=root/oms
-OAAS_CERTPATH=/etc/opt/microsoft/omsagent/certs/oaas.crt
+OAAS_CERTPATH=/etc/opt/microsoft/omsagent/certs/oms.crt
 PYTHON_PID_DIR=/var/opt/microsoft/omsconfig
 BUILD_OMS_VAL=1
 else

--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -220,10 +220,7 @@ for prov in ${{PROVIDERS}}; do
 done
 
 #if BUILD_OMS == 1
-chown -R ${{RUN_AS_USER}} /etc/opt/omi/conf/${{SHORT_NAME}}
-chown -R ${{RUN_AS_USER}} $OMI_REGISTER_DIR/root-oms
 /usr/sbin/usermod -g omiusers omsagent
-chown -R omsagent /opt/microsoft/omsagent/plugin
 
 # Set up the nxOMSAgent module
 /opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nx_1.0.zip 0
@@ -231,6 +228,9 @@ chown -R omsagent /opt/microsoft/omsagent/plugin
 /opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSCustomLog_1.0.zip 0
 /opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSPlugin_1.0.zip 0
 
+chown -R ${{RUN_AS_USER}} /opt/microsoft/omsagent/plugin
+chown -R ${{RUN_AS_USER}} /etc/opt/omi/conf/${{SHORT_NAME}}
+chown -R ${{RUN_AS_USER}} $OMI_REGISTER_DIR/root-oms
 chown -R ${{RUN_AS_USER}} /opt/microsoft/omsconfig/modules
 
 #else

--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -231,6 +231,8 @@ chown -R omsagent /opt/microsoft/omsagent/plugin
 /opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSCustomLog_1.0.zip 0
 /opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSPlugin_1.0.zip 0
 
+chown -R ${{RUN_AS_USER}} /opt/microsoft/omsconfig/modules
+
 #else
 /opt/microsoft/dsc/Scripts/InstallModule.py /opt/microsoft/dsc/module_packages/nx_1.0.zip 0
 #endif

--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -223,10 +223,10 @@ done
 /usr/sbin/usermod -g omiusers omsagent
 
 # Set up the nxOMSAgent module
-/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nx_1.0.zip 0
-/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSAgent_1.0.zip 0
-/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSCustomLog_1.0.zip 0
-/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSPlugin_1.0.zip 0
+su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nx_1.0.zip 0"
+su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSAgent_1.0.zip 0"
+su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSCustomLog_1.0.zip 0"
+su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSPlugin_1.0.zip 0"
 
 chown -R ${{RUN_AS_USER}} /opt/microsoft/omsagent/plugin
 chown -R ${{RUN_AS_USER}} /etc/opt/omi/conf/${{SHORT_NAME}}

--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -252,7 +252,11 @@ fi
 ln -fs $LIBCURL_SO /opt/omi/lib/libcurl.so.3
 ln -fs $LIBCURL_SO /opt/omi/lib/libcurl.so.4
 
+#if BUILD_OMS == 1
+su - omsagent -c "/opt/microsoft/${{SHORT_NAME}}/Scripts/RegenerateInitFiles.py"
+#else
 /opt/microsoft/${{SHORT_NAME}}/Scripts/RegenerateInitFiles.py
+#endif
 
 /opt/omi/bin/service_control restart
 

--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -221,17 +221,16 @@ done
 
 #if BUILD_OMS == 1
 /usr/sbin/usermod -g omiusers omsagent
+chown -R ${{RUN_AS_USER}} /opt/microsoft/omsconfig/modules
+chown -R ${{RUN_AS_USER}} $OMI_REGISTER_DIR/root-oms
+chown -R ${{RUN_AS_USER}} /etc/opt/omi/conf/${{SHORT_NAME}}
+chown -R ${{RUN_AS_USER}} /opt/microsoft/omsagent/plugin
 
 # Set up the nxOMSAgent module
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nx_1.0.zip 0"
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSAgent_1.0.zip 0"
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSCustomLog_1.0.zip 0"
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSPlugin_1.0.zip 0"
-
-chown -R ${{RUN_AS_USER}} /opt/microsoft/omsagent/plugin
-chown -R ${{RUN_AS_USER}} /etc/opt/omi/conf/${{SHORT_NAME}}
-chown -R ${{RUN_AS_USER}} $OMI_REGISTER_DIR/root-oms
-chown -R ${{RUN_AS_USER}} /opt/microsoft/omsconfig/modules
 
 #else
 /opt/microsoft/dsc/Scripts/InstallModule.py /opt/microsoft/dsc/module_packages/nx_1.0.zip 0


### PR DESCRIPTION
This allows omsconfig to register with a pull server, if a metaconfig is applied with a registration key in a web manager.