### PR TITLE
nxService.py - Log and return error from Inventory_Marshall() if 'Con…

### DIFF
--- a/Providers/Scripts/2.4x-2.5x/Scripts/Tests/test_nxProviders.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/Tests/test_nxProviders.py
@@ -1987,6 +1987,18 @@ class nxServiceTestCases(unittest2.TestCase):
         self.assertTrue(r[0] == 0,"Inventory_Marshall('*', " + self.provider + "provider, False,'')  should return == 0")
         print repr(r[1])
 
+    def testInventoryMarshallControllerWildcard(self):
+        r=nxService.Inventory_Marshall('*', '*', False,'')
+        self.assertTrue(r[0] == 0,"Inventory_Marshall('*', " + self.provider + "provider, False,'')  should return == 0")
+        print repr(r[1])
+
+    def testInventoryMarshallControllerError(self):
+        l = ['systemd', 'upstart', 'init']
+        l.remove(self.provider)
+        r=nxService.Inventory_Marshall('*', l[0], False,'')
+        self.assertTrue(r[0] == -1,"Inventory_Marshall('*', " + self.provider + "provider, False,'')  should return == -1")
+        print repr(r[1])
+
     def testInventoryMarshallDummyService(self):
         self.assertTrue(nxService.Set_Marshall("dummy_service", self.provider, True, "running")==
                         [0],'nxService.Set_Marshall("dummy_service", "'+self.provider+'", True, "running") should return ==[0]')
@@ -2028,6 +2040,7 @@ class nxServiceTestCases(unittest2.TestCase):
                         'CheckInventory("Gummy_service", self.provider, True, "", r[1]) should == False')
 
     def testInventoryMarshallDummyServiceFilterNameError(self):
+        time.sleep(3)
         self.assertTrue(nxService.Set_Marshall("dummy_service", self.provider, True, "running")==
                         [0],'nxService.Set_Marshall("dummy_service", "'+self.provider+'", True, "running") should return ==[0]')
         r=nxService.Inventory_Marshall('dummy?*rice', self.provider, True,'')
@@ -2036,6 +2049,7 @@ class nxServiceTestCases(unittest2.TestCase):
                         'CheckInventory("dummy?*rice", self.provider, True, "", r[1]) should == False')
 
     def testInventoryMarshallDummyServiceFilterEnabledError(self):
+        time.sleep(3)
         self.assertTrue(nxService.Set_Marshall("dummy_service", self.provider, True, "running")==
                         [0],'nxService.Set_Marshall("dummy_service", "'+self.provider+'", True, "running") should return ==[0]')
         r=nxService.Inventory_Marshall('dummy?*ice', self.provider, True,'')

--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxService.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxService.py
@@ -108,10 +108,11 @@ def Inventory_Marshall(Name, Controller, Enabled, State):
     (Name, Controller, Enabled, State) = init_vars(
         Name, Controller, Enabled, State)
     if Controller == '':
-        return [-1], {"__Inventory":{}}
+        return -1, {"__Inventory":{}}
     sc = ServiceContext(Name, Controller, Enabled, State)
     sc.FilterEnabled = FilterEnabled
-    GetAll(sc)
+    if not GetAll(sc):
+        return  -1, {"__Inventory":{}}
     for srv in sc.services_list:
         srv['Name'] = protocol.MI_String(srv['Name'])
         srv['Controller'] = protocol.MI_String(srv['Controller'])
@@ -1316,11 +1317,11 @@ def GetOne(sc):
 
 def GetAll(sc):
     if sc.Controller == 'init':
-        InitdGetAll(sc)
+        return InitdGetAll(sc)
     if sc.Controller == 'systemd':
-        SystemdGetAll(sc)
+        return SystemdGetAll(sc)
     if sc.Controller == 'upstart':
-        UpstartGetAll(sc)
+        return UpstartGetAll(sc)
 
 def GetRunlevels(sc):
     if sc.runlevels_d == None:
@@ -1347,6 +1348,10 @@ def GetRunlevels(sc):
 
 def SystemdGetAll(sc):
     d = {}
+    if os.system('which systemctl') != 0:
+        Print("Error: Controller incorectly specified", file=sys.stderr)
+        LG().Log('ERROR', "Error: 'Controller' incorrectly specified.")
+        return False
     Name=sc.Name
     if '*' not in Name and len(Name) > 0:
         Name = Name.replace('.service','')
@@ -1377,9 +1382,14 @@ def SystemdGetAll(sc):
         else:
             d['Runlevels'] = subs.sub('',s[1])
         sc.services_list.append(copy.deepcopy(d))
+    return True
 
 def UpstartGetAll(sc):
     d={}
+    if os.system('which initctl') != 0:
+        Print("Error: Controller incorectly specified", file=sys.stderr)
+        LG().Log('ERROR', "Error: 'Controller' incorrectly specified.")
+        return False
     cmd = "initctl list  | sed 's/[(].*[)] //g' | tr ', ' ' ' | awk '{print $1,$2}'"
     code, txt = RunGetOutput(cmd, False, False)
     services=txt.splitlines()
@@ -1410,9 +1420,14 @@ def UpstartGetAll(sc):
         code, out = RunGetOutput(cmd, False, False) 
         d['Runlevels'] = out[1:]
         sc.services_list.append(copy.deepcopy(d))
+    return True
 
 def InitdGetAll(sc):
     d={}
+    if os.system('which chkconfig') != 0:
+        Print("Error: Controller incorectly specified", file=sys.stderr)
+        LG().Log('ERROR', "Error: 'Controller' incorrectly specified.")
+        return False
     cmd = 'chkconfig -l | grep -vE "based| off"'
     code, txt = RunGetOutput(cmd, False, False)
     services=txt.splitlines()
@@ -1440,6 +1455,7 @@ def InitdGetAll(sc):
             continue
         d['Runlevels'] = reduce(lambda x, y: x + ' ' + y, s[1:])
         sc.services_list.append(copy.deepcopy(d))
+    return True
 
 def GetController():
     if UpstartExists():

--- a/Providers/Scripts/2.6x-2.7x/Scripts/Tests/test_nxProviders.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/Tests/test_nxProviders.py
@@ -1806,7 +1806,7 @@ class nxServiceTestCases(unittest2.TestCase):
         """
         Setup test resources
         """
-        self.provider = None
+        self.controller = None
         nxService.SetShowMof(True)
         print self.id() + '\n'
         dist=platform.dist()[0].lower()
@@ -1825,7 +1825,7 @@ class nxServiceTestCases(unittest2.TestCase):
         elif 'debian' in dist:
             init_file=debian_init_file
         if nxService.SystemdExists():
-            self.provider='systemd'
+            self.controller='systemd'
             try:
                 if 'ubuntu' in dist or 'cent' in dist:
                     nxService.WriteFile('/lib/systemd/system/dummy_service.service',init_file)
@@ -1839,7 +1839,7 @@ class nxServiceTestCases(unittest2.TestCase):
                 print repr(sys.exc_info())
             os.system('systemctl --system daemon-reload &> /dev/null')
         elif nxService.UpstartExists():
-            self.provider='upstart'
+            self.controller='upstart'
             try:
                 nxService.WriteFile('/etc/default/dummy_service',upstart_etc_default)
                 os.chmod('/etc/default/dummy_service',0744)
@@ -1852,7 +1852,7 @@ class nxServiceTestCases(unittest2.TestCase):
                 print repr(sys.exc_info())
 
         elif nxService.InitExists():
-            self.provider='init'
+            self.controller='init'
             try:
                 nxService.WriteFile('/etc/init.d/dummy_service',init_file)
                 os.chmod('/etc/init.d/dummy_service',0744)
@@ -1875,12 +1875,12 @@ class nxServiceTestCases(unittest2.TestCase):
             else:
                 os.system('rm /usr/sbin/dummy_service.py /etc/rc.d/dummy_service &> /dev/null')
             os.system('systemctl --system daemon-reload &> /dev/null')
-        elif nxService.InitExists():
-            os.system('chkconfig --del dummy_service &> /dev/null')
-            os.system('rm /usr/sbin/dummy_service.py /etc/init.d/dummy_service &> /dev/null')
         elif nxService.UpstartExists():
             os.system('update-rc.d -f dummy_service remove &> /dev/null')
             os.system('rm /usr/sbin/dummy_service.py /etc/init/dummy_service.conf /etc/init.d/dummy_service /etc/default/dummy_service &> /dev/null')
+        elif nxService.InitExists():
+            os.system('chkconfig --del dummy_service &> /dev/null')
+            os.system('rm /usr/sbin/dummy_service.py /etc/init.d/dummy_service &> /dev/null')
             
         time.sleep(1)
         os.system("ps -ef | grep -v grep | grep dummy_service | awk '{print $2}' | xargs -L1 kill &> /dev/null")
@@ -1934,147 +1934,155 @@ class nxServiceTestCases(unittest2.TestCase):
         return retval,d
 
     def testSetEnable(self):
-        provider=self.provider
-        self.assertTrue(nxService.Set_Marshall("dummy_service", provider, True, "running")==
-                        [0],'nxService.Set_Marshall("dummy_service", "'+provider+'", True, "running") should return ==[0]')
+        controller=self.controller
+        self.assertTrue(nxService.Set_Marshall("dummy_service", controller, True, "running")==
+                        [0],'nxService.Set_Marshall("dummy_service", "'+controller+'", True, "running") should return ==[0]')
 
     def testSetDisable(self):
-        provider=self.provider
-        self.assertTrue(nxService.Set_Marshall("dummy_service", provider, True, "running")==
-                        [0],'nxService.Set_Marshall("dummy_service", "'+provider+'", True, "running") should return ==[0]')
-        self.assertTrue(nxService.Set_Marshall("dummy_service", provider, False, "stopped")==
-                        [0],'nxService.Set_Marshall("dummy_service", "'+provider+'", False, "stopped") should return ==[0]')
+        controller=self.controller
+        self.assertTrue(nxService.Set_Marshall("dummy_service", controller, True, "running")==
+                        [0],'nxService.Set_Marshall("dummy_service", "'+controller+'", True, "running") should return ==[0]')
+        self.assertTrue(nxService.Set_Marshall("dummy_service", controller, False, "stopped")==
+                        [0],'nxService.Set_Marshall("dummy_service", "'+controller+'", False, "stopped") should return ==[0]')
 
     def testSetEnableError(self):
-        provider=self.provider
-        self.assertTrue(nxService.Set_Marshall("yummyservice", provider, True, "running")==
-                        [-1],'nxService.Set_Marshall("yummyservice", "'+provider+'", True, "running") should return ==[-1]')
+        controller=self.controller
+        self.assertTrue(nxService.Set_Marshall("yummyservice", controller, True, "running")==
+                        [-1],'nxService.Set_Marshall("yummyservice", "'+controller+'", True, "running") should return ==[-1]')
 
     def testSetDisableError(self):
-        provider=self.provider
-        self.assertTrue(nxService.Set_Marshall("yummyservice", provider, False, "stopped")==
-                        [-1],'nxService.Set_Marshall("yummyservice", "'+provider+'", False, "stopped") should return ==[-1]')
+        controller=self.controller
+        self.assertTrue(nxService.Set_Marshall("yummyservice", controller, False, "stopped")==
+                        [-1],'nxService.Set_Marshall("yummyservice", "'+controller+'", False, "stopped") should return ==[-1]')
 
     def testGetEnable(self):
-        provider=self.provider
-        self.assertTrue(nxService.Set_Marshall("dummy_service", provider, True, "running")==
-                        [0],'nxService.Set_Marshall("dummy_service", "'+provider+'", True, "running") should return ==[0]')
-        r=nxService.Get_Marshall("dummy_service", provider, True, "running")
+        controller=self.controller
+        self.assertTrue(nxService.Set_Marshall("dummy_service", controller, True, "running")==
+                        [0],'nxService.Set_Marshall("dummy_service", "'+controller+'", True, "running") should return ==[0]')
+        r=nxService.Get_Marshall("dummy_service", controller, True, "running")
         print repr(r[1])
-        self.assertTrue(check_values(r,self.make_MI(0,"dummy_service", provider, True, "running",None,None,None)) == True
-                        ,'nxService.Get_Marshall("dummy_service", "'+provider+'", True, "running") should return ==[0]')
+        self.assertTrue(check_values(r,self.make_MI(0,"dummy_service", controller, True, "running",None,None,None)) == True
+                        ,'nxService.Get_Marshall("dummy_service", "'+controller+'", True, "running") should return ==[0]')
 
     def testGetDisable(self):
-        provider=self.provider
-        self.assertTrue(nxService.Set_Marshall("dummy_service", provider, True, "running")==
-                        [0],'nxService.Set_Marshall("dummy_service", "'+provider+'", True, "running") should return ==[0]')
-        self.assertTrue(nxService.Set_Marshall("dummy_service", provider, False, "stopped")==
-                        [0],'nxService.Set_Marshall("dummy_service", "'+provider+'", False, "stopped") should return ==[0]')
-        r=nxService.Get_Marshall("dummy_service", provider, False, "stopped")
+        controller=self.controller
+        self.assertTrue(nxService.Set_Marshall("dummy_service", controller, True, "running")==
+                        [0],'nxService.Set_Marshall("dummy_service", "'+controller+'", True, "running") should return ==[0]')
+        self.assertTrue(nxService.Set_Marshall("dummy_service", controller, False, "stopped")==
+                        [0],'nxService.Set_Marshall("dummy_service", "'+controller+'", False, "stopped") should return ==[0]')
+        r=nxService.Get_Marshall("dummy_service", controller, False, "stopped")
         print 'GET:'+repr(r)
-        self.assertTrue(check_values(r,self.make_MI(0,"dummy_service", provider, False, "stopped", None, None, None)) == True
-                        ,'nxService.Get_Marshall("dummy_service", "'+provider+'", False, "stopped") should return ==[0,"dummy_service", provider, False, "stopped"]')
+        self.assertTrue(check_values(r,self.make_MI(0,"dummy_service", controller, False, "stopped", None, None, None)) == True
+                        ,'nxService.Get_Marshall("dummy_service", "'+controller+'", False, "stopped") should return ==[0,"dummy_service", controller, False, "stopped"]')
 
     def testGetEnableError(self):
-        provider=self.provider
-        self.assertTrue(nxService.Set_Marshall("yummyservice", provider, True, "running")==
-                        [-1],'nxService.Set_Marshall("yummyservice", "'+provider+'", True, "running") should return ==[-1]')
-        r=nxService.Get_Marshall("yummyservice", provider, True, "running")
+        controller=self.controller
+        self.assertTrue(nxService.Set_Marshall("yummyservice", controller, True, "running")==
+                        [-1],'nxService.Set_Marshall("yummyservice", "'+controller+'", True, "running") should return ==[-1]')
+        r=nxService.Get_Marshall("yummyservice", controller, True, "running")
         print 'GET:'+repr(r)
-        self.assertTrue(check_values(r,self.make_MI(0,"yummyservice", provider, True, "running", None, None, None)) == False
-                        ,'nxService.Get_Marshall("yummyservice", "'+provider+'", True, "running")[0:5] should return ==[-1,"yummyservice", provider, True, "running"]')
+        self.assertTrue(check_values(r,self.make_MI(0,"yummyservice", controller, True, "running", None, None, None)) == False
+                        ,'nxService.Get_Marshall("yummyservice", "'+controller+'", True, "running")[0:5] should return ==[-1,"yummyservice", controller, True, "running"]')
 
     def testGetDisableError(self):
-        provider=self.provider
-        self.assertTrue(nxService.Set_Marshall("yummyservice", provider, False, "stopped")==
-                        [-1],'nxService.Set_Marshall("yummyservice", "'+provider+'", False, "stopped") should return ==[-1]')
-        r=nxService.Get_Marshall("yummyservice", provider, False, "stopped")
+        controller=self.controller
+        self.assertTrue(nxService.Set_Marshall("yummyservice", controller, False, "stopped")==
+                        [-1],'nxService.Set_Marshall("yummyservice", "'+controller+'", False, "stopped") should return ==[-1]')
+        r=nxService.Get_Marshall("yummyservice", controller, False, "stopped")
         print 'GET:'+repr(r)
-        self.assertTrue(check_values(r,self.make_MI(0,"yummyservice", provider, False, "stopped", None, None, None)) == False
-                        ,'nxService.Get_Marshall("yummyservice", "'+provider+'", False, "stopped")[0:5] should return ==[-1,"yummyservice", provider, False, "stopped"]')
+        self.assertTrue(check_values(r,self.make_MI(0,"yummyservice", controller, False, "stopped", None, None, None)) == False
+                        ,'nxService.Get_Marshall("yummyservice", "'+controller+'", False, "stopped")[0:5] should return ==[-1,"yummyservice", controller, False, "stopped"]')
 
     def testInventoryMarshall(self):
-        r=nxService.Inventory_Marshall('*', self.provider, False,'')
-        self.assertTrue(r[0] == 0,"Inventory_Marshall('*', " + self.provider + "provider, False,'')  should return == 0")
+        r=nxService.Inventory_Marshall('*', self.controller, None,'')
+        self.assertTrue(r[0] == 0,"Inventory_Marshall('*', " + self.controller + ", None,'')  should return == 0")
         print repr(r[1])
 
     def testInventoryMarshallControllerWildcard(self):
-        r=nxService.Inventory_Marshall('*', '*', False,'')
-        self.assertTrue(r[0] == 0,"Inventory_Marshall('*', " + self.provider + "provider, False,'')  should return == 0")
+        r=nxService.Inventory_Marshall('*', '*', None,'')
+        self.assertTrue(r[0] == 0,"Inventory_Marshall('*', '*', None,'')  should return == 0")
         print repr(r[1])
 
     def testInventoryMarshallControllerError(self):
-        l = ['systemd', 'upstart', 'init']
-        l.remove(self.provider)
-        r=nxService.Inventory_Marshall('*', l[0], False,'')
-        self.assertTrue(r[0] == -1,"Inventory_Marshall('*', " + self.provider + "provider, False,'')  should return == -1")
+        controllers = ['systemd', 'upstart', 'init']
+        controllers.remove(self.controller)
+        r=nxService.Inventory_Marshall('*', controllers[0], None,'')
+        self.assertTrue(r[0] == -1,"Inventory_Marshall('*', " + self.controller + ", None,'')  should return == -1")
         print repr(r[1])
 
     def testInventoryMarshallDummyService(self):
-        self.assertTrue(nxService.Set_Marshall("dummy_service", self.provider, True, "running")==
-                        [0],'nxService.Set_Marshall("dummy_service", "'+self.provider+'", True, "running") should return ==[0]')
-        r=nxService.Inventory_Marshall('dummy_service', self.provider, True,'')
-        self.assertTrue(r[0] == 0,"Inventory_Marshall('dummy_service', " + self.provider + "provider, True,'')  should return == 0")
-        self.assertTrue(self.CheckInventory('dummy_service', self.provider, True, '', r[1]) == True, \
-                        'CheckInventory("dummy_service", self.provider, True, "", r[1]) should == True')
+        self.assertTrue(nxService.Set_Marshall("dummy_service", self.controller, True, "running")==
+                        [0],'nxService.Set_Marshall("dummy_service", "'+self.controller+'", True, "running") should return ==[0]')
+        r=nxService.Inventory_Marshall('dummy_service', self.controller, None,'')
+        self.assertTrue(r[0] == 0,"Inventory_Marshall('dummy_service', " + self.controller + ", None,'')  should return == 0")
+        self.assertTrue(self.CheckInventory('dummy_service', self.controller, None, '', r[1]) == True, \
+                        'CheckInventory("dummy_service", self.controller, None, "", r[1]) should == True')
 
     def testInventoryMarshallDummyServiceFilterName(self):
-        self.assertTrue(nxService.Set_Marshall("dummy_service", self.provider, True, "running")==
-                        [0],'nxService.Set_Marshall("dummy_service", "'+self.provider+'", True, "running") should return ==[0]')
-        r=nxService.Inventory_Marshall('dummy?*ice', self.provider, True,'')
-        self.assertTrue(r[0] == 0,"Inventory_Marshall('dummy?*ice', " + self.provider + "provider, True,'')  should return == 0")
-        self.assertTrue(self.CheckInventory('dummy?*ice', self.provider, True, '', r[1]) == True, \
-                        'CheckInventory("dummy?*ice", self.provider, True, "", r[1]) should == True')
+        self.assertTrue(nxService.Set_Marshall("dummy_service", self.controller, True, "running")==
+                        [0],'nxService.Set_Marshall("dummy_service", "'+self.controller+'", True, "running") should return ==[0]')
+        r=nxService.Inventory_Marshall('dummy?*ice', self.controller, None,'')
+        self.assertTrue(r[0] == 0,"Inventory_Marshall('dummy?*ice', " + self.controller + ", None,'')  should return == 0")
+        self.assertTrue(self.CheckInventory('dummy?*ice', self.controller, None, '', r[1]) == True, \
+                        'CheckInventory("dummy?*ice", ' + self.controller + ', None, "", r[1]) should == True')
 
     def testInventoryMarshallDummyServiceFilterEnabled(self):
-        self.assertTrue(nxService.Set_Marshall("dummy_service", self.provider, True, "running")==
-                        [0],'nxService.Set_Marshall("dummy_service", "'+self.provider+'", True, "running") should return ==[0]')
-        r=nxService.Inventory_Marshall('dummy?*ice', self.provider, True,'')
-        self.assertTrue(r[0] == 0,"Inventory_Marshall('dummy?*ice', " + self.provider + "provider, True,'')  should return == 0")
-        self.assertTrue(self.CheckInventory('dummy?*ice', self.provider, True, '', r[1]) == True, \
-                        'CheckInventory("dummy?*ice", self.provider, True, "", r[1]) should == True')
+        self.assertTrue(nxService.Set_Marshall("dummy_service", self.controller, True, "running")==
+                        [0],'nxService.Set_Marshall("dummy_service", "'+self.controller+'", True, "running") should return ==[0]')
+        r=nxService.Inventory_Marshall('dummy?*ice', self.controller, True,'')
+        self.assertTrue(r[0] == 0,"Inventory_Marshall('dummy?*ice', " + self.controller + ", True,'')  should return == 0")
+        self.assertTrue(self.CheckInventory('dummy?*ice', self.controller, True, '', r[1]) == True, \
+                        'CheckInventory("dummy?*ice", ' + self.controller + ', True, "", r[1]) should == True')
 
     def testInventoryMarshallDummyServiceFilterState(self):
-        self.assertTrue(nxService.Set_Marshall("dummy_service", self.provider, True, "running")==
-                        [0],'nxService.Set_Marshall("dummy_service", "'+self.provider+'", True, "running") should return ==[0]')
-        r=nxService.Inventory_Marshall('dummy?*ice', self.provider, True,'running')
-        self.assertTrue(r[0] == 0,"Inventory_Marshall('dummy?*ice', " + self.provider + "provider, True,'running')  should return == 0")
-        self.assertTrue(self.CheckInventory('dummy?*ice', self.provider, True, 'running', r[1]) == True, \
-                        'CheckInventory("dummy?*ice", self.provider, True, "running", r[1]) should == True')
+        # This test inconsistantly fails on slower systems.  The sleep here reduces these failures.
+        time.sleep(3)
+        self.assertTrue(nxService.Set_Marshall("dummy_service", self.controller, True, "running")==
+                        [0],'nxService.Set_Marshall("dummy_service", "'+self.controller+'", True, "running") should return ==[0]')
+        r=nxService.Inventory_Marshall('dummy?*ice', self.controller, None,'running')
+        self.assertTrue(r[0] == 0,"Inventory_Marshall('dummy?*ice', " + self.controller + ", None,'running')  should return == 0")
+        self.assertTrue(self.CheckInventory('dummy?*ice', self.controller, None, 'running', r[1]) == True, \
+                        'CheckInventory("dummy?*ice", ' + self.controller + ', None, "running", r[1]) should == True')
 
     def testInventoryMarshallDummyServiceError(self):
-        self.assertTrue(nxService.Set_Marshall("dummy_service", self.provider, True, "running")==
-                        [0],'nxService.Set_Marshall("dummy_service", "'+self.provider+'", True, "running") should return ==[0]')
-        r=nxService.Inventory_Marshall('Gummy_service', self.provider, True,'')
-        self.assertTrue(r[0] == 0, "Inventory_Marshall('Gummy_service', " + self.provider + "provider, True,'')  should return == 0")
-        self.assertTrue(self.CheckInventory('Gummy_service', self.provider, True, '', r[1]) == False, \
-                        'CheckInventory("Gummy_service", self.provider, True, "", r[1]) should == False')
+        # This test inconsistantly fails on slower systems.  The sleep here reduces these failures.
+        time.sleep(3)
+        self.assertTrue(nxService.Set_Marshall("dummy_service", self.controller, True, "running")==
+                        [0],'nxService.Set_Marshall("dummy_service", "'+self.controller+'", True, "running") should return ==[0]')
+        r=nxService.Inventory_Marshall('Gummy_service', self.controller, None,'')
+        self.assertTrue(r[0] == 0, "Inventory_Marshall('Gummy_service', " + self.controller + ", None,'')  should return == 0")
+        self.assertTrue(self.CheckInventory('Gummy_service', self.controller, None, '', r[1]) == False, \
+                        'CheckInventory("Gummy_service", self.controller, None, "", r[1]) should == False')
 
     def testInventoryMarshallDummyServiceFilterNameError(self):
+        # This test inconsistantly fails on slower systems.  The sleep here reduces these failures.
         time.sleep(3)
-        self.assertTrue(nxService.Set_Marshall("dummy_service", self.provider, True, "running")==
-                        [0],'nxService.Set_Marshall("dummy_service", "'+self.provider+'", True, "running") should return ==[0]')
-        r=nxService.Inventory_Marshall('dummy?*rice', self.provider, True,'')
-        self.assertTrue(r[0] == 0,"Inventory_Marshall('dummy?*rice', " + self.provider + "provider, True,'')  should return == 0")
-        self.assertTrue(self.CheckInventory('dummy?*rice', self.provider, True, '', r[1]) == False, \
-                        'CheckInventory("dummy?*rice", self.provider, True, "", r[1]) should == False')
+        self.assertTrue(nxService.Set_Marshall("dummy_service", self.controller, True, "running")==
+                        [0],'nxService.Set_Marshall("dummy_service", "'+self.controller+'", True, "running") should return ==[0]')
+        r=nxService.Inventory_Marshall('dummy?*rice', self.controller, None,'')
+        self.assertTrue(r[0] == 0,"Inventory_Marshall('dummy?*rice', " + self.controller + ", None,'')  should return == 0")
+        self.assertTrue(self.CheckInventory('dummy?*rice', self.controller, None, '', r[1]) == False, \
+                        'CheckInventory("dummy?*rice", self.controller, None, "", r[1]) should == False')
 
     def testInventoryMarshallDummyServiceFilterEnabledError(self):
+        # This test inconsistantly fails on slower systems.  The sleep here reduces these failures.
         time.sleep(3)
-        self.assertTrue(nxService.Set_Marshall("dummy_service", self.provider, True, "running")==
-                        [0],'nxService.Set_Marshall("dummy_service", "'+self.provider+'", True, "running") should return ==[0]')
-        r=nxService.Inventory_Marshall('dummy?*ice', self.provider, True,'')
-        self.assertTrue(r[0] == 0,"Inventory_Marshall('dummy?*ice', " + self.provider + "provider, True,'')  should return == 0")
-        self.assertTrue(self.CheckInventory('dummy?*ice', self.provider, False, '', r[1]) == False, \
-                        'CheckInventory("dummy?*ice", self.provider, False, "", r[1]) should == False')
+        self.assertTrue(nxService.Set_Marshall("dummy_service", self.controller, True, "running")==
+                        [0],'nxService.Set_Marshall("dummy_service", "'+self.controller+'", True, "running") should return ==[0]')
+        r=nxService.Inventory_Marshall('dummy?*ice', self.controller, False,'')
+        self.assertTrue(r[0] == 0,"Inventory_Marshall('dummy?*ice', " + self.controller + ", False,'')  should return == 0")
+        self.assertTrue(self.CheckInventory('dummy?*ice', self.controller, False, '', r[1]) == False, \
+                        'CheckInventory("dummy?*ice", ' + self.controller + ', False, "", r[1]) should == False')
 
     def testInventoryMarshallDummyServiceFilterStateError(self):
-        self.assertTrue(nxService.Set_Marshall("dummy_service", self.provider, True, "running")==
-                        [0],'nxService.Set_Marshall("dummy_service", "'+self.provider+'", True, "running") should return ==[0]')
-        r=nxService.Inventory_Marshall('dummy?*ice', self.provider, True,'stopped')
-        self.assertTrue(r[0] == 0,"Inventory_Marshall('dummy?*ice', " + self.provider + "provider, True,'stopped')  should return == 0")
-        self.assertTrue(self.CheckInventory('dummy?*ice', self.provider, True, 'stopped', r[1]) == False, \
-                        'CheckInventory("dummy?*ice", self.provider, True, "stopped", r[1]) should == False')
+        # This test inconsistantly fails on slower systems.  The sleep here reduces these failures.
+        time.sleep(3)
+        self.assertTrue(nxService.Set_Marshall("dummy_service", self.controller, True, "running")==
+                        [0],'nxService.Set_Marshall("dummy_service", "'+self.controller+'", True, "running") should return ==[0]')
+        r=nxService.Inventory_Marshall('dummy?*ice', self.controller, None,'stopped')
+        self.assertTrue(r[0] == 0,"Inventory_Marshall('dummy?*ice', " + self.controller + ", None,'stopped')  should return == 0")
+        self.assertTrue(self.CheckInventory('dummy?*ice', self.controller, None, 'stopped', r[1]) == False, \
+                        'CheckInventory("dummy?*ice", ' + self.controller + ', None, "stopped", r[1]) should == False')
 
 
 class nxSshAuthorizedKeysTestCases(unittest2.TestCase):

--- a/Providers/Scripts/2.6x-2.7x/Scripts/Tests/test_nxProviders.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/Tests/test_nxProviders.py
@@ -1998,6 +1998,18 @@ class nxServiceTestCases(unittest2.TestCase):
         self.assertTrue(r[0] == 0,"Inventory_Marshall('*', " + self.provider + "provider, False,'')  should return == 0")
         print repr(r[1])
 
+    def testInventoryMarshallControllerWildcard(self):
+        r=nxService.Inventory_Marshall('*', '*', False,'')
+        self.assertTrue(r[0] == 0,"Inventory_Marshall('*', " + self.provider + "provider, False,'')  should return == 0")
+        print repr(r[1])
+
+    def testInventoryMarshallControllerError(self):
+        l = ['systemd', 'upstart', 'init']
+        l.remove(self.provider)
+        r=nxService.Inventory_Marshall('*', l[0], False,'')
+        self.assertTrue(r[0] == -1,"Inventory_Marshall('*', " + self.provider + "provider, False,'')  should return == -1")
+        print repr(r[1])
+
     def testInventoryMarshallDummyService(self):
         self.assertTrue(nxService.Set_Marshall("dummy_service", self.provider, True, "running")==
                         [0],'nxService.Set_Marshall("dummy_service", "'+self.provider+'", True, "running") should return ==[0]')
@@ -2039,6 +2051,7 @@ class nxServiceTestCases(unittest2.TestCase):
                         'CheckInventory("Gummy_service", self.provider, True, "", r[1]) should == False')
 
     def testInventoryMarshallDummyServiceFilterNameError(self):
+        time.sleep(3)
         self.assertTrue(nxService.Set_Marshall("dummy_service", self.provider, True, "running")==
                         [0],'nxService.Set_Marshall("dummy_service", "'+self.provider+'", True, "running") should return ==[0]')
         r=nxService.Inventory_Marshall('dummy?*rice', self.provider, True,'')
@@ -2047,6 +2060,7 @@ class nxServiceTestCases(unittest2.TestCase):
                         'CheckInventory("dummy?*rice", self.provider, True, "", r[1]) should == False')
 
     def testInventoryMarshallDummyServiceFilterEnabledError(self):
+        time.sleep(3)
         self.assertTrue(nxService.Set_Marshall("dummy_service", self.provider, True, "running")==
                         [0],'nxService.Set_Marshall("dummy_service", "'+self.provider+'", True, "running") should return ==[0]')
         r=nxService.Inventory_Marshall('dummy?*ice', self.provider, True,'')

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxService.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxService.py
@@ -1278,8 +1278,8 @@ def Get(Name, Controller, Enabled, State):
     exit_code = 0
 
     if not sc.Controller:
-        Print("Error: Controller not specified", file=sys.stderr)
-        LG().Log('ERROR', "Error: Controller not specified")
+        Print("Error: Controller not specified.", file=sys.stderr)
+        LG().Log('ERROR', "Error: Controller not specified.")
         exit_code = -1
     elif sc.Controller == "systemd":
         if not ServiceExistsInSystemd(sc):
@@ -1367,8 +1367,8 @@ def GetRunlevels(sc):
 def SystemdGetAll(sc):
     d = {}
     if os.system('which systemctl') != 0:
-        Print("Error: Controller incorectly specified", file=sys.stderr)
-        LG().Log('ERROR', "Error: 'Controller' incorrectly specified.")
+        Print("Error: 'Controller' = " + sc.Controller + " is incorrectly specified.", file=sys.stderr)
+        LG().Log('ERROR', "Error: 'Controller' = " + sc.Controller + " is incorrectly specified.")
         return False
     Name=sc.Name
     if '*' not in Name and len(Name) > 0:
@@ -1404,24 +1404,35 @@ def SystemdGetAll(sc):
 
 def UpstartGetAll(sc):
     d={}
+    names={}
     if os.system('which initctl') != 0:
-        Print("Error: Controller incorectly specified", file=sys.stderr)
-        LG().Log('ERROR', "Error: 'Controller' incorrectly specified.")
+        Print("Error: 'Controller' = " + sc.Controller + " is incorrectly specified.", file=sys.stderr)
+        LG().Log('ERROR', "Error: 'Controller' = " + sc.Controller + " is incorrectly specified.")
         return False
     cmd = "initctl list  | sed 's/[(].*[)] //g' | tr ', ' ' ' | awk '{print $1,$2}'"
     code, txt = RunGetOutput(cmd, False, False)
-    services=txt.splitlines()
+    services = txt.splitlines()
+    cmd = "service --status-all &> /tmp/tmpfile ; cat /tmp/tmpfile ; rm /tmp/tmpfile"
+    code, txt = RunGetOutput(cmd, False, False)
+    txt = txt.replace('[','')
+    txt = txt.replace(']','')
+    services.extend(txt.splitlines())
     for srv in services:
         if len(srv) == 0:
             continue
         s=srv.split()
+        if len(s[0]) == 1: #swap them.
+            s.reverse()
         d['Name'] = s[0]
         if len(sc.Name) and not fnmatch.fnmatch(d['Name'],sc.Name):
             continue
+        if d['Name'] in names.keys():
+            continue
+        names[d['Name']] = None
         d['Controller'] =  sc.Controller
         d['Description'] = ''
         d['State'] = 'stopped'
-        if 'running' in s[1]:
+        if 'running' in s[1] or '+' in s[1]:
             d['State'] = 'running'
         if len(sc.State) and sc.State != d['State'].lower():
             continue
@@ -1434,17 +1445,20 @@ def UpstartGetAll(sc):
         d['Enabled'] = True
         if sc.FilterEnabled and sc.Enabled != d['Enabled']:
             continue
-        cmd = 'initctl show-config ' + d['Name'] + ' | grep -E "start |stop " | tr "\n" " " | tr -s " " '
-        code, out = RunGetOutput(cmd, False, False) 
-        d['Runlevels'] = out[1:]
+        if len(s[1]) > 1:
+            cmd = 'initctl show-config ' + d['Name'] + ' | grep -E "start |stop " | tr "\n" " " | tr -s " " '
+            code, out = RunGetOutput(cmd, False, False) 
+            d['Runlevels'] = out[1:]
+        else:
+            d['Runlevels'] = GetRunlevels(sc)
         sc.services_list.append(copy.deepcopy(d))
     return True
 
 def InitdGetAll(sc):
     d={}
     if os.system('which chkconfig') != 0:
-        Print("Error: Controller incorectly specified", file=sys.stderr)
-        LG().Log('ERROR', "Error: 'Controller' incorrectly specified.")
+        Print("Error: 'Controller' = " + sc.Controller + " is incorrectly specified.", file=sys.stderr)
+        LG().Log('ERROR', "Error: 'Controller' = " + sc.Controller + " is incorrectly specified.")
         return False
     cmd = 'chkconfig -l | grep -vE "based| off"'
     code, txt = RunGetOutput(cmd, False, False)

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxService.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxService.py
@@ -112,10 +112,11 @@ def Inventory_Marshall(Name, Controller, Enabled, State):
     (Name, Controller, Enabled, State) = init_vars(
         Name, Controller, Enabled, State)
     if Controller == '':
-        return [-1], {"__Inventory":{}}
+        return -1, {"__Inventory":{}}
     sc = ServiceContext(Name, Controller, Enabled, State)
     sc.FilterEnabled = FilterEnabled
-    GetAll(sc)
+    if not GetAll(sc):
+        return  -1, {"__Inventory":{}}
     for srv in sc.services_list:
         srv['Name'] = protocol.MI_String(srv['Name'])
         srv['Controller'] = protocol.MI_String(srv['Controller'])
@@ -1334,11 +1335,11 @@ def GetOne(sc):
 
 def GetAll(sc):
     if sc.Controller == 'init':
-        InitdGetAll(sc)
+        return InitdGetAll(sc)
     if sc.Controller == 'systemd':
-        SystemdGetAll(sc)
+        return SystemdGetAll(sc)
     if sc.Controller == 'upstart':
-        UpstartGetAll(sc)
+        return UpstartGetAll(sc)
 
 def GetRunlevels(sc):
     if sc.runlevels_d == None:
@@ -1365,6 +1366,10 @@ def GetRunlevels(sc):
 
 def SystemdGetAll(sc):
     d = {}
+    if os.system('which systemctl') != 0:
+        Print("Error: Controller incorectly specified", file=sys.stderr)
+        LG().Log('ERROR', "Error: 'Controller' incorrectly specified.")
+        return False
     Name=sc.Name
     if '*' not in Name and len(Name) > 0:
         Name = Name.replace('.service','')
@@ -1395,9 +1400,14 @@ def SystemdGetAll(sc):
         else:
             d['Runlevels'] = subs.sub('',s[1])
         sc.services_list.append(copy.deepcopy(d))
+    return True
 
 def UpstartGetAll(sc):
     d={}
+    if os.system('which initctl') != 0:
+        Print("Error: Controller incorectly specified", file=sys.stderr)
+        LG().Log('ERROR', "Error: 'Controller' incorrectly specified.")
+        return False
     cmd = "initctl list  | sed 's/[(].*[)] //g' | tr ', ' ' ' | awk '{print $1,$2}'"
     code, txt = RunGetOutput(cmd, False, False)
     services=txt.splitlines()
@@ -1428,9 +1438,14 @@ def UpstartGetAll(sc):
         code, out = RunGetOutput(cmd, False, False) 
         d['Runlevels'] = out[1:]
         sc.services_list.append(copy.deepcopy(d))
+    return True
 
 def InitdGetAll(sc):
     d={}
+    if os.system('which chkconfig') != 0:
+        Print("Error: Controller incorectly specified", file=sys.stderr)
+        LG().Log('ERROR', "Error: 'Controller' incorrectly specified.")
+        return False
     cmd = 'chkconfig -l | grep -vE "based| off"'
     code, txt = RunGetOutput(cmd, False, False)
     services=txt.splitlines()
@@ -1458,6 +1473,7 @@ def InitdGetAll(sc):
             continue
         d['Runlevels'] = reduce(lambda x, y: x + ' ' + y, s[1:])
         sc.services_list.append(copy.deepcopy(d))
+    return True
 
 def GetController():
     if UpstartExists():

--- a/Providers/Scripts/3.x/Scripts/Tests/test_nxProviders.py
+++ b/Providers/Scripts/3.x/Scripts/Tests/test_nxProviders.py
@@ -1998,6 +1998,18 @@ class nxServiceTestCases(unittest2.TestCase):
         self.assertTrue(r[0] == 0,"Inventory_Marshall('*', " + self.provider + "provider, False,'')  should return == 0")
         print(repr(r[1]))
 
+    def testInventoryMarshallControllerWildcard(self):
+        r=nxService.Inventory_Marshall('*', '*', False,'')
+        self.assertTrue(r[0] == 0,"Inventory_Marshall('*', " + self.provider + "provider, False,'')  should return == 0")
+        print(repr(r[1]))
+
+    def testInventoryMarshallControllerError(self):
+        l = ['systemd', 'upstart', 'init']
+        l.remove(self.provider)
+        r=nxService.Inventory_Marshall('*', l[0], False,'')
+        self.assertTrue(r[0] == -1,"Inventory_Marshall('*', " + self.provider + "provider, False,'')  should return == -1")
+        print(repr(r[1]))
+
     def testInventoryMarshallDummyService(self):
         self.assertTrue(nxService.Set_Marshall("dummy_service", self.provider, True, "running")==
                         [0],'nxService.Set_Marshall("dummy_service", "'+self.provider+'", True, "running") should return ==[0]')
@@ -2031,6 +2043,7 @@ class nxServiceTestCases(unittest2.TestCase):
                         'CheckInventory("dummy?*ice", self.provider, True, "running", r[1]) should == True')
 
     def testInventoryMarshallDummyServiceError(self):
+        time.sleep(3)
         self.assertTrue(nxService.Set_Marshall("dummy_service", self.provider, True, "running")==
                         [0],'nxService.Set_Marshall("dummy_service", "'+self.provider+'", True, "running") should return ==[0]')
         r=nxService.Inventory_Marshall('Gummy_service', self.provider, True,'')
@@ -2039,6 +2052,7 @@ class nxServiceTestCases(unittest2.TestCase):
                         'CheckInventory("Gummy_service", self.provider, True, "", r[1]) should == False')
 
     def testInventoryMarshallDummyServiceFilterNameError(self):
+        time.sleep(3)
         self.assertTrue(nxService.Set_Marshall("dummy_service", self.provider, True, "running")==
                         [0],'nxService.Set_Marshall("dummy_service", "'+self.provider+'", True, "running") should return ==[0]')
         r=nxService.Inventory_Marshall('dummy?*rice', self.provider, True,'')
@@ -2047,6 +2061,7 @@ class nxServiceTestCases(unittest2.TestCase):
                         'CheckInventory("dummy?*rice", self.provider, True, "", r[1]) should == False')
 
     def testInventoryMarshallDummyServiceFilterEnabledError(self):
+        time.sleep(3)
         self.assertTrue(nxService.Set_Marshall("dummy_service", self.provider, True, "running")==
                         [0],'nxService.Set_Marshall("dummy_service", "'+self.provider+'", True, "running") should return ==[0]')
         r=nxService.Inventory_Marshall('dummy?*ice', self.provider, True,'')
@@ -2055,6 +2070,7 @@ class nxServiceTestCases(unittest2.TestCase):
                         'CheckInventory("dummy?*ice", self.provider, False, "", r[1]) should == False')
 
     def testInventoryMarshallDummyServiceFilterStateError(self):
+        time.sleep(3)
         self.assertTrue(nxService.Set_Marshall("dummy_service", self.provider, True, "running")==
                         [0],'nxService.Set_Marshall("dummy_service", "'+self.provider+'", True, "running") should return ==[0]')
         r=nxService.Inventory_Marshall('dummy?*ice', self.provider, True,'stopped')
@@ -3457,3 +3473,4 @@ if __name__ == '__main__':
     s20=unittest2.TestLoader().loadTestsFromTestCase(nxOMSCustomLogTestCases)
     alltests = unittest2.TestSuite([s1,s2,s3,s4,s5,s6,s7,s8,s9,s10,s11,s12,s13,s14,s15,s16,s17,s18,s19,s20])
     unittest2.TextTestRunner(stream=sys.stdout,verbosity=3).run(alltests)
+    )

--- a/Providers/Scripts/3.x/Scripts/Tests/test_nxProviders.py
+++ b/Providers/Scripts/3.x/Scripts/Tests/test_nxProviders.py
@@ -1806,7 +1806,7 @@ class nxServiceTestCases(unittest2.TestCase):
         """
         Setup test resources
         """
-        self.provider = None
+        self.controller = None
         nxService.SetShowMof(True)
         print(self.id() + '\n')
         dist=platform.dist()[0].lower()
@@ -1825,7 +1825,7 @@ class nxServiceTestCases(unittest2.TestCase):
         elif 'debian' in dist:
             init_file=debian_init_file
         if nxService.SystemdExists():
-            self.provider='systemd'
+            self.controller='systemd'
             try:
                 if 'ubuntu' in dist or 'cent' in dist:
                     nxService.WriteFile('/lib/systemd/system/dummy_service.service',init_file)
@@ -1839,7 +1839,7 @@ class nxServiceTestCases(unittest2.TestCase):
                 print(repr(sys.exc_info()))
             os.system('systemctl --system daemon-reload &> /dev/null')
         elif nxService.UpstartExists():
-            self.provider='upstart'
+            self.controller='upstart'
             try:
                 nxService.WriteFile('/etc/default/dummy_service',upstart_etc_default)
                 os.chmod('/etc/default/dummy_service',0o744)
@@ -1852,7 +1852,7 @@ class nxServiceTestCases(unittest2.TestCase):
                 print(repr(sys.exc_info()))
 
         elif nxService.InitExists():
-            self.provider='init'
+            self.controller='init'
             try:
                 nxService.WriteFile('/etc/init.d/dummy_service',init_file)
                 os.chmod('/etc/init.d/dummy_service',0o744)
@@ -1875,12 +1875,12 @@ class nxServiceTestCases(unittest2.TestCase):
             else:
                 os.system('rm /usr/sbin/dummy_service.py /etc/rc.d/dummy_service &> /dev/null')
             os.system('systemctl --system daemon-reload &> /dev/null')
-        elif nxService.InitExists():
-            os.system('chkconfig --del dummy_service &> /dev/null')
-            os.system('rm /usr/sbin/dummy_service.py /etc/init.d/dummy_service &> /dev/null')
         elif nxService.UpstartExists():
             os.system('update-rc.d -f dummy_service remove &> /dev/null')
             os.system('rm /usr/sbin/dummy_service.py /etc/init/dummy_service.conf /etc/init.d/dummy_service /etc/default/dummy_service &> /dev/null')
+        elif nxService.InitExists():
+            os.system('chkconfig --del dummy_service &> /dev/null')
+            os.system('rm /usr/sbin/dummy_service.py /etc/init.d/dummy_service &> /dev/null')
             
         time.sleep(1)
         os.system("ps -ef | grep -v grep | grep dummy_service | awk '{print $2}' | xargs -L1 kill &> /dev/null")
@@ -1934,149 +1934,155 @@ class nxServiceTestCases(unittest2.TestCase):
         return retval,d
 
     def testSetEnable(self):
-        provider=self.provider
-        self.assertTrue(nxService.Set_Marshall("dummy_service", provider, True, "running")==
-                        [0],'nxService.Set_Marshall("dummy_service", "'+provider+'", True, "running") should return ==[0]')
+        controller=self.controller
+        self.assertTrue(nxService.Set_Marshall("dummy_service", controller, True, "running")==
+                        [0],'nxService.Set_Marshall("dummy_service", "'+controller+'", True, "running") should return ==[0]')
 
     def testSetDisable(self):
-        provider=self.provider
-        self.assertTrue(nxService.Set_Marshall("dummy_service", provider, True, "running")==
-                        [0],'nxService.Set_Marshall("dummy_service", "'+provider+'", True, "running") should return ==[0]')
-        self.assertTrue(nxService.Set_Marshall("dummy_service", provider, False, "stopped")==
-                        [0],'nxService.Set_Marshall("dummy_service", "'+provider+'", False, "stopped") should return ==[0]')
+        controller=self.controller
+        self.assertTrue(nxService.Set_Marshall("dummy_service", controller, True, "running")==
+                        [0],'nxService.Set_Marshall("dummy_service", "'+controller+'", True, "running") should return ==[0]')
+        self.assertTrue(nxService.Set_Marshall("dummy_service", controller, False, "stopped")==
+                        [0],'nxService.Set_Marshall("dummy_service", "'+controller+'", False, "stopped") should return ==[0]')
 
     def testSetEnableError(self):
-        provider=self.provider
-        self.assertTrue(nxService.Set_Marshall("yummyservice", provider, True, "running")==
-                        [-1],'nxService.Set_Marshall("yummyservice", "'+provider+'", True, "running") should return ==[-1]')
+        controller=self.controller
+        self.assertTrue(nxService.Set_Marshall("yummyservice", controller, True, "running")==
+                        [-1],'nxService.Set_Marshall("yummyservice", "'+controller+'", True, "running") should return ==[-1]')
 
     def testSetDisableError(self):
-        provider=self.provider
-        self.assertTrue(nxService.Set_Marshall("yummyservice", provider, False, "stopped")==
-                        [-1],'nxService.Set_Marshall("yummyservice", "'+provider+'", False, "stopped") should return ==[-1]')
+        controller=self.controller
+        self.assertTrue(nxService.Set_Marshall("yummyservice", controller, False, "stopped")==
+                        [-1],'nxService.Set_Marshall("yummyservice", "'+controller+'", False, "stopped") should return ==[-1]')
 
     def testGetEnable(self):
-        provider=self.provider
-        self.assertTrue(nxService.Set_Marshall("dummy_service", provider, True, "running")==
-                        [0],'nxService.Set_Marshall("dummy_service", "'+provider+'", True, "running") should return ==[0]')
-        r=nxService.Get_Marshall("dummy_service", provider, True, "running")
+        controller=self.controller
+        self.assertTrue(nxService.Set_Marshall("dummy_service", controller, True, "running")==
+                        [0],'nxService.Set_Marshall("dummy_service", "'+controller+'", True, "running") should return ==[0]')
+        r=nxService.Get_Marshall("dummy_service", controller, True, "running")
         print(repr(r[1]))
-        self.assertTrue(check_values(r,self.make_MI(0,"dummy_service", provider, True, "running",None,None,None)) == True
-                        ,'nxService.Get_Marshall("dummy_service", "'+provider+'", True, "running") should return ==[0]')
+        self.assertTrue(check_values(r,self.make_MI(0,"dummy_service", controller, True, "running",None,None,None)) == True
+                        ,'nxService.Get_Marshall("dummy_service", "'+controller+'", True, "running") should return ==[0]')
 
     def testGetDisable(self):
-        provider=self.provider
-        self.assertTrue(nxService.Set_Marshall("dummy_service", provider, True, "running")==
-                        [0],'nxService.Set_Marshall("dummy_service", "'+provider+'", True, "running") should return ==[0]')
-        self.assertTrue(nxService.Set_Marshall("dummy_service", provider, False, "stopped")==
-                        [0],'nxService.Set_Marshall("dummy_service", "'+provider+'", False, "stopped") should return ==[0]')
-        r=nxService.Get_Marshall("dummy_service", provider, False, "stopped")
+        controller=self.controller
+        self.assertTrue(nxService.Set_Marshall("dummy_service", controller, True, "running")==
+                        [0],'nxService.Set_Marshall("dummy_service", "'+controller+'", True, "running") should return ==[0]')
+        self.assertTrue(nxService.Set_Marshall("dummy_service", controller, False, "stopped")==
+                        [0],'nxService.Set_Marshall("dummy_service", "'+controller+'", False, "stopped") should return ==[0]')
+        r=nxService.Get_Marshall("dummy_service", controller, False, "stopped")
         print('GET:'+repr(r))
-        self.assertTrue(check_values(r,self.make_MI(0,"dummy_service", provider, False, "stopped", None, None, None)) == True
-                        ,'nxService.Get_Marshall("dummy_service", "'+provider+'", False, "stopped") should return ==[0,"dummy_service", provider, False, "stopped"]')
+        self.assertTrue(check_values(r,self.make_MI(0,"dummy_service", controller, False, "stopped", None, None, None)) == True
+                        ,'nxService.Get_Marshall("dummy_service", "'+controller+'", False, "stopped") should return ==[0,"dummy_service", controller, False, "stopped"]')
 
     def testGetEnableError(self):
-        provider=self.provider
-        self.assertTrue(nxService.Set_Marshall("yummyservice", provider, True, "running")==
-                        [-1],'nxService.Set_Marshall("yummyservice", "'+provider+'", True, "running") should return ==[-1]')
-        r=nxService.Get_Marshall("yummyservice", provider, True, "running")
+        controller=self.controller
+        self.assertTrue(nxService.Set_Marshall("yummyservice", controller, True, "running")==
+                        [-1],'nxService.Set_Marshall("yummyservice", "'+controller+'", True, "running") should return ==[-1]')
+        r=nxService.Get_Marshall("yummyservice", controller, True, "running")
         print('GET:'+repr(r))
-        self.assertTrue(check_values(r,self.make_MI(0,"yummyservice", provider, True, "running", None, None, None)) == False
-                        ,'nxService.Get_Marshall("yummyservice", "'+provider+'", True, "running")[0:5] should return ==[-1,"yummyservice", provider, True, "running"]')
+        self.assertTrue(check_values(r,self.make_MI(0,"yummyservice", controller, True, "running", None, None, None)) == False
+                        ,'nxService.Get_Marshall("yummyservice", "'+controller+'", True, "running")[0:5] should return ==[-1,"yummyservice", controller, True, "running"]')
 
     def testGetDisableError(self):
-        provider=self.provider
-        self.assertTrue(nxService.Set_Marshall("yummyservice", provider, False, "stopped")==
-                        [-1],'nxService.Set_Marshall("yummyservice", "'+provider+'", False, "stopped") should return ==[-1]')
-        r=nxService.Get_Marshall("yummyservice", provider, False, "stopped")
+        controller=self.controller
+        self.assertTrue(nxService.Set_Marshall("yummyservice", controller, False, "stopped")==
+                        [-1],'nxService.Set_Marshall("yummyservice", "'+controller+'", False, "stopped") should return ==[-1]')
+        r=nxService.Get_Marshall("yummyservice", controller, False, "stopped")
         print('GET:'+repr(r))
-        self.assertTrue(check_values(r,self.make_MI(0,"yummyservice", provider, False, "stopped", None, None, None)) == False
-                        ,'nxService.Get_Marshall("yummyservice", "'+provider+'", False, "stopped")[0:5] should return ==[-1,"yummyservice", provider, False, "stopped"]')
+        self.assertTrue(check_values(r,self.make_MI(0,"yummyservice", controller, False, "stopped", None, None, None)) == False
+                        ,'nxService.Get_Marshall("yummyservice", "'+controller+'", False, "stopped")[0:5] should return ==[-1,"yummyservice", controller, False, "stopped"]')
 
     def testInventoryMarshall(self):
-        r=nxService.Inventory_Marshall('*', self.provider, False,'')
-        self.assertTrue(r[0] == 0,"Inventory_Marshall('*', " + self.provider + "provider, False,'')  should return == 0")
+        r=nxService.Inventory_Marshall('*', self.controller, None,'')
+        self.assertTrue(r[0] == 0,"Inventory_Marshall('*', " + self.controller + ", None,'')  should return == 0")
         print(repr(r[1]))
 
     def testInventoryMarshallControllerWildcard(self):
-        r=nxService.Inventory_Marshall('*', '*', False,'')
-        self.assertTrue(r[0] == 0,"Inventory_Marshall('*', " + self.provider + "provider, False,'')  should return == 0")
+        r=nxService.Inventory_Marshall('*', '*', None,'')
+        self.assertTrue(r[0] == 0,"Inventory_Marshall('*', '*', None,'')  should return == 0")
         print(repr(r[1]))
 
     def testInventoryMarshallControllerError(self):
-        l = ['systemd', 'upstart', 'init']
-        l.remove(self.provider)
-        r=nxService.Inventory_Marshall('*', l[0], False,'')
-        self.assertTrue(r[0] == -1,"Inventory_Marshall('*', " + self.provider + "provider, False,'')  should return == -1")
+        controllers = ['systemd', 'upstart', 'init']
+        controllers.remove(self.controller)
+        r=nxService.Inventory_Marshall('*', controllers[0], None,'')
+        self.assertTrue(r[0] == -1,"Inventory_Marshall('*', " + self.controller + ", None,'')  should return == -1")
         print(repr(r[1]))
 
     def testInventoryMarshallDummyService(self):
-        self.assertTrue(nxService.Set_Marshall("dummy_service", self.provider, True, "running")==
-                        [0],'nxService.Set_Marshall("dummy_service", "'+self.provider+'", True, "running") should return ==[0]')
-        r=nxService.Inventory_Marshall('dummy_service', self.provider, True,'')
-        self.assertTrue(r[0] == 0,"Inventory_Marshall('dummy_service', " + self.provider + "provider, True,'')  should return == 0")
-        self.assertTrue(self.CheckInventory('dummy_service', self.provider, True, '', r[1]) == True, \
-                        'CheckInventory("dummy_service", self.provider, True, "", r[1]) should == True')
+        self.assertTrue(nxService.Set_Marshall("dummy_service", self.controller, True, "running")==
+                        [0],'nxService.Set_Marshall("dummy_service", "'+self.controller+'", True, "running") should return ==[0]')
+        r=nxService.Inventory_Marshall('dummy_service', self.controller, None,'')
+        self.assertTrue(r[0] == 0,"Inventory_Marshall('dummy_service', " + self.controller + ", None,'')  should return == 0")
+        self.assertTrue(self.CheckInventory('dummy_service', self.controller, None, '', r[1]) == True, \
+                        'CheckInventory("dummy_service", self.controller, None, "", r[1]) should == True')
 
     def testInventoryMarshallDummyServiceFilterName(self):
-        self.assertTrue(nxService.Set_Marshall("dummy_service", self.provider, True, "running")==
-                        [0],'nxService.Set_Marshall("dummy_service", "'+self.provider+'", True, "running") should return ==[0]')
-        r=nxService.Inventory_Marshall('dummy?*ice', self.provider, True,'')
-        self.assertTrue(r[0] == 0,"Inventory_Marshall('dummy?*ice', " + self.provider + "provider, True,'')  should return == 0")
-        self.assertTrue(self.CheckInventory('dummy?*ice', self.provider, True, '', r[1]) == True, \
-                        'CheckInventory("dummy?*ice", self.provider, True, "", r[1]) should == True')
+        self.assertTrue(nxService.Set_Marshall("dummy_service", self.controller, True, "running")==
+                        [0],'nxService.Set_Marshall("dummy_service", "'+self.controller+'", True, "running") should return ==[0]')
+        r=nxService.Inventory_Marshall('dummy?*ice', self.controller, None,'')
+        self.assertTrue(r[0] == 0,"Inventory_Marshall('dummy?*ice', " + self.controller + ", None,'')  should return == 0")
+        self.assertTrue(self.CheckInventory('dummy?*ice', self.controller, None, '', r[1]) == True, \
+                        'CheckInventory("dummy?*ice", ' + self.controller + ', None, "", r[1]) should == True')
 
     def testInventoryMarshallDummyServiceFilterEnabled(self):
-        self.assertTrue(nxService.Set_Marshall("dummy_service", self.provider, True, "running")==
-                        [0],'nxService.Set_Marshall("dummy_service", "'+self.provider+'", True, "running") should return ==[0]')
-        r=nxService.Inventory_Marshall('dummy?*ice', self.provider, True,'')
-        self.assertTrue(r[0] == 0,"Inventory_Marshall('dummy?*ice', " + self.provider + "provider, True,'')  should return == 0")
-        self.assertTrue(self.CheckInventory('dummy?*ice', self.provider, True, '', r[1]) == True, \
-                        'CheckInventory("dummy?*ice", self.provider, True, "", r[1]) should == True')
+        self.assertTrue(nxService.Set_Marshall("dummy_service", self.controller, True, "running")==
+                        [0],'nxService.Set_Marshall("dummy_service", "'+self.controller+'", True, "running") should return ==[0]')
+        r=nxService.Inventory_Marshall('dummy?*ice', self.controller, True,'')
+        self.assertTrue(r[0] == 0,"Inventory_Marshall('dummy?*ice', " + self.controller + ", True,'')  should return == 0")
+        self.assertTrue(self.CheckInventory('dummy?*ice', self.controller, True, '', r[1]) == True, \
+                        'CheckInventory("dummy?*ice", ' + self.controller + ', True, "", r[1]) should == True')
 
     def testInventoryMarshallDummyServiceFilterState(self):
-        self.assertTrue(nxService.Set_Marshall("dummy_service", self.provider, True, "running")==
-                        [0],'nxService.Set_Marshall("dummy_service", "'+self.provider+'", True, "running") should return ==[0]')
-        r=nxService.Inventory_Marshall('dummy?*ice', self.provider, True,'running')
-        self.assertTrue(r[0] == 0,"Inventory_Marshall('dummy?*ice', " + self.provider + "provider, True,'running')  should return == 0")
-        self.assertTrue(self.CheckInventory('dummy?*ice', self.provider, True, 'running', r[1]) == True, \
-                        'CheckInventory("dummy?*ice", self.provider, True, "running", r[1]) should == True')
+        # This test inconsistantly fails on slower systems.  The sleep here reduces these failures.
+        time.sleep(3)
+        self.assertTrue(nxService.Set_Marshall("dummy_service", self.controller, True, "running")==
+                        [0],'nxService.Set_Marshall("dummy_service", "'+self.controller+'", True, "running") should return ==[0]')
+        r=nxService.Inventory_Marshall('dummy?*ice', self.controller, None,'running')
+        self.assertTrue(r[0] == 0,"Inventory_Marshall('dummy?*ice', " + self.controller + ", None,'running')  should return == 0")
+        self.assertTrue(self.CheckInventory('dummy?*ice', self.controller, None, 'running', r[1]) == True, \
+                        'CheckInventory("dummy?*ice", ' + self.controller + ', None, "running", r[1]) should == True')
 
     def testInventoryMarshallDummyServiceError(self):
+        # This test inconsistantly fails on slower systems.  The sleep here reduces these failures.
         time.sleep(3)
-        self.assertTrue(nxService.Set_Marshall("dummy_service", self.provider, True, "running")==
-                        [0],'nxService.Set_Marshall("dummy_service", "'+self.provider+'", True, "running") should return ==[0]')
-        r=nxService.Inventory_Marshall('Gummy_service', self.provider, True,'')
-        self.assertTrue(r[0] == 0, "Inventory_Marshall('Gummy_service', " + self.provider + "provider, True,'')  should return == 0")
-        self.assertTrue(self.CheckInventory('Gummy_service', self.provider, True, '', r[1]) == False, \
-                        'CheckInventory("Gummy_service", self.provider, True, "", r[1]) should == False')
+        self.assertTrue(nxService.Set_Marshall("dummy_service", self.controller, True, "running")==
+                        [0],'nxService.Set_Marshall("dummy_service", "'+self.controller+'", True, "running") should return ==[0]')
+        r=nxService.Inventory_Marshall('Gummy_service', self.controller, None,'')
+        self.assertTrue(r[0] == 0, "Inventory_Marshall('Gummy_service', " + self.controller + ", None,'')  should return == 0")
+        self.assertTrue(self.CheckInventory('Gummy_service', self.controller, None, '', r[1]) == False, \
+                        'CheckInventory("Gummy_service", self.controller, None, "", r[1]) should == False')
 
     def testInventoryMarshallDummyServiceFilterNameError(self):
+        # This test inconsistantly fails on slower systems.  The sleep here reduces these failures.
         time.sleep(3)
-        self.assertTrue(nxService.Set_Marshall("dummy_service", self.provider, True, "running")==
-                        [0],'nxService.Set_Marshall("dummy_service", "'+self.provider+'", True, "running") should return ==[0]')
-        r=nxService.Inventory_Marshall('dummy?*rice', self.provider, True,'')
-        self.assertTrue(r[0] == 0,"Inventory_Marshall('dummy?*rice', " + self.provider + "provider, True,'')  should return == 0")
-        self.assertTrue(self.CheckInventory('dummy?*rice', self.provider, True, '', r[1]) == False, \
-                        'CheckInventory("dummy?*rice", self.provider, True, "", r[1]) should == False')
+        self.assertTrue(nxService.Set_Marshall("dummy_service", self.controller, True, "running")==
+                        [0],'nxService.Set_Marshall("dummy_service", "'+self.controller+'", True, "running") should return ==[0]')
+        r=nxService.Inventory_Marshall('dummy?*rice', self.controller, None,'')
+        self.assertTrue(r[0] == 0,"Inventory_Marshall('dummy?*rice', " + self.controller + ", None,'')  should return == 0")
+        self.assertTrue(self.CheckInventory('dummy?*rice', self.controller, None, '', r[1]) == False, \
+                        'CheckInventory("dummy?*rice", self.controller, None, "", r[1]) should == False')
 
     def testInventoryMarshallDummyServiceFilterEnabledError(self):
+        # This test inconsistantly fails on slower systems.  The sleep here reduces these failures.
         time.sleep(3)
-        self.assertTrue(nxService.Set_Marshall("dummy_service", self.provider, True, "running")==
-                        [0],'nxService.Set_Marshall("dummy_service", "'+self.provider+'", True, "running") should return ==[0]')
-        r=nxService.Inventory_Marshall('dummy?*ice', self.provider, True,'')
-        self.assertTrue(r[0] == 0,"Inventory_Marshall('dummy?*ice', " + self.provider + "provider, True,'')  should return == 0")
-        self.assertTrue(self.CheckInventory('dummy?*ice', self.provider, False, '', r[1]) == False, \
-                        'CheckInventory("dummy?*ice", self.provider, False, "", r[1]) should == False')
+        self.assertTrue(nxService.Set_Marshall("dummy_service", self.controller, True, "running")==
+                        [0],'nxService.Set_Marshall("dummy_service", "'+self.controller+'", True, "running") should return ==[0]')
+        r=nxService.Inventory_Marshall('dummy?*ice', self.controller, False,'')
+        self.assertTrue(r[0] == 0,"Inventory_Marshall('dummy?*ice', " + self.controller + ", False,'')  should return == 0")
+        self.assertTrue(self.CheckInventory('dummy?*ice', self.controller, False, '', r[1]) == False, \
+                        'CheckInventory("dummy?*ice", ' + self.controller + ', False, "", r[1]) should == False')
 
     def testInventoryMarshallDummyServiceFilterStateError(self):
+        # This test inconsistantly fails on slower systems.  The sleep here reduces these failures.
         time.sleep(3)
-        self.assertTrue(nxService.Set_Marshall("dummy_service", self.provider, True, "running")==
-                        [0],'nxService.Set_Marshall("dummy_service", "'+self.provider+'", True, "running") should return ==[0]')
-        r=nxService.Inventory_Marshall('dummy?*ice', self.provider, True,'stopped')
-        self.assertTrue(r[0] == 0,"Inventory_Marshall('dummy?*ice', " + self.provider + "provider, True,'stopped')  should return == 0")
-        self.assertTrue(self.CheckInventory('dummy?*ice', self.provider, True, 'stopped', r[1]) == False, \
-                        'CheckInventory("dummy?*ice", self.provider, True, "stopped", r[1]) should == False')
+        self.assertTrue(nxService.Set_Marshall("dummy_service", self.controller, True, "running")==
+                        [0],'nxService.Set_Marshall("dummy_service", "'+self.controller+'", True, "running") should return ==[0]')
+        r=nxService.Inventory_Marshall('dummy?*ice', self.controller, None,'stopped')
+        self.assertTrue(r[0] == 0,"Inventory_Marshall('dummy?*ice', " + self.controller + ", None,'stopped')  should return == 0")
+        self.assertTrue(self.CheckInventory('dummy?*ice', self.controller, None, 'stopped', r[1]) == False, \
+                        'CheckInventory("dummy?*ice", ' + self.controller + ', None, "stopped", r[1]) should == False')
 
 
 class nxSshAuthorizedKeysTestCases(unittest2.TestCase):
@@ -3473,4 +3479,4 @@ if __name__ == '__main__':
     s20=unittest2.TestLoader().loadTestsFromTestCase(nxOMSCustomLogTestCases)
     alltests = unittest2.TestSuite([s1,s2,s3,s4,s5,s6,s7,s8,s9,s10,s11,s12,s13,s14,s15,s16,s17,s18,s19,s20])
     unittest2.TextTestRunner(stream=sys.stdout,verbosity=3).run(alltests)
-    )
+

--- a/Providers/Scripts/3.x/Scripts/nxService.py
+++ b/Providers/Scripts/3.x/Scripts/nxService.py
@@ -1274,8 +1274,8 @@ def Get(Name, Controller, Enabled, State):
     exit_code = 0
 
     if not sc.Controller:
-        Print("Error: Controller not specified", file=sys.stderr)
-        LG().Log('ERROR', "Error: Controller not specified")
+        Print("Error: Controller not specified.", file=sys.stderr)
+        LG().Log('ERROR', "Error: Controller not specified.")
         exit_code = -1
     elif sc.Controller == "systemd":
         if not ServiceExistsInSystemd(sc):
@@ -1363,8 +1363,8 @@ def GetRunlevels(sc):
 def SystemdGetAll(sc):
     d = {}
     if os.system('which systemctl') != 0:
-        Print("Error: Controller incorectly specified", file=sys.stderr)
-        LG().Log('ERROR', "Error: 'Controller' incorrectly specified.")
+        Print("Error: 'Controller' = " + sc.Controller + " is incorrectly specified.", file=sys.stderr)
+        LG().Log('ERROR', "Error: 'Controller' = " + sc.Controller + " is incorrectly specified.")
         return False
     Name=sc.Name
     if '*' not in Name and len(Name) > 0:
@@ -1400,24 +1400,35 @@ def SystemdGetAll(sc):
 
 def UpstartGetAll(sc):
     d={}
+    names={}
     if os.system('which initctl') != 0:
-        Print("Error: Controller incorectly specified", file=sys.stderr)
-        LG().Log('ERROR', "Error: 'Controller' incorrectly specified.")
+        Print("Error: 'Controller' = " + sc.Controller + " is incorrectly specified.", file=sys.stderr)
+        LG().Log('ERROR', "Error: 'Controller' = " + sc.Controller + " is incorrectly specified.")
         return False
     cmd = "initctl list  | sed 's/[(].*[)] //g' | tr ', ' ' ' | awk '{print $1,$2}'"
     code, txt = RunGetOutput(cmd, False, False)
-    services=txt.splitlines()
+    services = txt.splitlines()
+    cmd = "service --status-all &> /tmp/tmpfile ; cat /tmp/tmpfile ; rm /tmp/tmpfile"
+    code, txt = RunGetOutput(cmd, False, False)
+    txt = txt.replace('[','')
+    txt = txt.replace(']','')
+    services.extend(txt.splitlines())
     for srv in services:
         if len(srv) == 0:
             continue
         s=srv.split()
+        if len(s[0]) == 1: #swap them.
+            s.reverse()
         d['Name'] = s[0]
         if len(sc.Name) and not fnmatch.fnmatch(d['Name'],sc.Name):
             continue
+        if d['Name'] in names.keys():
+            continue
+        names[d['Name']] = None
         d['Controller'] =  sc.Controller
         d['Description'] = ''
         d['State'] = 'stopped'
-        if 'running' in s[1]:
+        if 'running' in s[1] or '+' in s[1]:
             d['State'] = 'running'
         if len(sc.State) and sc.State != d['State'].lower():
             continue
@@ -1430,17 +1441,20 @@ def UpstartGetAll(sc):
         d['Enabled'] = True
         if sc.FilterEnabled and sc.Enabled != d['Enabled']:
             continue
-        cmd = 'initctl show-config ' + d['Name'] + ' | grep -E "start |stop " | tr "\n" " " | tr -s " " '
-        code, out = RunGetOutput(cmd, False, False) 
-        d['Runlevels'] = out[1:]
+        if len(s[1]) > 1:
+            cmd = 'initctl show-config ' + d['Name'] + ' | grep -E "start |stop " | tr "\n" " " | tr -s " " '
+            code, out = RunGetOutput(cmd, False, False) 
+            d['Runlevels'] = out[1:]
+        else:
+            d['Runlevels'] = GetRunlevels(sc)
         sc.services_list.append(copy.deepcopy(d))
     return True
 
 def InitdGetAll(sc):
     d={}
     if os.system('which chkconfig') != 0:
-        Print("Error: Controller incorectly specified", file=sys.stderr)
-        LG().Log('ERROR', "Error: 'Controller' incorrectly specified.")
+        Print("Error: 'Controller' = " + sc.Controller + " is incorrectly specified.", file=sys.stderr)
+        LG().Log('ERROR', "Error: 'Controller' = " + sc.Controller + " is incorrectly specified.")
         return False
     cmd = 'chkconfig -l | grep -vE "based| off"'
     code, txt = RunGetOutput(cmd, False, False)


### PR DESCRIPTION
…troller' is not valid for the service system.

This prevents 'chkconfig not found:' and other errors from showing up in the output.
@KrisBash 
@johnkord 