### PR TITLE
Adding error msg so users know to update cURL and SSL libraries

### DIFF
--- a/LCM/dsc/engine/lcm/strings.inc
+++ b/LCM/dsc/engine/lcm/strings.inc
@@ -454,7 +454,7 @@ INTERNAL_Intlstr_Define2( ID_PULL_CURLPERFORMFAILED,
 			  ID_PULL_CURLPERFORMFAILED,
       			  _In_z_ const PAL_Char*, firstString,
                           _In_z_ const PAL_Char*, secondString,
-                 	  "cURL failed to perform on this base url: " Intlstr_tstr(1)  " with this error message: "  Intlstr_tstr(2) ".")
+                 	  "cURL failed to perform on this base url: " Intlstr_tstr(1)  " with this error message: "  Intlstr_tstr(2) ". Make sure cURL and SSL libraries are up to date.")
 
 INTERNAL_Intlstr_Define0( ID_PULL_INVALIDRESPONSEFROMSERVER,
 			  ID_PULL_INVALIDRESPONSEFROMSERVER,

--- a/Providers/Extras/Scripts/omsconfig_logrotate.conf
+++ b/Providers/Extras/Scripts/omsconfig_logrotate.conf
@@ -1,9 +1,6 @@
-/var/opt/omi/log/*.log /var/opt/microsoft/omsconfig/omsconfig.log {
+/var/opt/microsoft/omsconfig/omsconfig.log {
     rotate 5
     sharedscripts
     weekly
     compress
-    postrotate
-	/opt/omi/bin/service_control restart
-    endscript
 }


### PR DESCRIPTION
On some really old platforms that have very old versions of cURL, a user might get:

/opt/omi/bin/omicli: result: MI_RESULT_FAILED
/opt/omi/bin/omicli: result: cURL failed to perform on this base url: scus-agentservice-prod-1.azure-automation.net with this error message: **SSL connect error.**


This error message update informs them they may need to update their version of cURL and/or SSL libraries.
