### PR TITLE
nxService.py - Debian Fixes and bug-fixes.

### DIFF
--- a/Providers/Scripts/2.4x-2.5x/Scripts/Tests/test_nxProviders.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/Tests/test_nxProviders.py
@@ -1606,7 +1606,7 @@ case "$1" in
         $0 start
         ;;
     status)
-        status_of_proc $WAZD_BIN && exit 0 || exit $?
+	status_of_proc -p $WAZD_PID $WAZD_BIN && exit 0 || exit $?
         ;;
     *)
         log_success_msg "Usage: /etc/init.d/dummy_service {start|stop|force-reload|restart|status}"
@@ -1799,10 +1799,12 @@ class nxServiceTestCases(unittest2.TestCase):
         dist=platform.dist()[0].lower()
         if os.path.exists('/etc/centos-release'):
             dist = 'centos'
+        if os.system('uname -a | grep -i ubuntu') == 0:
+            dist='ubuntu'
         init_file=''
         if 'suse' in dist:
             init_file=suse_init_file
-        elif 'ubuntu' in dist or 'debian' in dist:
+        elif 'ubuntu' in dist:
             if nxService.SystemdExists():
                 init_file=ubuntu_systemd_init_file
         elif 'redhat' in dist:
@@ -1816,7 +1818,7 @@ class nxServiceTestCases(unittest2.TestCase):
         if nxService.SystemdExists():
             self.controller='systemd'
             try:
-                if 'ubuntu' in dist or 'debian' in dist or 'cent' in dist:
+                if 'ubuntu' in dist  or 'cent' in dist:
                     nxService.WriteFile('/lib/systemd/system/dummy_service.service',init_file)
                     os.chmod('/lib/systemd/system/dummy_service.service',0744)
                 else:

--- a/Providers/Scripts/2.6x-2.7x/Scripts/Tests/test_nxProviders.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/Tests/test_nxProviders.py
@@ -1619,7 +1619,7 @@ case "$1" in
         $0 start
         ;;
     status)
-        status_of_proc $WAZD_BIN && exit 0 || exit $?
+	status_of_proc -p $WAZD_PID $WAZD_BIN && exit 0 || exit $?
         ;;
     *)
         log_success_msg "Usage: /etc/init.d/dummy_service {start|stop|force-reload|restart|status}"

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxService.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxService.py
@@ -253,7 +253,8 @@ systemctl_path = "/usr/bin/systemctl"
 upstart_start_path = "/sbin/start"
 upstart_stop_path = "/sbin/stop"
 upstart_status_path = "/sbin/status"
-initd_service = "/sbin/service"
+code, out = RunGetOutput('which service', False, False)
+initd_service = out.strip('\n')
 initd_chkconfig = "/sbin/chkconfig"
 initd_invokerc = "/usr/sbin/invoke-rc.d"
 initd_updaterc = "/usr/sbin/update-rc.d"
@@ -811,7 +812,8 @@ def ServiceExistsInInit(sc):
         [check_state_program, sc.Name, "status"])
 
     if "unrecognized service" in process_stderr \
-           or "no such service" in process_stderr:
+           or "no such service" in process_stderr \
+           or "not found" in process_stderr:
         Print(process_stderr, file=sys.stderr)
         LG().Log('INFO', process_stderr)
         return False
@@ -1341,27 +1343,28 @@ def GetAll(sc):
     if sc.Controller == 'upstart':
         return UpstartGetAll(sc)
 
-def GetRunlevels(sc):
+def GetRunlevels(sc,Name):
     if sc.runlevels_d == None:
         sc.runlevels_d = {}
         cmd="file /etc/rc*.d/* | grep link | awk '{print $5,$1}' | sort"
         code, out = RunGetOutput(cmd, False, False)
         for line in out.splitlines():
+            line = line.replace("'",'')
             srv = line.split(' ')[0]
             rl = line.split(' ')[1]
             n = os.path.basename(srv)
             if n not in sc.runlevels_d.keys():
                 sc.runlevels_d[n]={}
-            if 'path' not in sc.runlevels_d[n].keys():
-                sc.runlevels_d[n]['path']=srv.replace('..','/etc')
-            if 'runlevels' not in sc.runlevels_d[n].keys():
-                sc.runlevels_d[n]['runlevels']=''
+            if 'Path' not in sc.runlevels_d[n].keys():
+                sc.runlevels_d[n]['Path']=srv.replace('..','/etc')
+            if 'Runlevels' not in sc.runlevels_d[n].keys():
+                sc.runlevels_d[n]['Runlevels']=''
             s='off'
-            if rl[11] == 's':
+            if rl[11].lower() == 's':
                 s='on'
-            sc.runlevels_d[n]['runlevels'] += rl[7]+':'+s+ ' '
-    if sc.Name in sc.runlevels_d.keys():
-        return sc.runlevels_d[sc.Name]
+            sc.runlevels_d[n]['Runlevels'] += rl[7]+':'+s+ ' '
+    if Name in sc.runlevels_d.keys():
+        return sc.runlevels_d[Name]
     return None
 
 def SystemdGetAll(sc):
@@ -1394,7 +1397,7 @@ def SystemdGetAll(sc):
         d['Enabled'] = 'enabled' in subs.sub('',s[5])
         if sc.FilterEnabled and sc.Enabled != d['Enabled']:
             continue
-        rld=GetRunlevels(sc)
+        rld=GetRunlevels(sc,d['Name'])
         if rld != None and 'Runlevels' in rld.keys():
             d['Runlevels'] = rld['Runlevels']
         else:
@@ -1441,7 +1444,7 @@ def UpstartGetAll(sc):
             d['Path'] = '/etc/init.d/' + s[0]
         elif os.path.exists('/etc/init/' + s[0] + '.conf'):
             d['Path'] = '/etc/init/' + s[0] + '.conf'
-        # 'initclt list' won't show disabled services
+        # 'initctl list' won't show disabled services
         d['Enabled'] = True
         if sc.FilterEnabled and sc.Enabled != d['Enabled']:
             continue
@@ -1450,42 +1453,73 @@ def UpstartGetAll(sc):
             code, out = RunGetOutput(cmd, False, False) 
             d['Runlevels'] = out[1:]
         else:
-            d['Runlevels'] = GetRunlevels(sc)
+            rld=GetRunlevels(sc,d['Name'])
+            if rld != None and 'Runlevels' in rld.keys():
+                d['Runlevels'] = rld['Runlevels']
         sc.services_list.append(copy.deepcopy(d))
     return True
 
 def InitdGetAll(sc):
     d={}
-    if os.system('which chkconfig') != 0:
-        Print("Error: 'Controller' = " + sc.Controller + " is incorrectly specified.", file=sys.stderr)
-        LG().Log('ERROR', "Error: 'Controller' = " + sc.Controller + " is incorrectly specified.")
-        return False
-    cmd = 'chkconfig -l | grep -vE "based| off"'
-    code, txt = RunGetOutput(cmd, False, False)
-    services=txt.splitlines()
+    if os.path.exists(initd_chkconfig):
+        cmd = initd_chkconfig + ' -l | grep -vE "based| off"'
+        code, txt = RunGetOutput(cmd, False, False)
+        services=txt.splitlines()
+        for srv in services:
+            if len(srv) == 0:
+                continue
+            s=srv.split()
+            d['Name'] = s[0]
+            if len(sc.Name) and not fnmatch.fnmatch(d['Name'],sc.Name):
+                continue
+            d['Controller'] =  sc.Controller
+            d['Description'] = ''
+            d['State'] = 'stopped'
+            cmd = 'service ' + s[0] + ' status'
+            code, txt = RunGetOutput(cmd, False, False)
+            if 'running' in txt:
+                d['State'] = 'running'
+            if len(sc.State) and sc.State != d['State'].lower():
+                continue
+            d['Path'] = ''
+            if os.path.exists('/etc/init.d/' + s[0]):
+                d['Path'] = '/etc/init.d/' + s[0]
+            d['Enabled'] = ':on' in srv
+            if sc.FilterEnabled and sc.Enabled != d['Enabled']:
+                continue
+            d['Runlevels'] = reduce(lambda x, y: x + ' ' + y, s[1:])
+            sc.services_list.append(copy.deepcopy(d))
+    else:
+        cmd = initd_service + ' --status-all &> /tmp/tmpfile ; cat /tmp/tmpfile ; rm /tmp/tmpfile'
+        code, txt = RunGetOutput(cmd, False, False)
+        txt = txt.replace('[','')
+        txt = txt.replace(']','')
+        services = txt.splitlines()
     for srv in services:
         if len(srv) == 0:
             continue
         s=srv.split()
-        d['Name'] = s[0]
+        d['Name'] = s[1]
         if len(sc.Name) and not fnmatch.fnmatch(d['Name'],sc.Name):
             continue
         d['Controller'] =  sc.Controller
         d['Description'] = ''
         d['State'] = 'stopped'
-        cmd = 'service ' + s[0] + ' status'
-        code, txt = RunGetOutput(cmd, False, False)
-        if 'running' in txt:
+        if '+' in s[0]:
             d['State'] = 'running'
         if len(sc.State) and sc.State != d['State'].lower():
             continue
         d['Path'] = ''
-        if os.path.exists('/etc/init.d/' + s[0]):
-            d['Path'] = '/etc/init.d/' + s[0]
-        d['Enabled'] = ':on' in srv
+        if os.path.exists('/etc/init.d/' + s[1]):
+            d['Path'] = '/etc/init.d/' + s[1]
+        elif os.path.exists('/etc/init/' + s[1] + '.conf'):
+            d['Path'] = '/etc/init/' + s[1] + '.conf'
+        rld=GetRunlevels(sc,d['Name'])
+        if rld != None and 'Runlevels' in rld.keys():
+            d['Runlevels'] = rld['Runlevels']
+        d['Enabled'] = 'on' in d['Runlevels']
         if sc.FilterEnabled and sc.Enabled != d['Enabled']:
             continue
-        d['Runlevels'] = reduce(lambda x, y: x + ' ' + y, s[1:])
         sc.services_list.append(copy.deepcopy(d))
     return True
 

--- a/Providers/Scripts/3.x/Scripts/Tests/test_nxProviders.py
+++ b/Providers/Scripts/3.x/Scripts/Tests/test_nxProviders.py
@@ -1619,7 +1619,7 @@ case "$1" in
         $0 start
         ;;
     status)
-        status_of_proc $WAZD_BIN && exit 0 || exit $?
+	status_of_proc -p $WAZD_PID $WAZD_BIN && exit 0 || exit $?
         ;;
     *)
         log_success_msg "Usage: /etc/init.d/dummy_service {start|stop|force-reload|restart|status}"

--- a/Providers/Scripts/3.x/Scripts/nxService.py
+++ b/Providers/Scripts/3.x/Scripts/nxService.py
@@ -249,7 +249,8 @@ systemctl_path = "/usr/bin/systemctl"
 upstart_start_path = "/sbin/start"
 upstart_stop_path = "/sbin/stop"
 upstart_status_path = "/sbin/status"
-initd_service = "/sbin/service"
+code, out = RunGetOutput('which service', False, False)
+initd_service = out.strip('\n')
 initd_chkconfig = "/sbin/chkconfig"
 initd_invokerc = "/usr/sbin/invoke-rc.d"
 initd_updaterc = "/usr/sbin/update-rc.d"
@@ -807,7 +808,8 @@ def ServiceExistsInInit(sc):
         [check_state_program, sc.Name, "status"])
 
     if "unrecognized service" in process_stderr \
-           or "no such service" in process_stderr:
+           or "no such service" in process_stderr \
+           or "not found" in process_stderr:
         Print(process_stderr, file=sys.stderr)
         LG().Log('INFO', process_stderr)
         return False
@@ -1337,27 +1339,28 @@ def GetAll(sc):
     if sc.Controller == 'upstart':
         return UpstartGetAll(sc)
 
-def GetRunlevels(sc):
+def GetRunlevels(sc,Name):
     if sc.runlevels_d == None:
         sc.runlevels_d = {}
         cmd="file /etc/rc*.d/* | grep link | awk '{print $5,$1}' | sort"
         code, out = RunGetOutput(cmd, False, False)
         for line in out.splitlines():
+            line = line.replace("'",'')
             srv = line.split(' ')[0]
             rl = line.split(' ')[1]
             n = os.path.basename(srv)
             if n not in sc.runlevels_d.keys():
                 sc.runlevels_d[n]={}
-            if 'path' not in sc.runlevels_d[n].keys():
-                sc.runlevels_d[n]['path']=srv.replace('..','/etc')
-            if 'runlevels' not in sc.runlevels_d[n].keys():
-                sc.runlevels_d[n]['runlevels']=''
+            if 'Path' not in sc.runlevels_d[n].keys():
+                sc.runlevels_d[n]['Path']=srv.replace('..','/etc')
+            if 'Runlevels' not in sc.runlevels_d[n].keys():
+                sc.runlevels_d[n]['Runlevels']=''
             s='off'
-            if rl[11] == 's':
+            if rl[11].lower() == 's':
                 s='on'
-            sc.runlevels_d[n]['runlevels'] += rl[7]+':'+s+ ' '
-    if sc.Name in sc.runlevels_d.keys():
-        return sc.runlevels_d[sc.Name]
+            sc.runlevels_d[n]['Runlevels'] += rl[7]+':'+s+ ' '
+    if Name in sc.runlevels_d.keys():
+        return sc.runlevels_d[Name]
     return None
 
 def SystemdGetAll(sc):
@@ -1390,7 +1393,7 @@ def SystemdGetAll(sc):
         d['Enabled'] = 'enabled' in subs.sub('',s[5])
         if sc.FilterEnabled and sc.Enabled != d['Enabled']:
             continue
-        rld=GetRunlevels(sc)
+        rld=GetRunlevels(sc,d['Name'])
         if rld != None and 'Runlevels' in rld.keys():
             d['Runlevels'] = rld['Runlevels']
         else:
@@ -1437,7 +1440,7 @@ def UpstartGetAll(sc):
             d['Path'] = '/etc/init.d/' + s[0]
         elif os.path.exists('/etc/init/' + s[0] + '.conf'):
             d['Path'] = '/etc/init/' + s[0] + '.conf'
-        # 'initclt list' won't show disabled services
+        # 'initctl list' won't show disabled services
         d['Enabled'] = True
         if sc.FilterEnabled and sc.Enabled != d['Enabled']:
             continue
@@ -1446,42 +1449,73 @@ def UpstartGetAll(sc):
             code, out = RunGetOutput(cmd, False, False) 
             d['Runlevels'] = out[1:]
         else:
-            d['Runlevels'] = GetRunlevels(sc)
+            rld=GetRunlevels(sc,d['Name'])
+            if rld != None and 'Runlevels' in rld.keys():
+                d['Runlevels'] = rld['Runlevels']
         sc.services_list.append(copy.deepcopy(d))
     return True
 
 def InitdGetAll(sc):
     d={}
-    if os.system('which chkconfig') != 0:
-        Print("Error: 'Controller' = " + sc.Controller + " is incorrectly specified.", file=sys.stderr)
-        LG().Log('ERROR', "Error: 'Controller' = " + sc.Controller + " is incorrectly specified.")
-        return False
-    cmd = 'chkconfig -l | grep -vE "based| off"'
-    code, txt = RunGetOutput(cmd, False, False)
-    services=txt.splitlines()
+    if os.path.exists(initd_chkconfig):
+        cmd = initd_chkconfig + ' -l | grep -vE "based| off"'
+        code, txt = RunGetOutput(cmd, False, False)
+        services=txt.splitlines()
+        for srv in services:
+            if len(srv) == 0:
+                continue
+            s=srv.split()
+            d['Name'] = s[0]
+            if len(sc.Name) and not fnmatch.fnmatch(d['Name'],sc.Name):
+                continue
+            d['Controller'] =  sc.Controller
+            d['Description'] = ''
+            d['State'] = 'stopped'
+            cmd = 'service ' + s[0] + ' status'
+            code, txt = RunGetOutput(cmd, False, False)
+            if 'running' in txt:
+                d['State'] = 'running'
+            if len(sc.State) and sc.State != d['State'].lower():
+                continue
+            d['Path'] = ''
+            if os.path.exists('/etc/init.d/' + s[0]):
+                d['Path'] = '/etc/init.d/' + s[0]
+            d['Enabled'] = ':on' in srv
+            if sc.FilterEnabled and sc.Enabled != d['Enabled']:
+                continue
+            d['Runlevels'] = reduce(lambda x, y: x + ' ' + y, s[1:])
+            sc.services_list.append(copy.deepcopy(d))
+    else:
+        cmd = initd_service + ' --status-all &> /tmp/tmpfile ; cat /tmp/tmpfile ; rm /tmp/tmpfile'
+        code, txt = RunGetOutput(cmd, False, False)
+        txt = txt.replace('[','')
+        txt = txt.replace(']','')
+        services = txt.splitlines()
     for srv in services:
         if len(srv) == 0:
             continue
         s=srv.split()
-        d['Name'] = s[0]
+        d['Name'] = s[1]
         if len(sc.Name) and not fnmatch.fnmatch(d['Name'],sc.Name):
             continue
         d['Controller'] =  sc.Controller
         d['Description'] = ''
         d['State'] = 'stopped'
-        cmd = 'service ' + s[0] + ' status'
-        code, txt = RunGetOutput(cmd, False, False)
-        if 'running' in txt:
+        if '+' in s[0]:
             d['State'] = 'running'
         if len(sc.State) and sc.State != d['State'].lower():
             continue
         d['Path'] = ''
-        if os.path.exists('/etc/init.d/' + s[0]):
-            d['Path'] = '/etc/init.d/' + s[0]
-        d['Enabled'] = ':on' in srv
+        if os.path.exists('/etc/init.d/' + s[1]):
+            d['Path'] = '/etc/init.d/' + s[1]
+        elif os.path.exists('/etc/init/' + s[1] + '.conf'):
+            d['Path'] = '/etc/init/' + s[1] + '.conf'
+        rld=GetRunlevels(sc,d['Name'])
+        if rld != None and 'Runlevels' in rld.keys():
+            d['Runlevels'] = rld['Runlevels']
+        d['Enabled'] = 'on' in d['Runlevels']
         if sc.FilterEnabled and sc.Enabled != d['Enabled']:
             continue
-        d['Runlevels'] = reduce(lambda x, y: x + ' ' + y, s[1:])
         sc.services_list.append(copy.deepcopy(d))
     return True
 


### PR DESCRIPTION
Determine path of 'service' at runtime.
Add "not found' to service errors in ServiceExistsInInit() to prevent false positive.
GetRunlevels():
    Add 'Name' argument to filter name correctly.
    Remove the single quote from shell cmd output in Debian.
    Fix Typos.
    Use 'Name' argument for correct filtering.
UpstartGetAll():
    Access output of GetRunLevels correctly.
InitdGetAll():
    Use 'service --status-all' if 'chkconfig' is not present.

test_nxProviders.py - Fix bug in dummy_service initd script.
Improve Debian/Ubuntu platform detection in the 2.4x-2.5x version.