### PR TITLE
CustomLog Ingests the Whole File

### DIFF
--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSCustomLog.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSCustomLog.py
@@ -119,7 +119,7 @@ def UpdateConf(CustomLogObjects):
         for customlog in CustomLogObjects:
             logname = customlog['LogName']
             filepaths = ','.join(customlog['FilePath'])
-            new_source+='\n<source>\n  type tail\n  path ' + filepaths + '\n  pos_file /var/opt/microsoft/omsagent/state/' + logname + '.pos\n  tag oms.blob.CustomLog.' + logname + '.*\n  format none\n</source>\n'
+            new_source+='\n<source>\n  type tail\n  path ' + filepaths + '\n  pos_file /var/opt/microsoft/omsagent/state/' + logname + '.pos\n  read_from_head true\n  tag oms.blob.CustomLog.' + logname + '.*\n  format none\n</source>\n'
     txt = header + new_source
     if os.path.isfile(conf_path): 
         shutil.copy2(conf_path, conf_path + '.bak')

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSCustomLog.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSCustomLog.py
@@ -120,7 +120,7 @@ def UpdateConf(CustomLogObjects):
         for customlog in CustomLogObjects:
             logname = customlog['LogName']
             filepaths = ','.join(customlog['FilePath'])
-            new_source+='\n<source>\n  type tail\n  path ' + filepaths + '\n  pos_file /var/opt/microsoft/omsagent/state/' + logname + '.pos\n  tag oms.blob.CustomLog.' + logname + '.*\n  format none\n</source>\n'
+            new_source+='\n<source>\n  type tail\n  path ' + filepaths + '\n  pos_file /var/opt/microsoft/omsagent/state/' + logname + '.pos\n  read_from_head true\n  tag oms.blob.CustomLog.' + logname + '.*\n  format none\n</source>\n'
     txt = header + new_source
     if os.path.isfile(conf_path): 
         shutil.copy2(conf_path, conf_path + '.bak')

--- a/Providers/Scripts/3.x/Scripts/nxOMSCustomLog.py
+++ b/Providers/Scripts/3.x/Scripts/nxOMSCustomLog.py
@@ -120,7 +120,7 @@ def UpdateConf(CustomLogObjects):
         for customlog in CustomLogObjects:
             logname = customlog['LogName']
             filepaths = ','.join(customlog['FilePath'])
-            new_source+='\n<source>\n  type tail\n  path ' + filepaths + '\n  pos_file /var/opt/microsoft/omsagent/state/' + logname + '.pos\n  tag oms.blob.CustomLog.' + logname + '.*\n  format none\n</source>\n'
+            new_source+='\n<source>\n  type tail\n  path ' + filepaths + '\n  pos_file /var/opt/microsoft/omsagent/state/' + logname + '.pos\n  read_from_head true\n  tag oms.blob.CustomLog.' + logname + '.*\n  format none\n</source>\n'
     txt = header + new_source
     if os.path.isfile(conf_path): 
         shutil.copy2(conf_path, conf_path + '.bak')


### PR DESCRIPTION
Set the read_from_head flag to true in the tail plugin, so that the CustomLog will ingest the file from the beginning.
@Microsoft/omsagent-devs 