### PR TITLE
nxService and nxPackage improvements.

### DIFF
--- a/Providers/Scripts/2.4x-2.5x/Scripts/Tests/test_nxProviders.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/Tests/test_nxProviders.py
@@ -1059,6 +1059,14 @@ class nxPackageTestCases(unittest2.TestCase):
         self.assertTrue(self.CheckInventory(self.pkg[2:], r[1]) == False, \
                         'CheckInventory(self.pkg, r[1]) should == False')
 
+    def testInventoryMarshallCmdlineError(self):
+        os.system('cp  ./Scripts/nxPackage.py /tmp/nxPackageBroken.py')
+        os.system(r'sed -i "s/\((f).*\)[0-9]/\120/" /tmp/nxPackageBroken.py')
+        nxPackageBroken = imp.load_source('nxPackageBroken','/tmp/nxPackageBroken.py') 
+        r=nxPackageBroken.Inventory_Marshall('','','*','',False,'',0)
+        os.system('rm /tmp/nxPackageBroken.py')
+        self.assertTrue(len(r[1]['__Inventory'].value) == 0,"nxPackageBroken.Inventory_Marshall('','','*','',False,'',0)  should return empty MI_INSTANCEA.")
+        print(repr(r[1]))
 
 
 class nxFileTestCases(unittest2.TestCase):
@@ -1412,6 +1420,7 @@ while True:
 upstart_etc_default="""# To disable , set DUMMY_SERVICE_ENABLED=0
 DUMMY_SERVICE_ENABLED=1
 """
+
 upstart_init_conf="""description "dummy_service"
 author "Eric Gable"
 export PATH=$PATH:/usr/local/bin
@@ -1581,7 +1590,7 @@ WAZD_PID=/var/run/dummy_service.pid
 case "$1" in
     start)
         log_begin_msg "Starting dummy_service..."
-        pid=$( pidofproc $WAZD_BIN )
+        pid=$( pidofproc -p $WAZD_PID $WAZD_BIN)
         if [ -n "$pid" ] ; then
               log_begin_msg "Already running."
               log_end_msg 0
@@ -1711,6 +1720,7 @@ case "$1" in
 esac
 rc_exit
 """
+
 redhat_init_file= """#!/bin/bash
 #
 # Init file for dummy_service.
@@ -1989,6 +1999,18 @@ class nxServiceTestCases(unittest2.TestCase):
         self.assertTrue(r[0] == 0,"Inventory_Marshall('*', " + self.controller + ", None,'')  should return == 0")
         print repr(r[1])
 
+    def testInventoryMarshallCmdlineError(self):
+        os.system('cp  ./Scripts/nxService.py /tmp/nxServiceBroken.py')
+        os.system('sed -i "s/cmd =  initd_service + \' --status-all \'/cmd =  initd_service + \' --atus-all \'/" /tmp/nxServiceBroken.py')
+        os.system('sed -i "s/cmd = initd_chkconfig + \' --list \'/cmd = initd_chkconfig + \' --ist \'/" /tmp/nxServiceBroken.py')
+        os.system('sed -i "s/cmd = \'initctl list\'/cmd = \'initctl ist\'/" /tmp/nxServiceBroken.py')
+        os.system('sed -i "s/cmd = \'systemctl -a list-unit-files \'/cmd = \'systemctl -a ist-unit-files \'/" /tmp/nxServiceBroken.py')
+        nxServiceBroken = imp.load_source('nxServiceBroken','/tmp/nxServiceBroken.py') 
+        r=nxServiceBroken.Inventory_Marshall('*', self.controller, None,'')
+        os.system('rm /tmp/nxServiceBroken.py')
+        self.assertTrue(r[0] == -1,"nxServiceBroken.Inventory_Marshall('*', " + self.controller + ", None,'')  should return == -1")
+        print(repr(r[1]))
+
     def testInventoryMarshallControllerWildcard(self):
         r=nxService.Inventory_Marshall('*', '*', None,'')
         self.assertTrue(r[0] == 0,"Inventory_Marshall('*', '*', None,'')  should return == 0")
@@ -2017,6 +2039,7 @@ class nxServiceTestCases(unittest2.TestCase):
         self.assertTrue(self.CheckInventory('dummy?*ice', self.controller, None, '', r[1]) == True, \
                         'CheckInventory("dummy?*ice", ' + self.controller + ', None, "", r[1]) should == True')
 
+    @unittest2.skipIf(self.controller == 'upstart','Not implemented in upstart')
     def testInventoryMarshallDummyServiceFilterEnabled(self):
         self.assertTrue(nxService.Set_Marshall("dummy_service", self.controller, True, "running")==
                         [0],'nxService.Set_Marshall("dummy_service", "'+self.controller+'", True, "running") should return ==[0]')
@@ -2035,7 +2058,7 @@ class nxServiceTestCases(unittest2.TestCase):
         self.assertTrue(self.CheckInventory('dummy?*ice', self.controller, None, 'running', r[1]) == True, \
                         'CheckInventory("dummy?*ice", ' + self.controller + ', None, "running", r[1]) should == True')
 
-    def testInventoryMarshallDummyServiceError(self):
+    def testInventoryMarshallDummyServiceFilterNameError(self):
         # This test inconsistantly fails on slower systems.  The sleep here reduces these failures.
         time.sleep(3)
         self.assertTrue(nxService.Set_Marshall("dummy_service", self.controller, True, "running")==
@@ -2044,16 +2067,6 @@ class nxServiceTestCases(unittest2.TestCase):
         self.assertTrue(r[0] == 0, "Inventory_Marshall('Gummy_service', " + self.controller + ", None,'')  should return == 0")
         self.assertTrue(self.CheckInventory('Gummy_service', self.controller, None, '', r[1]) == False, \
                         'CheckInventory("Gummy_service", self.controller, None, "", r[1]) should == False')
-
-    def testInventoryMarshallDummyServiceFilterNameError(self):
-        # This test inconsistantly fails on slower systems.  The sleep here reduces these failures.
-        time.sleep(3)
-        self.assertTrue(nxService.Set_Marshall("dummy_service", self.controller, True, "running")==
-                        [0],'nxService.Set_Marshall("dummy_service", "'+self.controller+'", True, "running") should return ==[0]')
-        r=nxService.Inventory_Marshall('dummy?*rice', self.controller, None,'')
-        self.assertTrue(r[0] == 0,"Inventory_Marshall('dummy?*rice', " + self.controller + ", None,'')  should return == 0")
-        self.assertTrue(self.CheckInventory('dummy?*rice', self.controller, None, '', r[1]) == False, \
-                        'CheckInventory("dummy?*rice", self.controller, None, "", r[1]) should == False')
 
     def testInventoryMarshallDummyServiceFilterEnabledError(self):
         # This test inconsistantly fails on slower systems.  The sleep here reduces these failures.

--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxPackage.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxPackage.py
@@ -44,7 +44,7 @@ LG = nxDSCLog.DSCLog
 #   [read] string Version;
 #   [read] boolean Installed;
 #   [read] string Architecture;
- 
+
 # };
 
 cache_file_dir = '/var/opt/microsoft/dsc/cache/nxPackage'
@@ -71,7 +71,7 @@ def init_vars(Ensure, PackageManager, Name, FilePath, PackageGroup, Arguments, R
         FilePath = ''
     if PackageGroup is None:
         PackageGroup = False
-    PackageGroup = ( PackageGroup == True )
+    PackageGroup = (PackageGroup == True)
     if Arguments is not None:
         Arguments = Arguments.encode('ascii', 'ignore')
     else:
@@ -144,6 +144,7 @@ def Get_Marshall(Ensure, PackageManager, Name, FilePath, PackageGroup, Arguments
         retd[k] = ld[k]
     return retval, retd
 
+
 def Inventory_Marshall(Ensure, PackageManager, Name, FilePath, PackageGroup, Arguments, ReturnCode):
     retval = 0
     sys.stdin.flush()
@@ -152,7 +153,7 @@ def Inventory_Marshall(Ensure, PackageManager, Name, FilePath, PackageGroup, Arg
     (Ensure, PackageManager, Name, FilePath, PackageGroup, Arguments, ReturnCode) = init_vars(
         Ensure, PackageManager, Name, FilePath, PackageGroup, Arguments, ReturnCode)
     retval, pkgs = GetAll(Ensure, PackageManager, Name,
-                   FilePath, PackageGroup, Arguments, ReturnCode)
+                          FilePath, PackageGroup, Arguments, ReturnCode)
     for p in pkgs:
         p['Ensure'] = protocol.MI_String('present')
         p['PackageManager'] = protocol.MI_String(PackageManager)
@@ -168,7 +169,7 @@ def Inventory_Marshall(Ensure, PackageManager, Name, FilePath, PackageGroup, Arg
         p['Size'] = protocol.MI_Uint32(int(p['Size']))
         p['Version'] = protocol.MI_String(p['Version'])
         p['Installed'] = protocol.MI_Boolean(True)
-    Inventory=protocol.MI_InstanceA(pkgs)
+    Inventory = protocol.MI_InstanceA(pkgs)
     retd = {}
     retd["__Inventory"] = Inventory
     return retval, retd
@@ -176,6 +177,7 @@ def Inventory_Marshall(Ensure, PackageManager, Name, FilePath, PackageGroup, Arg
 #
 # Begin user defined DSC functions
 #
+
 
 def GetPackageSystem():
     ret = None
@@ -285,8 +287,10 @@ class Params:
         self.cmds['apt'] = {}
         self.cmds['yum'] = {}
         self.cmds['zypper'] = {}
-        self.cmds['dpkg']['present'] = 'DEBIAN_FRONTEND=noninteractive dpkg % -i '
-        self.cmds['dpkg']['absent'] = 'DEBIAN_FRONTEND=noninteractive dpkg % -r '
+        self.cmds['dpkg'][
+            'present'] = 'DEBIAN_FRONTEND=noninteractive dpkg % -i '
+        self.cmds['dpkg'][
+            'absent'] = 'DEBIAN_FRONTEND=noninteractive dpkg % -r '
         self.cmds['dpkg'][
             'stat'] = "dpkg-query -W -f='${Description}|${Maintainer}|'Unknown'|${Installed-Size}|${Version}|${Status}|${Architecture}\n' "
         self.cmds['dpkg'][
@@ -439,16 +443,19 @@ def ParseInfo(p, info):
             p.Architecture = f[6]
 
         if len(f) is not 6:
-            Print('ERROR.   ' + p.PackageManager, file=sys.stdout)
-            LG().Log('ERROR', 'ERROR.   ' + p.PackageManager)
+            Print(
+                'ERROR in ParseInfo.  Output was ' + info, file=sys.stdout)
+            LG().Log(
+                'ERROR', 'ERROR in ParseInfo.  Output was ' + info)
 
 
-def ParseAllInfo(info,p):
-    pkg_list=[]
-    d={}
-    if len(info) < 1 or  '@@' not in info:
+def ParseAllInfo(info, p):
+    pkg_list = []
+    d = {}
+    if len(info) < 1 or '@@' not in info:
         return pkg_list
     for pkg in info.split('@@'):
+        d['Name'] = ''
         d['PackageDescription'] = ''
         d['Publisher'] = ''
         d['InstalledOn'] = ''
@@ -460,7 +467,7 @@ def ParseAllInfo(info,p):
                 f = pkg.strip().split('|')
                 if len(f) is 8:
                     d['Name'] = f[0]
-                    if len(p.Name) and not fnmatch.fnmatch(d['Name'],p.Name):
+                    if len(p.Name) and not fnmatch.fnmatch(d['Name'], p.Name):
                         continue
                     d['PackageDescription'] = f[1]
                     d['Publisher'] = f[2]
@@ -473,10 +480,14 @@ def ParseAllInfo(info,p):
                     d['Installed'] = ('install' in f[6])
                     d['Architecture'] = f[7]
                 if len(f) is not 8:
-                    Print('ERROR in ParseAll.', file=sys.stdout)
-                    LG().Log('ERROR', 'ERROR in ParseAll.')
+                    Print(
+                        'ERROR in ParseAllInfo.  Output was ' + info, file=sys.stdout)
+                    LG().Log(
+                        'ERROR', 'ERROR in ParseAllInfo.  Output was ' + info)
+                    return pkg_list         
                 pkg_list.append(copy.deepcopy(d))
     return pkg_list
+
 
 def DoEnableDisable(p):
     # if the path is set, use the path and self.PackageSystem
@@ -510,16 +521,17 @@ def DoEnableDisable(p):
                 'ERROR', 'Error: Group mode not implemented for ' + p.PackageManager)
             return False, 'Error: Group mode not implemented for ' + p.PackageManager
     else:
-        cmd = 'LANG=en_US.UTF8 ' + p.cmds[p.PackageManager][p.Ensure] + ' ' + p.Name
+        cmd = 'LANG=en_US.UTF8 ' + \
+            p.cmds[p.PackageManager][p.Ensure] + ' ' + p.Name
     cmd = cmd.replace('%', p.Arguments)
     cmd = cmd.replace('^', p.CommandArguments)
     code, out = RunGetOutput(cmd, False)
     if len(p.LocalPath) > 1:  # create cache entry and remove the tmp file
         WriteCacheInfo(p)
         RemoveFile(p.LocalPath)
-    if p.PackageManager == 'yum' and ( 'No Match for argument: ' + p.Name in out or 'Nothing to do' in out ): # yum returns 0 on unknown package
+    if p.PackageManager == 'yum' and ('No Match for argument: ' + p.Name in out or 'Nothing to do' in out):  # yum returns 0 on unknown package
         return False, out
-    if p.PackageManager == 'zypper' and "package '" + p.Name + "' not found" in out: # zypper returns 0 on unknown package
+    if p.PackageManager == 'zypper' and "package '" + p.Name + "' not found" in out:  # zypper returns 0 on unknown package
         return False, out
     if code is not int(p.ReturnCode):
         return False, out
@@ -564,7 +576,8 @@ def WriteCacheInfo(p):
     cache_file_path = cache_file_dir + '/' + os.path.basename(p.LocalPath)
     F, error = opened_w_error(cache_file_path, 'w+')
     if error:
-        Print("Exception creating cache file " + cache_file_path + " Error: " + str(error), file=sys.stderr)
+        Print("Exception creating cache file " +
+              cache_file_path + " Error: " + str(error), file=sys.stderr)
         LG().Log('ERROR',  "Exception creating cache file " + cache_file_path +
                  " Error: " + str(error))
         return False
@@ -579,7 +592,8 @@ def ReadCacheInfo(p):
         return False
     F, error = opened_w_error(cache_file_path, 'r')
     if error:
-        Print("Exception opening cache file " + cache_file_path + " Error: " + str(error), file=sys.stderr)
+        Print("Exception opening cache file " + cache_file_path +
+              " Error: " + str(error), file=sys.stderr)
         LG().Log('ERROR',  "Exception creating cache file " + cache_file_path +
                  " Error: " + str(error))
         return False
@@ -658,9 +672,10 @@ def Get(Ensure, PackageManager, Name, FilePath, PackageGroup, Arguments, ReturnC
     ParseInfo(p, out)
     return [0, p.PackageManager, p.PackageDescription, p.Publisher, p.InstalledOn, p.Size, p.Version, installed, p.Architecture]
 
+
 def GetAll(Ensure, PackageManager, Name,
-                   FilePath, PackageGroup, Arguments, ReturnCode):
-    pkgs=None
+           FilePath, PackageGroup, Arguments, ReturnCode):
+    pkgs = None
     try:
         p = Params(Ensure, PackageManager, Name,
                    FilePath, PackageGroup, Arguments, ReturnCode)
@@ -672,7 +687,7 @@ def GetAll(Ensure, PackageManager, Name,
         return [-1, ]
     cmd = 'LANG=en_US.UTF8 ' + p.cmds[p.PackageManager]['stat_all']
     code, out = RunGetOutput(cmd, False)
-    pkgs=ParseAllInfo(out,p)
+    pkgs = ParseAllInfo(out, p)
     return [0, pkgs]
 
 
@@ -736,17 +751,20 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             no_output, cmd, stderr=subprocess.STDOUT, shell=True)
     except subprocess.CalledProcessError, e:
         if chk_err:
-            Print("CalledProcessError.  Error Code is " + str(e.returncode), file=sys.stdout)
-            Print("CalledProcessError.  Command string was " + e.cmd, file=sys.stdout)
-            Print("CalledProcessError.  Command result was " + (e.output[:-1]).decode('utf8','ignore').encode("ascii", "ignore"), file=sys.stdout)
+            Print("CalledProcessError.  Error Code is " +
+                  str(e.returncode), file=sys.stdout)
+            Print(
+                "CalledProcessError.  Command string was " + e.cmd, file=sys.stdout)
+            Print("CalledProcessError.  Command result was " + (e.output[:-1]).decode(
+                'utf8', 'ignore').encode("ascii", "ignore"), file=sys.stdout)
         if no_output:
             return e.returncode, None
         else:
-            return e.returncode, e.output.decode('utf8','ignore').encode('ascii', 'ignore')
+            return e.returncode, e.output.decode('utf8', 'ignore').encode('ascii', 'ignore')
     if no_output:
         return 0, None
     else:
-        return 0, output.decode('utf8','ignore').encode('ascii', 'ignore')
+        return 0, output.decode('utf8', 'ignore').encode('ascii', 'ignore')
 
 
 def Print(s, file=sys.stdout):
@@ -772,11 +790,15 @@ def RemoveFile(path):
     try:
         os.remove(path)
     except OSError, error:
-        Print("Exception removing file" + path + " Error: " + str(error), file=sys.stderr)
-        LG().Log('ERROR', "Exception removing file" + path + " Error: " + str(error))
+        Print("Exception removing file" + path +
+              " Error: " + str(error), file=sys.stderr)
+        LG().Log('ERROR', "Exception removing file" +
+                 path + " Error: " + str(error))
     except IOError, error:
-        Print("Exception removing file" + path + " Error: " + str(error), file=sys.stderr)
-        LG().Log('ERROR', "Exception removing file" + path + " Error: " + str(error))
+        Print("Exception removing file" + path +
+              " Error: " + str(error), file=sys.stderr)
+        LG().Log('ERROR', "Exception removing file" +
+                 path + " Error: " + str(error))
     return error
 
 
@@ -789,11 +811,15 @@ def LStatFile(path):
     try:
         d = os.lstat(path)
     except OSError, error:
-        Print("Exception lstating file " + path + " Error: " + str(error), file=sys.stderr)
-        LG().Log('ERROR', "Exception lstating file " + path + " Error: " + str(error))
+        Print("Exception lstating file " + path +
+              " Error: " + str(error), file=sys.stderr)
+        LG().Log('ERROR', "Exception lstating file " +
+                 path + " Error: " + str(error))
     except IOError, error:
-        Print("Exception lstating file " + path + " Error: " + str(error), file=sys.stderr)
-        LG().Log('ERROR', "Exception lstating file " + path + " Error: " + str(error))
+        Print("Exception lstating file " + path +
+              " Error: " + str(error), file=sys.stderr)
+        LG().Log('ERROR', "Exception lstating file " +
+                 path + " Error: " + str(error))
     return d
 
 
@@ -802,11 +828,15 @@ def MakeDirs(path):
     try:
         os.makedirs(path)
     except OSError, error:
-        Print("Exception making dir" + path + " Error: " + str(error), file=sys.stderr)
-        LG().Log('ERROR',  "Exception making dir" + path + " Error: " + str(error))
+        Print("Exception making dir" + path +
+              " Error: " + str(error), file=sys.stderr)
+        LG().Log('ERROR',  "Exception making dir" +
+                 path + " Error: " + str(error))
     except IOError, error:
-        Print("Exception making dir" + path + " Error: " + str(error), file=sys.stderr)
-        LG().Log('ERROR',  "Exception making dir" + path + " Error: " + str(error))
+        Print("Exception making dir" + path +
+              " Error: " + str(error), file=sys.stderr)
+        LG().Log('ERROR',  "Exception making dir" +
+                 path + " Error: " + str(error))
     return error
 
 
@@ -830,9 +860,9 @@ def GetRemoteFile(p):
     if dst_st is not None:
         dst_mtime = time.gmtime(dst_st.st_mtime)
     if lm_mtime is not None and dst_mtime is not None and dst_mtime >= lm_mtime:
-        data = '' # skip download, the file is the same
+        data = ''  # skip download, the file is the same
     else:
-        data='keep going'
+        data = 'keep going'
         try:
             F = open(p.LocalPath, 'wb+')
             while data:
@@ -840,7 +870,7 @@ def GetRemoteFile(p):
                 if data is not None and len(data) > 0:
                     F.write(data)
             F.close()
-        except  Exception, e:
+        except Exception, e:
             Print(repr(e))
             LG().Log('ERROR', repr(e))
             F.close()

--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxService.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxService.py
@@ -103,16 +103,17 @@ def Get_Marshall(Name, Controller, Enabled, State):
         retd[k] = ld[k]
     return retval, retd
 
+
 def Inventory_Marshall(Name, Controller, Enabled, State):
-    FilterEnabled = ( Enabled != None )
+    FilterEnabled = (Enabled != None)
     (Name, Controller, Enabled, State) = init_vars(
         Name, Controller, Enabled, State)
     if Controller == '':
-        return -1, {"__Inventory":{}}
+        return -1, {"__Inventory": {}}
     sc = ServiceContext(Name, Controller, Enabled, State)
     sc.FilterEnabled = FilterEnabled
     if not GetAll(sc):
-        return  -1, {"__Inventory":{}}
+        return -1, {"__Inventory": {}}
     for srv in sc.services_list:
         srv['Name'] = protocol.MI_String(srv['Name'])
         srv['Controller'] = protocol.MI_String(srv['Controller'])
@@ -121,14 +122,14 @@ def Inventory_Marshall(Name, Controller, Enabled, State):
         srv['Path'] = protocol.MI_String(srv['Path'])
         srv['Description'] = protocol.MI_String(srv['Description'])
         srv['Runlevels'] = protocol.MI_String(srv['Runlevels'])
-    Inventory=protocol.MI_InstanceA(sc.services_list)
+    Inventory = protocol.MI_InstanceA(sc.services_list)
     retd = {}
     retd["__Inventory"] = Inventory
     return 0, retd
 
-# ##########################
+#
 # Begin user defined DSC functions
-# ##########################
+#
 
 
 def SetShowMof(a):
@@ -267,8 +268,10 @@ def ReadFile(path):
     error = None
     F, error = opened_w_error(path, 'rb')
     if error:
-        Print("Exception opening file " + path + " Error: " + str(error), file=sys.stderr)
-        LG().Log('ERROR', "Exception opening file " + path + " Error: " + str(error))
+        Print("Exception opening file " + path +
+              " Error: " + str(error), file=sys.stderr)
+        LG().Log('ERROR', "Exception opening file " +
+           path + " Error: " + str(error))
     else:
         d = F.read()
         F.close()
@@ -287,8 +290,10 @@ def WriteFile(path, contents):
     error = None
     F, error = opened_w_error(path, 'wb+')
     if error:
-        Print("Exception opening file " + path + " Error: " + str(error), file=sys.stderr)
-        LG().Log('ERROR', "Exception opening file " + path + " Error: " + str(error))
+        Print("Exception opening file " + path +
+              " Error: " + str(error), file=sys.stderr)
+        LG().Log('ERROR', "Exception opening file " +
+           path + " Error: " + str(error))
     else:
         F.write(contents)
     return error
@@ -652,7 +657,7 @@ def GetInitState(sc):
         check_state_program = '/usr/sbin/service'
         if os.path.isfile('/usr/sbin/service'):
             check_state_program = '/usr/sbin/service'
-        else: # invoke the service directly
+        else:  # invoke the service directly
             check_state_program = '/etc/init.d/'
     if check_state_program == '/etc/init.d/':
         (process_stdout, process_stderr, retval) = Process(
@@ -1022,7 +1027,7 @@ def ModifyInitService(sc):
     if os.path.isfile(initd_invokerc) and os.path.isfile(initd_updaterc):
         if os.path.isfile('/usr/sbin/service'):
             check_state_program = '/usr/sbin/service'
-        else: # invoke the service directly
+        else:  # invoke the service directly
             check_state_program = '/etc/init.d/'
         check_enabled_program = initd_updaterc
         if sc.Enabled is True:
@@ -1037,17 +1042,17 @@ def ModifyInitService(sc):
                 # try 'defaults'
                 (process_stdout, process_stderr, retval) = Process(
                 [check_enabled_program, "-f", sc.Name, "defaults"])
-                if retval is not 0 :
+                if retval is not 0:
                     Print("Error: " + check_enabled_program + " -f " +
                           sc.Name + " defaults failed: " + process_stderr,
                           file=sys.stderr)
                     LG().Log('ERROR', "Error: " + check_enabled_program +
                              " -f " + sc.Name + " defaults failed: " + process_stderr)
                     return [-1]
-                if 'already exist' in process_stdout: # we need to remove them first
+                if 'already exist' in process_stdout:  # we need to remove them first
                     (process_stdout, process_stderr, retval) = Process(
                         [check_enabled_program, "-f", sc.Name, "remove"])
-                    if retval is not 0 :
+                    if retval is not 0:
                         Print("Error: " + check_enabled_program + " -f " +
                               sc.Name + " remove failed: " + process_stderr,
                               file=sys.stderr)
@@ -1057,7 +1062,7 @@ def ModifyInitService(sc):
                     # it should work now
                     (process_stdout, process_stderr, retval) = Process(
                         [check_enabled_program, "-f", sc.Name, "defaults"])
-                    if retval is not 0 :
+                    if retval is not 0:
                         Print("Error: " + check_enabled_program + " -f " +
                               sc.Name + " defaults failed: " + process_stderr,
                               file=sys.stderr)
@@ -1095,17 +1100,17 @@ def ModifyInitService(sc):
                 # try 'defaults'
                 (process_stdout, process_stderr, retval) = Process(
                 [check_enabled_program, "-f", sc.Name, "defaults"])
-                if retval is not 0 :
+                if retval is not 0:
                     Print("Error: " + check_enabled_program + " -f " +
                           sc.Name + " defaults failed: " + process_stderr,
                           file=sys.stderr)
                     LG().Log('ERROR', "Error: " + check_enabled_program +
                              " -f " + sc.Name + " defaults failed: " + process_stderr)
                     return [-1]
-                if 'already exist' in process_stdout: # we need to remove them first
+                if 'already exist' in process_stdout:  # we need to remove them first
                     (process_stdout, process_stderr, retval) = Process(
                         [check_enabled_program, "-f", sc.Name, "remove"])
-                    if retval is not 0 :
+                    if retval is not 0:
                         Print("Error: " + check_enabled_program + " -f " +
                               sc.Name + " remove failed: " + process_stderr,
                               file=sys.stderr)
@@ -1115,14 +1120,14 @@ def ModifyInitService(sc):
                     # it should work now
                     (process_stdout, process_stderr, retval) = Process(
                         [check_enabled_program, "-f", sc.Name, "defaults"])
-                    if retval is not 0 :
+                    if retval is not 0:
                         Print("Error: " + check_enabled_program + " -f " +
                               sc.Name + " defaults failed: " + process_stderr,
                               file=sys.stderr)
                         LG().Log('ERROR', "Error: " + check_enabled_program +
                                  " -f " + sc.Name + " defaults failed: " + process_stderr)
                         return [-1]
-                    
+
         elif sc.Enabled is False:
             (process_stdout, process_stderr, retval) = Process(
                 [check_enabled_program, sc.Name, "off"])
@@ -1142,7 +1147,7 @@ def ModifyInitService(sc):
                              " -f " + sc.Name + " remove failed: " + process_stderr)
                     return [-1]
 
-    if sc.State == "running":		
+    if sc.State == "running":
         # don't try to read stdout or stderr as 'service start' comand
         # re-directs them, causing a hang in subprocess.communicate()
         if check_state_program == '/etc/init.d/':
@@ -1311,11 +1316,13 @@ def Get(Name, Controller, Enabled, State):
         GetOne(sc)
     return [exit_code, Name, Controller, Enabled, State, Path, sc.Description, sc.Runlevels]
 
+
 def GetOne(sc):
     GetAll(sc)
     if len(sc.services_list):
-        sc.Description=sc.services_list[0]['Description']
-        sc.Runlevels=sc.services_list[0]['Runlevels']
+        sc.Description = sc.services_list[0]['Description']
+        sc.Runlevels = sc.services_list[0]['Runlevels']
+
 
 def GetAll(sc):
     if sc.Controller == 'init':
@@ -1325,41 +1332,64 @@ def GetAll(sc):
     if sc.Controller == 'upstart':
         return UpstartGetAll(sc)
 
-def GetRunlevels(sc,Name):
+
+def GetRunlevels(sc, Name):
     if sc.runlevels_d == None:
         sc.runlevels_d = {}
-        cmd="file /etc/rc*.d/* | grep link | awk '{print $5,$1}' | sort"
+        cmd = "file /etc/rc*.d/* | grep link | awk '{print $5,$1}' | sort"
         code, out = RunGetOutput(cmd, False, False)
         for line in out.splitlines():
-            line = line.replace("'",'')
+            line = line.replace("'", '')
             srv = line.split(' ')[0]
             rl = line.split(' ')[1]
             n = os.path.basename(srv)
             if n not in sc.runlevels_d.keys():
-                sc.runlevels_d[n]={}
+                sc.runlevels_d[n] = {}
             if 'Path' not in sc.runlevels_d[n].keys():
-                sc.runlevels_d[n]['Path']=srv.replace('..','/etc')
+                sc.runlevels_d[n]['Path'] = srv.replace('..', '/etc')
             if 'Runlevels' not in sc.runlevels_d[n].keys():
-                sc.runlevels_d[n]['Runlevels']=''
-            s='off'
+                sc.runlevels_d[n]['Runlevels'] = ''
+            s = 'off'
             if rl[11].lower() == 's':
-                s='on'
-            sc.runlevels_d[n]['Runlevels'] += rl[7]+':'+s+ ' '
+                s = 'on'
+            sc.runlevels_d[n]['Runlevels'] += rl[7] + ':' + s + ' '
     if Name in sc.runlevels_d.keys():
         return sc.runlevels_d[Name]
     return None
 
+
 def SystemdGetAll(sc):
     d = {}
     if os.system('which systemctl') != 0:
-        Print("Error: 'Controller' = " + sc.Controller + " is incorrectly specified.", file=sys.stderr)
-        LG().Log('ERROR', "Error: 'Controller' = " + sc.Controller + " is incorrectly specified.")
+        Print("Error: 'Controller' = " + sc.Controller +
+              " is incorrectly specified.", file=sys.stderr)
+        LG().Log('ERROR', "Error: 'Controller' = " +
+           sc.Controller + " is incorrectly specified.")
         return False
-    Name=sc.Name
-    if '*' not in Name and len(Name) > 0:
-        Name = Name.replace('.service','')
+    Name = sc.Name
+    if '*' not in Name and '?' not in Name and len(Name) > 0:
+        Name = Name.replace('.service', '')
         Name += '.service'
-    cmd='systemctl -a list-unit-files ' + Name +  '| grep \.service | grep -v "@" | awk \'{print $1}\' | xargs systemctl -a --no-pager --no-legend -p "Names,WantedBy,Description,SubState,FragmentPath,UnitFileState" show'
+    # Do the commands work?
+    # There may be no error detected in our multi-pipe command below.
+    # To keep from returning garbage, we must test the commands.
+    # RunGetOutput(chk_err = True) will log the error message here if it
+    # occurs.
+    cmd = 'systemctl -a list-unit-files ' + Name
+    code, txt = RunGetOutput(cmd, False, True)
+    if code != 0:
+        return False
+    sname = ''
+    # Get the last service name from the output.
+    m = re.search(r'.*?\n(.*?)[.]service.*?\n', txt, re.M)
+    if m is not None:
+        sname = m.group(1)
+    cmd = 'systemctl -a --no-pager --no-legend -p "Names,WantedBy,Description,SubState,FragmentPath,UnitFileState" show ' + sname
+    code, txt = RunGetOutput(cmd, False, True)
+    if code != 0: 
+        return False
+    # Now we know it will work.
+    cmd = 'systemctl -a list-unit-files ' + Name +  '| grep \.service | grep -v "@" | awk \'{print $1}\' | xargs systemctl -a --no-pager --no-legend -p "Names,WantedBy,Description,SubState,FragmentPath,UnitFileState" show'
     code, txt = RunGetOutput(cmd, False, False)
     txt=txt.replace('\n\n','@@')
     txt=txt.replace('\n','|')
@@ -1394,6 +1424,19 @@ def UpstartGetAll(sc):
         Print("Error: 'Controller' = " + sc.Controller + " is incorrectly specified.", file=sys.stderr)
         LG().Log('ERROR', "Error: 'Controller' = " + sc.Controller + " is incorrectly specified.")
         return False
+    # Do the commands work?
+    # There may be no error detected in our multi-pipe command below.
+    # To keep from returning garbage, we must test the commands.
+    # RunGetOutput(chk_err = True) will log the error message here if it occurs.
+    cmd = 'initctl list'
+    code, txt = RunGetOutput(cmd, False, True)
+    if code != 0: 
+        return False
+    cmd = 'service --status-all'
+    code, txt = RunGetOutput(cmd, False, True)
+    if code != 0: 
+        return False
+    # Now we know it will work.
     cmd = "initctl list  | sed 's/[(].*[)] //g' | tr ', ' ' ' | awk '{print $1,$2}'"
     code, txt = RunGetOutput(cmd, False, False)
     services = txt.splitlines()
@@ -1444,7 +1487,16 @@ def UpstartGetAll(sc):
 def InitdGetAll(sc):
     d={}
     if os.path.exists(initd_chkconfig):
-        cmd = initd_chkconfig + ' -l | grep -vE "based| off"'
+        # Does the command work?
+        # There may be no error detected in our multi-pipe command below.
+        # To keep from returning garbage, we must test the command.
+        # RunGetOutput(chk_err = True) will log the error message here if it occurs.
+        cmd = initd_chkconfig + ' --list '
+        code, txt = RunGetOutput(cmd, False, True)
+        if code != 0: 
+            return False
+        # Now we know it will work.
+        cmd = initd_chkconfig + ' --list | grep -vE "based| off"'
         code, txt = RunGetOutput(cmd, False, False)
         services=txt.splitlines()
         for srv in services:
@@ -1472,6 +1524,15 @@ def InitdGetAll(sc):
             d['Runlevels'] = reduce(lambda x, y: x + ' ' + y, s[1:])
             sc.services_list.append(copy.deepcopy(d))
     else:
+        # Does the command work?
+        # There may be no error detected in our multi-statement command below.
+        # To keep from returning garbage, we must test the command.
+        # RunGetOutput(chk_err = True) will log the error message here if it occurs.
+        cmd =  initd_service + ' --status-all '
+        code, txt = RunGetOutput(cmd, False, True)
+        if code != 0: 
+            return False
+        # Now we know it will work.
         cmd = initd_service + ' --status-all &> /tmp/tmpfile ; cat /tmp/tmpfile ; rm /tmp/tmpfile'
         code, txt = RunGetOutput(cmd, False, False)
         txt = txt.replace('[','')

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxPackage.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxPackage.py
@@ -48,7 +48,7 @@ LG = nxDSCLog.DSCLog
 #   [read] string Version;
 #   [read] boolean Installed;
 #   [read] string Architecture;
- 
+
 # };
 
 cache_file_dir = '/var/opt/microsoft/dsc/cache/nxPackage'
@@ -147,6 +147,7 @@ def Get_Marshall(Ensure, PackageManager, Name, FilePath, PackageGroup, Arguments
         retd[k] = ld[k]
     return retval, retd
 
+
 def Inventory_Marshall(Ensure, PackageManager, Name, FilePath, PackageGroup, Arguments, ReturnCode):
     retval = 0
     sys.stdin.flush()
@@ -155,7 +156,7 @@ def Inventory_Marshall(Ensure, PackageManager, Name, FilePath, PackageGroup, Arg
     (Ensure, PackageManager, Name, FilePath, PackageGroup, Arguments, ReturnCode) = init_vars(
         Ensure, PackageManager, Name, FilePath, PackageGroup, Arguments, ReturnCode)
     retval, pkgs = GetAll(Ensure, PackageManager, Name,
-                   FilePath, PackageGroup, Arguments, ReturnCode)
+                          FilePath, PackageGroup, Arguments, ReturnCode)
     for p in pkgs:
         p['Ensure'] = protocol.MI_String('present')
         p['PackageManager'] = protocol.MI_String(PackageManager)
@@ -171,7 +172,7 @@ def Inventory_Marshall(Ensure, PackageManager, Name, FilePath, PackageGroup, Arg
         p['Size'] = protocol.MI_Uint32(int(p['Size']))
         p['Version'] = protocol.MI_String(p['Version'])
         p['Installed'] = protocol.MI_Boolean(True)
-    Inventory=protocol.MI_InstanceA(pkgs)
+    Inventory = protocol.MI_InstanceA(pkgs)
     retd = {}
     retd["__Inventory"] = Inventory
     return retval, retd
@@ -179,6 +180,7 @@ def Inventory_Marshall(Ensure, PackageManager, Name, FilePath, PackageGroup, Arg
 #
 # Begin user defined DSC functions
 #
+
 
 def GetPackageSystem():
     ret = None
@@ -287,8 +289,10 @@ class Params:
         self.cmds['apt'] = {}
         self.cmds['yum'] = {}
         self.cmds['zypper'] = {}
-        self.cmds['dpkg']['present'] = 'DEBIAN_FRONTEND=noninteractive dpkg % -i '
-        self.cmds['dpkg']['absent'] = 'DEBIAN_FRONTEND=noninteractive dpkg % -r '
+        self.cmds['dpkg'][
+            'present'] = 'DEBIAN_FRONTEND=noninteractive dpkg % -i '
+        self.cmds['dpkg'][
+            'absent'] = 'DEBIAN_FRONTEND=noninteractive dpkg % -r '
         self.cmds['dpkg'][
             'stat'] = "dpkg-query -W -f='${Description}|${Maintainer}|'Unknown'|${Installed-Size}|${Version}|${Status}|${Architecture}\n' "
         self.cmds['dpkg'][
@@ -439,16 +443,19 @@ def ParseInfo(p, info):
             p.Architecture = f[6]
 
         if len(f) is not 6:
-            print('ERROR.   ' + p.PackageManager, file=sys.stdout)
-            LG().Log('ERROR', 'ERROR.   ' + p.PackageManager)
+            print(
+                'ERROR in ParseInfo.  Output was ' + info, file=sys.stdout)
+            LG().Log(
+                'ERROR', 'ERROR in ParseInfo.  Output was ' + info)
 
 
-def ParseAllInfo(info,p):
-    pkg_list=[]
-    d={}
-    if len(info) < 1 or  '@@' not in info:
+def ParseAllInfo(info, p):
+    pkg_list = []
+    d = {}
+    if len(info) < 1 or '@@' not in info:
         return pkg_list
     for pkg in info.split('@@'):
+        d['Name'] = ''
         d['PackageDescription'] = ''
         d['Publisher'] = ''
         d['InstalledOn'] = ''
@@ -460,7 +467,7 @@ def ParseAllInfo(info,p):
                 f = pkg.strip().split('|')
                 if len(f) is 8:
                     d['Name'] = f[0]
-                    if len(p.Name) and not fnmatch.fnmatch(d['Name'],p.Name):
+                    if len(p.Name) and not fnmatch.fnmatch(d['Name'], p.Name):
                         continue
                     d['PackageDescription'] = f[1]
                     d['Publisher'] = f[2]
@@ -473,10 +480,14 @@ def ParseAllInfo(info,p):
                     d['Installed'] = ('install' in f[6])
                     d['Architecture'] = f[7]
                 if len(f) is not 8:
-                    print('ERROR in ParseAll.', file=sys.stdout)
-                    LG().Log('ERROR', 'ERROR in ParseAll.')
+                    print(
+                        'ERROR in ParseAllInfo.  Output was ' + info, file=sys.stdout)
+                    LG().Log(
+                        'ERROR', 'ERROR in ParseAllInfo.  Output was ' + info)
+                    return pkg_list         
                 pkg_list.append(copy.deepcopy(d))
     return pkg_list
+
 
 def DoEnableDisable(p):
     # if the path is set, use the path and self.PackageSystem
@@ -510,16 +521,17 @@ def DoEnableDisable(p):
                 'ERROR', 'Error: Group mode not implemented for ' + p.PackageManager)
             return False, 'Error: Group mode not implemented for ' + p.PackageManager
     else:
-        cmd = 'LANG=en_US.UTF8 ' + p.cmds[p.PackageManager][p.Ensure] + ' ' + p.Name
+        cmd = 'LANG=en_US.UTF8 ' + \
+            p.cmds[p.PackageManager][p.Ensure] + ' ' + p.Name
     cmd = cmd.replace('%', p.Arguments)
     cmd = cmd.replace('^', p.CommandArguments)
     code, out = RunGetOutput(cmd, False)
     if len(p.LocalPath) > 1:  # create cache entry and remove the tmp file
         WriteCacheInfo(p)
         RemoveFile(p.LocalPath)
-    if p.PackageManager == 'yum' and ( 'No Match for argument: ' + p.Name in out or 'Nothing to do' in out ): # yum returns 0 on unknown package  
+    if p.PackageManager == 'yum' and ('No Match for argument: ' + p.Name in out or 'Nothing to do' in out):  # yum returns 0 on unknown package
         return False, out
-    if p.PackageManager == 'zypper' and "package '" + p.Name + "' not found" in out: # zypper returns 0 on unknown package
+    if p.PackageManager == 'zypper' and "package '" + p.Name + "' not found" in out:  # zypper returns 0 on unknown package
         return False, out
     if code is not int(p.ReturnCode):
         return False, out
@@ -660,9 +672,10 @@ def Get(Ensure, PackageManager, Name, FilePath, PackageGroup, Arguments, ReturnC
     ParseInfo(p, out)
     return [0, p.PackageManager, p.PackageDescription, p.Publisher, p.InstalledOn, p.Size, p.Version, installed, p.Architecture]
 
+
 def GetAll(Ensure, PackageManager, Name,
-                   FilePath, PackageGroup, Arguments, ReturnCode):
-    pkgs=None
+           FilePath, PackageGroup, Arguments, ReturnCode):
+    pkgs = None
     try:
         p = Params(Ensure, PackageManager, Name,
                    FilePath, PackageGroup, Arguments, ReturnCode)
@@ -674,7 +687,7 @@ def GetAll(Ensure, PackageManager, Name,
         return [-1, ]
     cmd = 'LANG=en_US.UTF8 ' + p.cmds[p.PackageManager]['stat_all']
     code, out = RunGetOutput(cmd, False)
-    pkgs=ParseAllInfo(out,p)
+    pkgs = ParseAllInfo(out, p)
     return [0, pkgs]
 
 
@@ -743,17 +756,20 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             no_output, cmd, stderr=subprocess.STDOUT, shell=True)
     except subprocess.CalledProcessError, e:
         if chk_err:
-            print("CalledProcessError.  Error Code is " + str(e.returncode), file=sys.stdout)
-            print("CalledProcessError.  Command string was " + e.cmd, file=sys.stdout)
-            print("CalledProcessError.  Command result was " + (e.output[:-1]).decode('utf8','ignore').encode("ascii", "ignore"), file=sys.stdout)
+            print("CalledProcessError.  Error Code is " +
+                  str(e.returncode), file=sys.stdout)
+            print(
+                "CalledProcessError.  Command string was " + e.cmd, file=sys.stdout)
+            print("CalledProcessError.  Command result was " + (e.output[:-1]).decode(
+                'utf8', 'ignore').encode("ascii", "ignore"), file=sys.stdout)
         if no_output:
             return e.returncode, None
         else:
-            return e.returncode, e.output.decode('utf8','ignore').encode('ascii', 'ignore')
+            return e.returncode, e.output.decode('utf8', 'ignore').encode('ascii', 'ignore')
     if no_output:
         return 0, None
     else:
-        return 0, output.decode('utf8','ignore').encode('ascii', 'ignore')
+        return 0, output.decode('utf8', 'ignore').encode('ascii', 'ignore')
 
 
 def GetTimeFromString(s):
@@ -845,9 +861,9 @@ def GetRemoteFile(p):
     if dst_st is not None:
         dst_mtime = time.gmtime(dst_st.st_mtime)
     if lm_mtime is not None and dst_mtime is not None and dst_mtime >= lm_mtime:
-        data = '' # skip download, the file is the same
+        data = ''  # skip download, the file is the same
     else:
-        data=b'keep going'
+        data = b'keep going'
         with (open(p.LocalPath, 'wb+')) as F:
             try:
                 while data:

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxService.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxService.py
@@ -107,16 +107,17 @@ def Get_Marshall(Name, Controller, Enabled, State):
         retd[k] = ld[k]
     return retval, retd
 
+
 def Inventory_Marshall(Name, Controller, Enabled, State):
-    FilterEnabled = ( Enabled != None )
+    FilterEnabled = (Enabled != None)
     (Name, Controller, Enabled, State) = init_vars(
         Name, Controller, Enabled, State)
     if Controller == '':
-        return -1, {"__Inventory":{}}
+        return -1, {"__Inventory": {}}
     sc = ServiceContext(Name, Controller, Enabled, State)
     sc.FilterEnabled = FilterEnabled
     if not GetAll(sc):
-        return  -1, {"__Inventory":{}}
+        return -1, {"__Inventory": {}}
     for srv in sc.services_list:
         srv['Name'] = protocol.MI_String(srv['Name'])
         srv['Controller'] = protocol.MI_String(srv['Controller'])
@@ -125,14 +126,14 @@ def Inventory_Marshall(Name, Controller, Enabled, State):
         srv['Path'] = protocol.MI_String(srv['Path'])
         srv['Description'] = protocol.MI_String(srv['Description'])
         srv['Runlevels'] = protocol.MI_String(srv['Runlevels'])
-    Inventory=protocol.MI_InstanceA(sc.services_list)
+    Inventory = protocol.MI_InstanceA(sc.services_list)
     retd = {}
     retd["__Inventory"] = Inventory
     return 0, retd
 
-# ##########################
+#
 # Begin user defined DSC functions
-# ##########################
+#
 
 
 def SetShowMof(a):
@@ -670,7 +671,7 @@ def GetInitState(sc):
         check_state_program = '/usr/sbin/service'
         if os.path.isfile('/usr/sbin/service'):
             check_state_program = '/usr/sbin/service'
-        else: # invoke the service directly
+        else:  # invoke the service directly
             check_state_program = '/etc/init.d/'
     if check_state_program == '/etc/init.d/':
         (process_stdout, process_stderr, retval) = Process(
@@ -1040,7 +1041,7 @@ def ModifyInitService(sc):
     if os.path.isfile(initd_invokerc) and os.path.isfile(initd_updaterc):
         if os.path.isfile('/usr/sbin/service'):
             check_state_program = '/usr/sbin/service'
-        else: # invoke the service directly
+        else:  # invoke the service directly
             check_state_program = '/etc/init.d/'
         check_enabled_program = initd_updaterc
         if sc.Enabled is True:
@@ -1055,17 +1056,17 @@ def ModifyInitService(sc):
                 # try 'defaults'
                 (process_stdout, process_stderr, retval) = Process(
                 [check_enabled_program, "-f", sc.Name, "defaults"])
-                if retval is not 0 :
+                if retval is not 0:
                     Print("Error: " + check_enabled_program + " -f " +
                           sc.Name + " defaults failed: " + process_stderr,
                           file=sys.stderr)
                     LG().Log('ERROR', "Error: " + check_enabled_program +
                              " -f " + sc.Name + " defaults failed: " + process_stderr)
                     return [-1]
-                if 'already exist' in process_stdout: # we need to remove them first
+                if 'already exist' in process_stdout:  # we need to remove them first
                     (process_stdout, process_stderr, retval) = Process(
                         [check_enabled_program, "-f", sc.Name, "remove"])
-                    if retval is not 0 :
+                    if retval is not 0:
                         Print("Error: " + check_enabled_program + " -f " +
                               sc.Name + " remove failed: " + process_stderr,
                               file=sys.stderr)
@@ -1075,7 +1076,7 @@ def ModifyInitService(sc):
                     # it should work now
                     (process_stdout, process_stderr, retval) = Process(
                         [check_enabled_program, "-f", sc.Name, "defaults"])
-                    if retval is not 0 :
+                    if retval is not 0:
                         Print("Error: " + check_enabled_program + " -f " +
                               sc.Name + " defaults failed: " + process_stderr,
                               file=sys.stderr)
@@ -1113,17 +1114,17 @@ def ModifyInitService(sc):
                 # try 'defaults'
                 (process_stdout, process_stderr, retval) = Process(
                 [check_enabled_program, "-f", sc.Name, "defaults"])
-                if retval is not 0 :
+                if retval is not 0:
                     Print("Error: " + check_enabled_program + " -f " +
                           sc.Name + " defaults failed: " + process_stderr,
                           file=sys.stderr)
                     LG().Log('ERROR', "Error: " + check_enabled_program +
                              " -f " + sc.Name + " defaults failed: " + process_stderr)
                     return [-1]
-                if 'already exist' in process_stdout: # we need to remove them first
+                if 'already exist' in process_stdout:  # we need to remove them first
                     (process_stdout, process_stderr, retval) = Process(
                         [check_enabled_program, "-f", sc.Name, "remove"])
-                    if retval is not 0 :
+                    if retval is not 0:
                         Print("Error: " + check_enabled_program + " -f " +
                               sc.Name + " remove failed: " + process_stderr,
                               file=sys.stderr)
@@ -1133,14 +1134,14 @@ def ModifyInitService(sc):
                     # it should work now
                     (process_stdout, process_stderr, retval) = Process(
                         [check_enabled_program, "-f", sc.Name, "defaults"])
-                    if retval is not 0 :
+                    if retval is not 0:
                         Print("Error: " + check_enabled_program + " -f " +
                               sc.Name + " defaults failed: " + process_stderr,
                               file=sys.stderr)
                         LG().Log('ERROR', "Error: " + check_enabled_program +
                                  " -f " + sc.Name + " defaults failed: " + process_stderr)
                         return [-1]
-                    
+
         elif sc.Enabled is False:
             (process_stdout, process_stderr, retval) = Process(
                 [check_enabled_program, sc.Name, "off"])
@@ -1160,7 +1161,7 @@ def ModifyInitService(sc):
                              " -f " + sc.Name + " remove failed: " + process_stderr)
                     return [-1]
 
-    if sc.State == "running":		
+    if sc.State == "running":
         # don't try to read stdout or stderr as 'service start' comand
         # re-directs them, causing a hang in subprocess.communicate()
         if check_state_program == '/etc/init.d/':
@@ -1329,11 +1330,13 @@ def Get(Name, Controller, Enabled, State):
         GetOne(sc)
     return [exit_code, Name, Controller, Enabled, State, Path, sc.Description, sc.Runlevels]
 
+
 def GetOne(sc):
     GetAll(sc)
     if len(sc.services_list):
-        sc.Description=sc.services_list[0]['Description']
-        sc.Runlevels=sc.services_list[0]['Runlevels']
+        sc.Description = sc.services_list[0]['Description']
+        sc.Runlevels = sc.services_list[0]['Runlevels']
+
 
 def GetAll(sc):
     if sc.Controller == 'init':
@@ -1343,41 +1346,64 @@ def GetAll(sc):
     if sc.Controller == 'upstart':
         return UpstartGetAll(sc)
 
-def GetRunlevels(sc,Name):
+
+def GetRunlevels(sc, Name):
     if sc.runlevels_d == None:
         sc.runlevels_d = {}
-        cmd="file /etc/rc*.d/* | grep link | awk '{print $5,$1}' | sort"
+        cmd = "file /etc/rc*.d/* | grep link | awk '{print $5,$1}' | sort"
         code, out = RunGetOutput(cmd, False, False)
         for line in out.splitlines():
-            line = line.replace("'",'')
+            line = line.replace("'", '')
             srv = line.split(' ')[0]
             rl = line.split(' ')[1]
             n = os.path.basename(srv)
             if n not in sc.runlevels_d.keys():
-                sc.runlevels_d[n]={}
+                sc.runlevels_d[n] = {}
             if 'Path' not in sc.runlevels_d[n].keys():
-                sc.runlevels_d[n]['Path']=srv.replace('..','/etc')
+                sc.runlevels_d[n]['Path'] = srv.replace('..', '/etc')
             if 'Runlevels' not in sc.runlevels_d[n].keys():
-                sc.runlevels_d[n]['Runlevels']=''
-            s='off'
+                sc.runlevels_d[n]['Runlevels'] = ''
+            s = 'off'
             if rl[11].lower() == 's':
-                s='on'
-            sc.runlevels_d[n]['Runlevels'] += rl[7]+':'+s+ ' '
+                s = 'on'
+            sc.runlevels_d[n]['Runlevels'] += rl[7] + ':' + s + ' '
     if Name in sc.runlevels_d.keys():
         return sc.runlevels_d[Name]
     return None
 
+
 def SystemdGetAll(sc):
     d = {}
     if os.system('which systemctl') != 0:
-        Print("Error: 'Controller' = " + sc.Controller + " is incorrectly specified.", file=sys.stderr)
-        LG().Log('ERROR', "Error: 'Controller' = " + sc.Controller + " is incorrectly specified.")
+        Print("Error: 'Controller' = " + sc.Controller +
+              " is incorrectly specified.", file=sys.stderr)
+        LG().Log('ERROR', "Error: 'Controller' = " +
+           sc.Controller + " is incorrectly specified.")
         return False
-    Name=sc.Name
-    if '*' not in Name and len(Name) > 0:
-        Name = Name.replace('.service','')
+    Name = sc.Name
+    if '*' not in Name and '?' not in Name and len(Name) > 0:
+        Name = Name.replace('.service', '')
         Name += '.service'
-    cmd='systemctl -a list-unit-files ' + Name +  '| grep \.service | grep -v "@" | awk \'{print $1}\' | xargs systemctl -a --no-pager --no-legend -p "Names,WantedBy,Description,SubState,FragmentPath,UnitFileState" show'
+    # Do the commands work?
+    # There may be no error detected in our multi-pipe command below.
+    # To keep from returning garbage, we must test the commands.
+    # RunGetOutput(chk_err = True) will log the error message here if it
+    # occurs.
+    cmd = 'systemctl -a list-unit-files ' + Name
+    code, txt = RunGetOutput(cmd, False, True)
+    if code != 0:
+        return False
+    sname = ''
+    # Get the last service name from the output.
+    m = re.search(r'.*?\n(.*?)[.]service.*?\n', txt, re.M)
+    if m is not None:
+        sname = m.group(1)
+    cmd = 'systemctl -a --no-pager --no-legend -p "Names,WantedBy,Description,SubState,FragmentPath,UnitFileState" show ' + sname
+    code, txt = RunGetOutput(cmd, False, True)
+    if code != 0: 
+        return False
+    # Now we know it will work.
+    cmd = 'systemctl -a list-unit-files ' + Name +  '| grep \.service | grep -v "@" | awk \'{print $1}\' | xargs systemctl -a --no-pager --no-legend -p "Names,WantedBy,Description,SubState,FragmentPath,UnitFileState" show'
     code, txt = RunGetOutput(cmd, False, False)
     txt=txt.replace('\n\n','@@')
     txt=txt.replace('\n','|')
@@ -1412,6 +1438,19 @@ def UpstartGetAll(sc):
         Print("Error: 'Controller' = " + sc.Controller + " is incorrectly specified.", file=sys.stderr)
         LG().Log('ERROR', "Error: 'Controller' = " + sc.Controller + " is incorrectly specified.")
         return False
+    # Do the commands work?
+    # There may be no error detected in our multi-pipe command below.
+    # To keep from returning garbage, we must test the commands.
+    # RunGetOutput(chk_err = True) will log the error message here if it occurs.
+    cmd = 'initctl list'
+    code, txt = RunGetOutput(cmd, False, True)
+    if code != 0: 
+        return False
+    cmd = 'service --status-all'
+    code, txt = RunGetOutput(cmd, False, True)
+    if code != 0: 
+        return False
+    # Now we know it will work.
     cmd = "initctl list  | sed 's/[(].*[)] //g' | tr ', ' ' ' | awk '{print $1,$2}'"
     code, txt = RunGetOutput(cmd, False, False)
     services = txt.splitlines()
@@ -1462,7 +1501,16 @@ def UpstartGetAll(sc):
 def InitdGetAll(sc):
     d={}
     if os.path.exists(initd_chkconfig):
-        cmd = initd_chkconfig + ' -l | grep -vE "based| off"'
+        # Does the command work?
+        # There may be no error detected in our multi-pipe command below.
+        # To keep from returning garbage, we must test the command.
+        # RunGetOutput(chk_err = True) will log the error message here if it occurs.
+        cmd = initd_chkconfig + ' --list '
+        code, txt = RunGetOutput(cmd, False, True)
+        if code != 0: 
+            return False
+        # Now we know it will work.
+        cmd = initd_chkconfig + ' --list | grep -vE "based| off"'
         code, txt = RunGetOutput(cmd, False, False)
         services=txt.splitlines()
         for srv in services:
@@ -1490,6 +1538,15 @@ def InitdGetAll(sc):
             d['Runlevels'] = reduce(lambda x, y: x + ' ' + y, s[1:])
             sc.services_list.append(copy.deepcopy(d))
     else:
+        # Does the command work?
+        # There may be no error detected in our multi-statement command below.
+        # To keep from returning garbage, we must test the command.
+        # RunGetOutput(chk_err = True) will log the error message here if it occurs.
+        cmd =  initd_service + ' --status-all '
+        code, txt = RunGetOutput(cmd, False, True)
+        if code != 0: 
+            return False
+        # Now we know it will work.
         cmd = initd_service + ' --status-all &> /tmp/tmpfile ; cat /tmp/tmpfile ; rm /tmp/tmpfile'
         code, txt = RunGetOutput(cmd, False, False)
         txt = txt.replace('[','')

--- a/Providers/Scripts/3.x/Scripts/Tests/test_nxProviders.py
+++ b/Providers/Scripts/3.x/Scripts/Tests/test_nxProviders.py
@@ -1072,6 +1072,14 @@ class nxPackageTestCases(unittest2.TestCase):
         self.assertTrue(self.CheckInventory(self.pkg[2:], r[1]) == False, \
                         'CheckInventory(self.pkg, r[1]) should == False')
 
+    def testInventoryMarshallCmdlineError(self):
+        os.system('cp  ./Scripts/nxPackage.py /tmp/nxPackageBroken.py')
+        os.system(r'sed -i "s/\((f).*\)[0-9]/\120/" /tmp/nxPackageBroken.py')
+        nxPackageBroken = imp.load_source('nxPackageBroken','/tmp/nxPackageBroken.py') 
+        r=nxPackageBroken.Inventory_Marshall('','','*','',False,'',0)
+        os.system('rm /tmp/nxPackageBroken.py')
+        self.assertTrue(len(r[1]['__Inventory'].value) == 0,"nxPackageBroken.Inventory_Marshall('','','*','',False,'',0)  should return empty MI_INSTANCEA.")
+        print(repr(r[1]))
 
 
 class nxFileTestCases(unittest2.TestCase):
@@ -1425,6 +1433,7 @@ while True:
 upstart_etc_default="""# To disable , set DUMMY_SERVICE_ENABLED=0
 DUMMY_SERVICE_ENABLED=1
 """
+
 upstart_init_conf="""description "dummy_service"
 author "Eric Gable"
 export PATH=$PATH:/usr/local/bin
@@ -1594,7 +1603,7 @@ WAZD_PID=/var/run/dummy_service.pid
 case "$1" in
     start)
         log_begin_msg "Starting dummy_service..."
-        pid=$( pidofproc $WAZD_BIN )
+        pid=$( pidofproc -p $WAZD_PID $WAZD_BIN)
         if [ -n "$pid" ] ; then
               log_begin_msg "Already running."
               log_end_msg 0
@@ -1724,6 +1733,7 @@ case "$1" in
 esac
 rc_exit
 """
+
 redhat_init_file= """#!/bin/bash
 #
 # Init file for dummy_service.
@@ -1998,6 +2008,18 @@ class nxServiceTestCases(unittest2.TestCase):
         self.assertTrue(r[0] == 0,"Inventory_Marshall('*', " + self.controller + ", None,'')  should return == 0")
         print(repr(r[1]))
 
+    def testInventoryMarshallCmdlineError(self):
+        os.system('cp  ./Scripts/nxService.py /tmp/nxServiceBroken.py')
+        os.system('sed -i "s/cmd =  initd_service + \' --status-all \'/cmd =  initd_service + \' --atus-all \'/" /tmp/nxServiceBroken.py')
+        os.system('sed -i "s/cmd = initd_chkconfig + \' --list \'/cmd = initd_chkconfig + \' --ist \'/" /tmp/nxServiceBroken.py')
+        os.system('sed -i "s/cmd = \'initctl list\'/cmd = \'initctl ist\'/" /tmp/nxServiceBroken.py')
+        os.system('sed -i "s/cmd = \'systemctl -a list-unit-files \'/cmd = \'systemctl -a ist-unit-files \'/" /tmp/nxServiceBroken.py')
+        nxServiceBroken = imp.load_source('nxServiceBroken','/tmp/nxServiceBroken.py') 
+        r=nxServiceBroken.Inventory_Marshall('*', self.controller, None,'')
+        os.system('rm /tmp/nxServiceBroken.py')
+        self.assertTrue(r[0] == -1,"nxServiceBroken.Inventory_Marshall('*', " + self.controller + ", None,'')  should return == -1")
+        print(repr(r[1]))
+
     def testInventoryMarshallControllerWildcard(self):
         r=nxService.Inventory_Marshall('*', '*', None,'')
         self.assertTrue(r[0] == 0,"Inventory_Marshall('*', '*', None,'')  should return == 0")
@@ -2026,6 +2048,7 @@ class nxServiceTestCases(unittest2.TestCase):
         self.assertTrue(self.CheckInventory('dummy?*ice', self.controller, None, '', r[1]) == True, \
                         'CheckInventory("dummy?*ice", ' + self.controller + ', None, "", r[1]) should == True')
 
+    @unittest2.skipIf(nxService.UpstartExists() == True,'Not implemented in upstart')
     def testInventoryMarshallDummyServiceFilterEnabled(self):
         self.assertTrue(nxService.Set_Marshall("dummy_service", self.controller, True, "running")==
                         [0],'nxService.Set_Marshall("dummy_service", "'+self.controller+'", True, "running") should return ==[0]')
@@ -2044,7 +2067,7 @@ class nxServiceTestCases(unittest2.TestCase):
         self.assertTrue(self.CheckInventory('dummy?*ice', self.controller, None, 'running', r[1]) == True, \
                         'CheckInventory("dummy?*ice", ' + self.controller + ', None, "running", r[1]) should == True')
 
-    def testInventoryMarshallDummyServiceError(self):
+    def testInventoryMarshallDummyServiceFilterNameError(self):
         # This test inconsistantly fails on slower systems.  The sleep here reduces these failures.
         time.sleep(3)
         self.assertTrue(nxService.Set_Marshall("dummy_service", self.controller, True, "running")==
@@ -2053,16 +2076,6 @@ class nxServiceTestCases(unittest2.TestCase):
         self.assertTrue(r[0] == 0, "Inventory_Marshall('Gummy_service', " + self.controller + ", None,'')  should return == 0")
         self.assertTrue(self.CheckInventory('Gummy_service', self.controller, None, '', r[1]) == False, \
                         'CheckInventory("Gummy_service", self.controller, None, "", r[1]) should == False')
-
-    def testInventoryMarshallDummyServiceFilterNameError(self):
-        # This test inconsistantly fails on slower systems.  The sleep here reduces these failures.
-        time.sleep(3)
-        self.assertTrue(nxService.Set_Marshall("dummy_service", self.controller, True, "running")==
-                        [0],'nxService.Set_Marshall("dummy_service", "'+self.controller+'", True, "running") should return ==[0]')
-        r=nxService.Inventory_Marshall('dummy?*rice', self.controller, None,'')
-        self.assertTrue(r[0] == 0,"Inventory_Marshall('dummy?*rice', " + self.controller + ", None,'')  should return == 0")
-        self.assertTrue(self.CheckInventory('dummy?*rice', self.controller, None, '', r[1]) == False, \
-                        'CheckInventory("dummy?*rice", self.controller, None, "", r[1]) should == False')
 
     def testInventoryMarshallDummyServiceFilterEnabledError(self):
         # This test inconsistantly fails on slower systems.  The sleep here reduces these failures.

--- a/Providers/Scripts/3.x/Scripts/nxPackage.py
+++ b/Providers/Scripts/3.x/Scripts/nxPackage.py
@@ -46,7 +46,7 @@ LG = nxDSCLog.DSCLog
 #   [read] string Version;
 #   [read] boolean Installed;
 #   [read] string Architecture;
- 
+
 # };
 
 cache_file_dir = '/var/opt/microsoft/dsc/cache/nxPackage'
@@ -135,6 +135,7 @@ def Get_Marshall(Ensure, PackageManager, Name, FilePath, PackageGroup, Arguments
         retd[k] = ld[k]
     return retval, retd
 
+
 def Inventory_Marshall(Ensure, PackageManager, Name, FilePath, PackageGroup, Arguments, ReturnCode):
     retval = 0
     sys.stdin.flush()
@@ -143,7 +144,7 @@ def Inventory_Marshall(Ensure, PackageManager, Name, FilePath, PackageGroup, Arg
     (Ensure, PackageManager, Name, FilePath, PackageGroup, Arguments, ReturnCode) = init_vars(
         Ensure, PackageManager, Name, FilePath, PackageGroup, Arguments, ReturnCode)
     retval, pkgs = GetAll(Ensure, PackageManager, Name,
-                   FilePath, PackageGroup, Arguments, ReturnCode)
+                          FilePath, PackageGroup, Arguments, ReturnCode)
     for p in pkgs:
         p['Ensure'] = protocol.MI_String('present')
         p['PackageManager'] = protocol.MI_String(PackageManager)
@@ -159,7 +160,7 @@ def Inventory_Marshall(Ensure, PackageManager, Name, FilePath, PackageGroup, Arg
         p['Size'] = protocol.MI_Uint32(int(p['Size']))
         p['Version'] = protocol.MI_String(p['Version'])
         p['Installed'] = protocol.MI_Boolean(True)
-    Inventory=protocol.MI_InstanceA(pkgs)
+    Inventory = protocol.MI_InstanceA(pkgs)
     retd = {}
     retd["__Inventory"] = Inventory
     return retval, retd
@@ -167,6 +168,7 @@ def Inventory_Marshall(Ensure, PackageManager, Name, FilePath, PackageGroup, Arg
 #
 # Begin user defined DSC functions
 #
+
 
 def GetPackageSystem():
     ret = None
@@ -275,8 +277,10 @@ class Params:
         self.cmds['apt'] = {}
         self.cmds['yum'] = {}
         self.cmds['zypper'] = {}
-        self.cmds['dpkg']['present'] = 'DEBIAN_FRONTEND=noninteractive dpkg % -i '
-        self.cmds['dpkg']['absent'] = 'DEBIAN_FRONTEND=noninteractive dpkg % -r '
+        self.cmds['dpkg'][
+            'present'] = 'DEBIAN_FRONTEND=noninteractive dpkg % -i '
+        self.cmds['dpkg'][
+            'absent'] = 'DEBIAN_FRONTEND=noninteractive dpkg % -r '
         self.cmds['dpkg'][
             'stat'] = "dpkg-query -W -f='${Description}|${Maintainer}|'Unknown'|${Installed-Size}|${Version}|${Status}|${Architecture}\n' "
         self.cmds['dpkg'][
@@ -427,16 +431,19 @@ def ParseInfo(p, info):
             p.Architecture = f[6]
 
         if len(f) is not 6:
-            print('ERROR.   ' + p.PackageManager, file=sys.stdout)
-            LG().Log('ERROR', 'ERROR.   ' + p.PackageManager)
+            print(
+                'ERROR in ParseInfo.  Output was ' + info, file=sys.stdout)
+            LG().Log(
+                'ERROR', 'ERROR in ParseInfo.  Output was ' + info)
 
 
-def ParseAllInfo(info,p):
-    pkg_list=[]
-    d={}
-    if len(info) < 1 or  '@@' not in info:
+def ParseAllInfo(info, p):
+    pkg_list = []
+    d = {}
+    if len(info) < 1 or '@@' not in info:
         return pkg_list
     for pkg in info.split('@@'):
+        d['Name'] = ''
         d['PackageDescription'] = ''
         d['Publisher'] = ''
         d['InstalledOn'] = ''
@@ -448,7 +455,7 @@ def ParseAllInfo(info,p):
                 f = pkg.strip().split('|')
                 if len(f) is 8:
                     d['Name'] = f[0]
-                    if len(p.Name) and not fnmatch.fnmatch(d['Name'],p.Name):
+                    if len(p.Name) and not fnmatch.fnmatch(d['Name'], p.Name):
                         continue
                     d['PackageDescription'] = f[1]
                     d['Publisher'] = f[2]
@@ -461,10 +468,14 @@ def ParseAllInfo(info,p):
                     d['Installed'] = ('install' in f[6])
                     d['Architecture'] = f[7]
                 if len(f) is not 8:
-                    print('ERROR in ParseAll.', file=sys.stdout)
-                    LG().Log('ERROR', 'ERROR in ParseAll.')
+                    print(
+                        'ERROR in ParseAllInfo.  Output was ' + info, file=sys.stdout)
+                    LG().Log(
+                        'ERROR', 'ERROR in ParseAllInfo.  Output was ' + info)
+                    return pkg_list         
                 pkg_list.append(copy.deepcopy(d))
     return pkg_list
+
 
 def DoEnableDisable(p):
     # if the path is set, use the path and self.PackageSystem
@@ -498,16 +509,17 @@ def DoEnableDisable(p):
                 'ERROR', 'Error: Group mode not implemented for ' + p.PackageManager)
             return False, 'Error: Group mode not implemented for ' + p.PackageManager
     else:
-        cmd = 'LANG=en_US.UTF8 ' + p.cmds[p.PackageManager][p.Ensure] + ' ' + p.Name
+        cmd = 'LANG=en_US.UTF8 ' + \
+            p.cmds[p.PackageManager][p.Ensure] + ' ' + p.Name
     cmd = cmd.replace('%', p.Arguments)
     cmd = cmd.replace('^', p.CommandArguments)
     code, out = RunGetOutput(cmd, False)
     if len(p.LocalPath) > 1:  # create cache entry and remove the tmp file
         WriteCacheInfo(p)
         RemoveFile(p.LocalPath)
-    if p.PackageManager == 'yum' and ( 'No Match for argument: ' + p.Name in out or 'Nothing to do' in out ): # yum returns 0 on unknown package
+    if p.PackageManager == 'yum' and ('No Match for argument: ' + p.Name in out or 'Nothing to do' in out):  # yum returns 0 on unknown package
         return False, out
-    if p.PackageManager == 'zypper' and "package '" + p.Name + "' not found" in out: # zypper returns 0 on unknown package
+    if p.PackageManager == 'zypper' and "package '" + p.Name + "' not found" in out:  # zypper returns 0 on unknown package
         return False, out
     if code is not int(p.ReturnCode):
         return False, out
@@ -647,9 +659,10 @@ def Get(Ensure, PackageManager, Name, FilePath, PackageGroup, Arguments, ReturnC
     ParseInfo(p, out)
     return [0, p.PackageManager, p.PackageDescription, p.Publisher, p.InstalledOn, p.Size, p.Version, installed, p.Architecture]
 
+
 def GetAll(Ensure, PackageManager, Name,
-                   FilePath, PackageGroup, Arguments, ReturnCode):
-    pkgs=None
+           FilePath, PackageGroup, Arguments, ReturnCode):
+    pkgs = None
     try:
         p = Params(Ensure, PackageManager, Name,
                    FilePath, PackageGroup, Arguments, ReturnCode)
@@ -661,7 +674,7 @@ def GetAll(Ensure, PackageManager, Name,
         return [-1, ]
     cmd = 'LANG=en_US.UTF8 ' + p.cmds[p.PackageManager]['stat_all']
     code, out = RunGetOutput(cmd, False)
-    pkgs=ParseAllInfo(out,p)
+    pkgs = ParseAllInfo(out, p)
     return [0, pkgs]
 
 
@@ -725,12 +738,12 @@ def RunGetOutput(cmd, no_output, chk_err=True):
 
     subprocess.check_output = check_output
     subprocess.CalledProcessError = CalledProcessError
-    output=b''
+    output = b''
     try:
         output = subprocess.check_output(
             no_output, cmd, stderr=subprocess.STDOUT, shell=True)
         if output is None:
-            output=b''
+            output = b''
     except subprocess.CalledProcessError as e:
         if chk_err:
             print('CalledProcessError.  Error Code is ' +
@@ -842,9 +855,9 @@ def GetRemoteFile(p):
     if dst_st is not None:
         dst_mtime = time.gmtime(dst_st.st_mtime)
     if lm_mtime is not None and dst_mtime is not None and dst_mtime >= lm_mtime:
-        data = '' # skip download, the file is the same
+        data = ''  # skip download, the file is the same
     else:
-        data=b'keep going'
+        data = b'keep going'
         with (open(p.LocalPath, 'wb+')) as F:
             try:
                 while data:

--- a/Providers/Scripts/3.x/Scripts/nxService.py
+++ b/Providers/Scripts/3.x/Scripts/nxService.py
@@ -101,16 +101,17 @@ def Get_Marshall(Name, Controller, Enabled, State):
         retd[k] = ld[k]
     return retval, retd
 
+
 def Inventory_Marshall(Name, Controller, Enabled, State):
-    FilterEnabled = ( Enabled != None )
+    FilterEnabled = (Enabled != None)
     (Name, Controller, Enabled, State) = init_vars(
         Name, Controller, Enabled, State)
     if Controller == '':
-        return -1, {"__Inventory":{}}
+        return -1, {"__Inventory": {}}
     sc = ServiceContext(Name, Controller, Enabled, State)
     sc.FilterEnabled = FilterEnabled
     if not GetAll(sc):
-        return  -1, {"__Inventory":{}}
+        return -1, {"__Inventory": {}}
     for srv in sc.services_list:
         srv['Name'] = protocol.MI_String(srv['Name'])
         srv['Controller'] = protocol.MI_String(srv['Controller'])
@@ -119,14 +120,14 @@ def Inventory_Marshall(Name, Controller, Enabled, State):
         srv['Path'] = protocol.MI_String(srv['Path'])
         srv['Description'] = protocol.MI_String(srv['Description'])
         srv['Runlevels'] = protocol.MI_String(srv['Runlevels'])
-    Inventory=protocol.MI_InstanceA(sc.services_list)
+    Inventory = protocol.MI_InstanceA(sc.services_list)
     retd = {}
     retd["__Inventory"] = Inventory
     return 0, retd
 
-# ##########################
+#
 # Begin user defined DSC functions
-# ##########################
+#
 
 
 def SetShowMof(a):
@@ -211,12 +212,12 @@ def RunGetOutput(cmd, no_output, chk_err=True):
 
     subprocess.check_output = check_output
     subprocess.CalledProcessError = CalledProcessError
-    output=b''
+    output = b''
     try:
         output = subprocess.check_output(
             no_output, cmd, stderr=subprocess.STDOUT, shell=True)
         if output is None:
-            output=b''
+            output = b''
     except subprocess.CalledProcessError as e:
         if chk_err:
             Print('CalledProcessError.  Error Code is ' +
@@ -230,19 +231,19 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             LG().Log(
                 'ERROR', 'CalledProcessError.  Command string was ' + e.cmd)
             Print('CalledProcessError.  Command result was ' +
-                  (e.output[:-1]).decode('ascii','ignore'), file=sys.stderr)
+                  (e.output[:-1]).decode('ascii', 'ignore'), file=sys.stderr)
             LG().Log(
                 'ERROR', 'CalledProcessError.  Command result was '
-                + (e.output[:-1]).decode('ascii','ignore'))
+                + (e.output[:-1]).decode('ascii', 'ignore'))
         if no_output:
             return e.returncode, None
         else:
-            return e.returncode, e.output.decode('ascii','ignore')
+            return e.returncode, e.output.decode('ascii', 'ignore')
 
     if no_output:
         return 0, None
     else:
-        return 0, output.decode('ascii','ignore')
+        return 0, output.decode('ascii', 'ignore')
 
 
 systemctl_path = "/usr/bin/systemctl"
@@ -666,7 +667,7 @@ def GetInitState(sc):
         check_state_program = '/usr/sbin/service'
         if os.path.isfile('/usr/sbin/service'):
             check_state_program = '/usr/sbin/service'
-        else: # invoke the service directly
+        else:  # invoke the service directly
             check_state_program = '/etc/init.d/'
     if check_state_program == '/etc/init.d/':
         (process_stdout, process_stderr, retval) = Process(
@@ -1036,7 +1037,7 @@ def ModifyInitService(sc):
     if os.path.isfile(initd_invokerc) and os.path.isfile(initd_updaterc):
         if os.path.isfile('/usr/sbin/service'):
             check_state_program = '/usr/sbin/service'
-        else: # invoke the service directly
+        else:  # invoke the service directly
             check_state_program = '/etc/init.d/'
         check_enabled_program = initd_updaterc
         if sc.Enabled is True:
@@ -1051,17 +1052,17 @@ def ModifyInitService(sc):
                 # try 'defaults'
                 (process_stdout, process_stderr, retval) = Process(
                 [check_enabled_program, "-f", sc.Name, "defaults"])
-                if retval is not 0 :
+                if retval is not 0:
                     Print("Error: " + check_enabled_program + " -f " +
                           sc.Name + " defaults failed: " + process_stderr,
                           file=sys.stderr)
                     LG().Log('ERROR', "Error: " + check_enabled_program +
                              " -f " + sc.Name + " defaults failed: " + process_stderr)
                     return [-1]
-                if 'already exist' in process_stdout: # we need to remove them first
+                if 'already exist' in process_stdout:  # we need to remove them first
                     (process_stdout, process_stderr, retval) = Process(
                         [check_enabled_program, "-f", sc.Name, "remove"])
-                    if retval is not 0 :
+                    if retval is not 0:
                         Print("Error: " + check_enabled_program + " -f " +
                               sc.Name + " remove failed: " + process_stderr,
                               file=sys.stderr)
@@ -1071,7 +1072,7 @@ def ModifyInitService(sc):
                     # it should work now
                     (process_stdout, process_stderr, retval) = Process(
                         [check_enabled_program, "-f", sc.Name, "defaults"])
-                    if retval is not 0 :
+                    if retval is not 0:
                         Print("Error: " + check_enabled_program + " -f " +
                               sc.Name + " defaults failed: " + process_stderr,
                               file=sys.stderr)
@@ -1109,17 +1110,17 @@ def ModifyInitService(sc):
                 # try 'defaults'
                 (process_stdout, process_stderr, retval) = Process(
                 [check_enabled_program, "-f", sc.Name, "defaults"])
-                if retval is not 0 :
+                if retval is not 0:
                     Print("Error: " + check_enabled_program + " -f " +
                           sc.Name + " defaults failed: " + process_stderr,
                           file=sys.stderr)
                     LG().Log('ERROR', "Error: " + check_enabled_program +
                              " -f " + sc.Name + " defaults failed: " + process_stderr)
                     return [-1]
-                if 'already exist' in process_stdout: # we need to remove them first
+                if 'already exist' in process_stdout:  # we need to remove them first
                     (process_stdout, process_stderr, retval) = Process(
                         [check_enabled_program, "-f", sc.Name, "remove"])
-                    if retval is not 0 :
+                    if retval is not 0:
                         Print("Error: " + check_enabled_program + " -f " +
                               sc.Name + " remove failed: " + process_stderr,
                               file=sys.stderr)
@@ -1129,14 +1130,14 @@ def ModifyInitService(sc):
                     # it should work now
                     (process_stdout, process_stderr, retval) = Process(
                         [check_enabled_program, "-f", sc.Name, "defaults"])
-                    if retval is not 0 :
+                    if retval is not 0:
                         Print("Error: " + check_enabled_program + " -f " +
                               sc.Name + " defaults failed: " + process_stderr,
                               file=sys.stderr)
                         LG().Log('ERROR', "Error: " + check_enabled_program +
                                  " -f " + sc.Name + " defaults failed: " + process_stderr)
                         return [-1]
-                    
+
         elif sc.Enabled is False:
             (process_stdout, process_stderr, retval) = Process(
                 [check_enabled_program, sc.Name, "off"])
@@ -1156,7 +1157,7 @@ def ModifyInitService(sc):
                              " -f " + sc.Name + " remove failed: " + process_stderr)
                     return [-1]
 
-    if sc.State == "running":		
+    if sc.State == "running":
         # don't try to read stdout or stderr as 'service start' comand
         # re-directs them, causing a hang in subprocess.communicate()
         if check_state_program == '/etc/init.d/':
@@ -1325,11 +1326,13 @@ def Get(Name, Controller, Enabled, State):
         GetOne(sc)
     return [exit_code, Name, Controller, Enabled, State, Path, sc.Description, sc.Runlevels]
 
+
 def GetOne(sc):
     GetAll(sc)
     if len(sc.services_list):
-        sc.Description=sc.services_list[0]['Description']
-        sc.Runlevels=sc.services_list[0]['Runlevels']
+        sc.Description = sc.services_list[0]['Description']
+        sc.Runlevels = sc.services_list[0]['Runlevels']
+
 
 def GetAll(sc):
     if sc.Controller == 'init':
@@ -1339,41 +1342,64 @@ def GetAll(sc):
     if sc.Controller == 'upstart':
         return UpstartGetAll(sc)
 
-def GetRunlevels(sc,Name):
+
+def GetRunlevels(sc, Name):
     if sc.runlevels_d == None:
         sc.runlevels_d = {}
-        cmd="file /etc/rc*.d/* | grep link | awk '{print $5,$1}' | sort"
+        cmd = "file /etc/rc*.d/* | grep link | awk '{print $5,$1}' | sort"
         code, out = RunGetOutput(cmd, False, False)
         for line in out.splitlines():
-            line = line.replace("'",'')
+            line = line.replace("'", '')
             srv = line.split(' ')[0]
             rl = line.split(' ')[1]
             n = os.path.basename(srv)
             if n not in sc.runlevels_d.keys():
-                sc.runlevels_d[n]={}
+                sc.runlevels_d[n] = {}
             if 'Path' not in sc.runlevels_d[n].keys():
-                sc.runlevels_d[n]['Path']=srv.replace('..','/etc')
+                sc.runlevels_d[n]['Path'] = srv.replace('..', '/etc')
             if 'Runlevels' not in sc.runlevels_d[n].keys():
-                sc.runlevels_d[n]['Runlevels']=''
-            s='off'
+                sc.runlevels_d[n]['Runlevels'] = ''
+            s = 'off'
             if rl[11].lower() == 's':
-                s='on'
-            sc.runlevels_d[n]['Runlevels'] += rl[7]+':'+s+ ' '
+                s = 'on'
+            sc.runlevels_d[n]['Runlevels'] += rl[7] + ':' + s + ' '
     if Name in sc.runlevels_d.keys():
         return sc.runlevels_d[Name]
     return None
 
+
 def SystemdGetAll(sc):
     d = {}
     if os.system('which systemctl') != 0:
-        Print("Error: 'Controller' = " + sc.Controller + " is incorrectly specified.", file=sys.stderr)
-        LG().Log('ERROR', "Error: 'Controller' = " + sc.Controller + " is incorrectly specified.")
+        Print("Error: 'Controller' = " + sc.Controller +
+              " is incorrectly specified.", file=sys.stderr)
+        LG().Log('ERROR', "Error: 'Controller' = " +
+           sc.Controller + " is incorrectly specified.")
         return False
-    Name=sc.Name
-    if '*' not in Name and len(Name) > 0:
-        Name = Name.replace('.service','')
+    Name = sc.Name
+    if '*' not in Name and '?' not in Name and len(Name) > 0:
+        Name = Name.replace('.service', '')
         Name += '.service'
-    cmd='systemctl -a list-unit-files ' + Name +  '| grep \.service | grep -v "@" | awk \'{print $1}\' | xargs systemctl -a --no-pager --no-legend -p "Names,WantedBy,Description,SubState,FragmentPath,UnitFileState" show'
+    # Do the commands work?
+    # There may be no error detected in our multi-pipe command below.
+    # To keep from returning garbage, we must test the commands.
+    # RunGetOutput(chk_err = True) will log the error message here if it
+    # occurs.
+    cmd = 'systemctl -a list-unit-files ' + Name
+    code, txt = RunGetOutput(cmd, False, True)
+    if code != 0:
+        return False
+    sname = ''
+    # Get the last service name from the output.
+    m = re.search(r'.*?\n(.*?)[.]service.*?\n', txt, re.M)
+    if m is not None:
+        sname = m.group(1)
+    cmd = 'systemctl -a --no-pager --no-legend -p "Names,WantedBy,Description,SubState,FragmentPath,UnitFileState" show ' + sname
+    code, txt = RunGetOutput(cmd, False, True)
+    if code != 0: 
+        return False
+    # Now we know it will work.
+    cmd = 'systemctl -a list-unit-files ' + Name +  '| grep \.service | grep -v "@" | awk \'{print $1}\' | xargs systemctl -a --no-pager --no-legend -p "Names,WantedBy,Description,SubState,FragmentPath,UnitFileState" show'
     code, txt = RunGetOutput(cmd, False, False)
     txt=txt.replace('\n\n','@@')
     txt=txt.replace('\n','|')
@@ -1408,6 +1434,19 @@ def UpstartGetAll(sc):
         Print("Error: 'Controller' = " + sc.Controller + " is incorrectly specified.", file=sys.stderr)
         LG().Log('ERROR', "Error: 'Controller' = " + sc.Controller + " is incorrectly specified.")
         return False
+    # Do the commands work?
+    # There may be no error detected in our multi-pipe command below.
+    # To keep from returning garbage, we must test the commands.
+    # RunGetOutput(chk_err = True) will log the error message here if it occurs.
+    cmd = 'initctl list'
+    code, txt = RunGetOutput(cmd, False, True)
+    if code != 0: 
+        return False
+    cmd = 'service --status-all'
+    code, txt = RunGetOutput(cmd, False, True)
+    if code != 0: 
+        return False
+    # Now we know it will work.
     cmd = "initctl list  | sed 's/[(].*[)] //g' | tr ', ' ' ' | awk '{print $1,$2}'"
     code, txt = RunGetOutput(cmd, False, False)
     services = txt.splitlines()
@@ -1458,7 +1497,16 @@ def UpstartGetAll(sc):
 def InitdGetAll(sc):
     d={}
     if os.path.exists(initd_chkconfig):
-        cmd = initd_chkconfig + ' -l | grep -vE "based| off"'
+        # Does the command work?
+        # There may be no error detected in our multi-pipe command below.
+        # To keep from returning garbage, we must test the command.
+        # RunGetOutput(chk_err = True) will log the error message here if it occurs.
+        cmd = initd_chkconfig + ' --list '
+        code, txt = RunGetOutput(cmd, False, True)
+        if code != 0: 
+            return False
+        # Now we know it will work.
+        cmd = initd_chkconfig + ' --list | grep -vE "based| off"'
         code, txt = RunGetOutput(cmd, False, False)
         services=txt.splitlines()
         for srv in services:
@@ -1486,6 +1534,15 @@ def InitdGetAll(sc):
             d['Runlevels'] = reduce(lambda x, y: x + ' ' + y, s[1:])
             sc.services_list.append(copy.deepcopy(d))
     else:
+        # Does the command work?
+        # There may be no error detected in our multi-statement command below.
+        # To keep from returning garbage, we must test the command.
+        # RunGetOutput(chk_err = True) will log the error message here if it occurs.
+        cmd =  initd_service + ' --status-all '
+        code, txt = RunGetOutput(cmd, False, True)
+        if code != 0: 
+            return False
+        # Now we know it will work.
         cmd = initd_service + ' --status-all &> /tmp/tmpfile ; cat /tmp/tmpfile ; rm /tmp/tmpfile'
         code, txt = RunGetOutput(cmd, False, False)
         txt = txt.replace('[','')


### PR DESCRIPTION
nxService.py:
    Fix bug when '?' is used as a wildcard in SystemdGetAll().
    Add a test of the critical shell commands used in Inventory_Marshall to prevent undetected errors;
    this should prevent garbage in the output when a command fails.
    Apply basic PEP8 whitespace formatting.

nxPackage.py:
    Add output of 'info' data to log upon errors in ParseInfo and ParseAllInfo.
    Apply basic PEP8 whitespace formatting.

test_nxProviders.py:
    Add testInventoryMarshallCmdlineError for nxService and nxPackage.
    This forces a failure of the shell commands used for InventoryMarshall,
    and checks that the output is void of data.