### PR TITLE
Adding InMOF and OutXML options to PerformInventory

### DIFF
--- a/LCM/dsc/common/inc/MSFT_DSCLocalConfigurationManager.h
+++ b/LCM/dsc/common/inc/MSFT_DSCLocalConfigurationManager.h
@@ -1308,6 +1308,107 @@ MI_INLINE MI_Result MI_CALL MSFT_DSCLocalConfigurationManager_PerformInventory_C
 /*
 **==============================================================================
 **
+** MSFT_DSCLocalConfigurationManager.PerformInventoryOOB()
+**
+**==============================================================================
+*/
+
+typedef struct _MSFT_DSCLocalConfigurationManager_PerformInventoryOOB
+{
+    MI_Instance __instance;
+    /*OUT*/ MI_ConstUint32Field MIReturn;
+    /*IN*/ MI_ConstStringField InventoryMOFPath;
+}
+MSFT_DSCLocalConfigurationManager_PerformInventoryOOB;
+
+MI_EXTERN_C MI_CONST MI_MethodDecl MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_rtti;
+
+MI_INLINE MI_Result MI_CALL MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_Construct(
+    _Out_ MSFT_DSCLocalConfigurationManager_PerformInventoryOOB* self,
+    _In_ MI_Context* context)
+{
+    return MI_Context_ConstructParameters(context, &MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_rtti,
+        (MI_Instance*)&self->__instance);
+}
+
+MI_INLINE MI_Result MI_CALL MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_Clone(
+    _In_ const MSFT_DSCLocalConfigurationManager_PerformInventoryOOB* self,
+    _Outptr_ MSFT_DSCLocalConfigurationManager_PerformInventoryOOB** newInstance)
+{
+    return MI_Instance_Clone(
+        &self->__instance, (MI_Instance**)newInstance);
+}
+
+MI_INLINE MI_Result MI_CALL MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_Destruct(
+    _Inout_ MSFT_DSCLocalConfigurationManager_PerformInventoryOOB* self)
+{
+    return MI_Instance_Destruct(&self->__instance);
+}
+
+MI_INLINE MI_Result MI_CALL MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_Delete(
+    _Inout_ MSFT_DSCLocalConfigurationManager_PerformInventoryOOB* self)
+{
+    return MI_Instance_Delete(&self->__instance);
+}
+
+MI_INLINE MI_Result MI_CALL MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_Post(
+    _In_ const MSFT_DSCLocalConfigurationManager_PerformInventoryOOB* self,
+    _In_ MI_Context* context)
+{
+    return MI_Context_PostInstance(context, &self->__instance);
+}
+
+MI_INLINE MI_Result MI_CALL MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_Set_MIReturn(
+    _Inout_ MSFT_DSCLocalConfigurationManager_PerformInventoryOOB* self,
+    _In_ MI_Uint32 x)
+{
+    ((MI_Uint32Field*)&self->MIReturn)->value = x;
+    ((MI_Uint32Field*)&self->MIReturn)->exists = 1;
+    return MI_RESULT_OK;
+}
+
+MI_INLINE MI_Result MI_CALL MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_Clear_MIReturn(
+    _Inout_ MSFT_DSCLocalConfigurationManager_PerformInventoryOOB* self)
+{
+    memset((void*)&self->MIReturn, 0, sizeof(self->MIReturn));
+    return MI_RESULT_OK;
+}
+
+MI_INLINE MI_Result MI_CALL MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_Set_InventoryMOFPath(
+    _Inout_ MSFT_DSCLocalConfigurationManager_PerformInventoryOOB* self,
+    _In_z_ const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        1,
+        (MI_Value*)&str,
+        MI_STRING,
+        0);
+}
+
+MI_INLINE MI_Result MI_CALL MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_SetPtr_InventoryMOFPath(
+    _Inout_ MSFT_DSCLocalConfigurationManager_PerformInventoryOOB* self,
+    _In_z_ const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        1,
+        (MI_Value*)&str,
+        MI_STRING,
+        MI_FLAG_BORROW);
+}
+
+MI_INLINE MI_Result MI_CALL MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_Clear_InventoryMOFPath(
+    _Inout_ MSFT_DSCLocalConfigurationManager_PerformInventoryOOB* self)
+{
+    return self->__instance.ft->ClearElementAt(
+        (MI_Instance*)&self->__instance,
+        1);
+}
+
+/*
+**==============================================================================
+**
 ** MSFT_DSCLocalConfigurationManager provider function prototypes
 **
 **==============================================================================
@@ -1423,6 +1524,15 @@ MI_EXTERN_C void MI_CALL MSFT_DSCLocalConfigurationManager_Invoke_PerformInvento
     _In_opt_z_ const MI_Char* methodName,
     _In_ const MSFT_DSCLocalConfigurationManager* instanceName,
     _In_opt_ const MSFT_DSCLocalConfigurationManager_PerformInventory* in);
+
+MI_EXTERN_C void MI_CALL MSFT_DSCLocalConfigurationManager_Invoke_PerformInventoryOOB(
+    _In_opt_ MSFT_DSCLocalConfigurationManager_Self* self,
+    _In_ MI_Context* context,
+    _In_opt_z_ const MI_Char* nameSpace,
+    _In_opt_z_ const MI_Char* className,
+    _In_opt_z_ const MI_Char* methodName,
+    _In_ const MSFT_DSCLocalConfigurationManager* instanceName,
+    _In_opt_ const MSFT_DSCLocalConfigurationManager_PerformInventoryOOB* in);
 
 
 #endif /* _MSFT_DSCLocalConfigurationManager_h */

--- a/LCM/dsc/engine/ConfigurationManager/LocalConfigManagerHelper.c
+++ b/LCM/dsc/engine/ConfigurationManager/LocalConfigManagerHelper.c
@@ -6812,6 +6812,7 @@ MI_Result GetLCMStatusCodeHistory(
 
 /* caller release outinstances */
 MI_Result CallPerformInventory(
+    _In_ MI_Char * InMOF,
     _Inout_ MI_InstanceA *outInstances,
     _In_ MI_Context* context,
     _Outptr_result_maybenull_ MI_Instance **cimErrorDetails)
@@ -6842,7 +6843,12 @@ MI_Result CallPerformInventory(
         return GetCimMIError(result, cimErrorDetails, ID_LCMHELPER_VALIDATE_CONFGDIR_FAILED);
     }
 
-    if (File_ExistT(GetInventoryFileName()) != 0)
+    if (InMOF == NULL || InMOF[0] == '\0')
+    {
+        InMOF = GetInventoryFileName();
+    }
+
+    if (File_ExistT(InMOF) != 0)
     {
 	SetLCMStatusReady();
 	return GetCimMIError(MI_RESULT_FAILED, cimErrorDetails, ID_LCMHELPER_INVENTORY_MOF_DOESNT_EXIST);
@@ -6855,7 +6861,7 @@ MI_Result CallPerformInventory(
         return result;
     }
 
-    result =  moduleManager->ft->LoadInstanceDocumentFromLocation(moduleManager, 0, GetInventoryFileName(), cimErrorDetails, &inventoryInstances, &documentIns);
+    result =  moduleManager->ft->LoadInstanceDocumentFromLocation(moduleManager, 0, InMOF, cimErrorDetails, &inventoryInstances, &documentIns);
     if (result != MI_RESULT_OK)
     {
         moduleManager->ft->Close(moduleManager, NULL);

--- a/LCM/dsc/engine/ConfigurationManager/LocalConfigManagerHelper.h
+++ b/LCM/dsc/engine/ConfigurationManager/LocalConfigManagerHelper.h
@@ -150,6 +150,12 @@ extern "C"
         MI_Boolean force,
         _In_ MI_Context* context,
         _Outptr_result_maybenull_ MI_Instance **cimErrorDetails);
+
+    MI_Result CallPerformInventory(
+        _In_ MI_Char * InMOF,
+        _Inout_ MI_InstanceA *outInstances,
+        _In_ MI_Context* context,
+        _Outptr_result_maybenull_ MI_Instance **cimErrorDetails);
     
     MI_Result CallRestoreConfiguration(MI_Uint32 dwFlags,
                                _In_ MI_Context* context,

--- a/LCM/dsc/engine/ConfigurationManager/LocalConfigurationManager.h
+++ b/LCM/dsc/engine/ConfigurationManager/LocalConfigurationManager.h
@@ -125,6 +125,7 @@ typedef struct _Context_Invoke_Basic
     MI_Uint32 flag;
     MI_Boolean force;
     MI_ConstUint8A data;
+    MI_Char * stringdata;
     MI_Boolean dataExist;
     
 } Context_Invoke_Basic;

--- a/LCM/dsc/engine/ConfigurationManager/MSFT_DSCLocalConfigurationManager.c
+++ b/LCM/dsc/engine/ConfigurationManager/MSFT_DSCLocalConfigurationManager.c
@@ -273,3 +273,19 @@ void MI_CALL MSFT_DSCLocalConfigurationManager_Invoke_PerformInventory(
     DSC_EventWriteMSFTMethodParameters(__WFUNCTION__,className,methodName,nameSpace);
     Invoke_PerformInventory(self, context, nameSpace, className, methodName, instanceName, in);
 }
+
+void MI_CALL MSFT_DSCLocalConfigurationManager_Invoke_PerformInventoryOOB(
+    _In_opt_ MSFT_DSCLocalConfigurationManager_Self* self,
+    _In_ MI_Context* context,
+    _In_opt_z_ const MI_Char* nameSpace,
+    _In_opt_z_ const MI_Char* className,
+    _In_opt_z_ const MI_Char* methodName,
+    _In_ const MSFT_DSCLocalConfigurationManager* instanceName,
+    _In_opt_ const MSFT_DSCLocalConfigurationManager_PerformInventoryOOB* in)
+{
+    SetJobId();
+
+    // Debug Log
+    DSC_EventWriteMSFTMethodParameters(__WFUNCTION__,className,methodName,nameSpace);
+    Invoke_PerformInventoryOOB(self, context, nameSpace, className, methodName, instanceName, in);
+}

--- a/LCM/dsc/engine/ConfigurationManager/omi_schema.c
+++ b/LCM/dsc/engine/ConfigurationManager/omi_schema.c
@@ -3250,7 +3250,6 @@ static MI_CONST MI_PropertyDecl MSFT_DSCMetaConfiguration_DisableModuleSignature
     NULL,
 };
 
-
 static MI_PropertyDecl MI_CONST* MI_CONST MSFT_DSCMetaConfiguration_props[] =
 {
     &MSFT_DSCMetaConfiguration_ConfigurationModeFrequencyMins_prop,
@@ -4842,6 +4841,125 @@ MI_CONST MI_MethodDecl MSFT_DSCLocalConfigurationManager_PerformInventory_rtti =
     (MI_ProviderFT_Invoke)MSFT_DSCLocalConfigurationManager_Invoke_PerformInventory, /* method */
 };
 
+static MI_CONST MI_Boolean MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_Static_qual_value = 1;
+
+static MI_CONST MI_Qualifier MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_Static_qual =
+{
+    MI_T("Static"),
+    MI_BOOLEAN,
+    MI_FLAG_DISABLEOVERRIDE|MI_FLAG_TOSUBCLASS,
+    &MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_Static_qual_value
+};
+
+static MI_CONST MI_Char* MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_Description_qual_value = MI_T("75");
+
+static MI_CONST MI_Qualifier MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_Description_qual =
+{
+    MI_T("Description"),
+    MI_STRING,
+    MI_FLAG_ENABLEOVERRIDE|MI_FLAG_TOSUBCLASS|MI_FLAG_TRANSLATABLE,
+    &MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_Description_qual_value
+};
+
+static MI_Qualifier MI_CONST* MI_CONST MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_quals[] =
+{
+    &MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_Static_qual,
+    &MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_Description_qual,
+};
+
+static MI_CONST MI_Boolean MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_InventoryMOFPath_In_qual_value = 1;
+
+static MI_CONST MI_Qualifier MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_InventoryMOFPath_In_qual =
+{
+    MI_T("In"),
+    MI_BOOLEAN,
+    MI_FLAG_DISABLEOVERRIDE|MI_FLAG_TOSUBCLASS,
+    &MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_InventoryMOFPath_In_qual_value
+};
+
+static MI_Qualifier MI_CONST* MI_CONST MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_InventoryMOFPath_quals[] =
+{
+    &MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_InventoryMOFPath_In_qual,
+};
+
+/* parameter MSFT_DSCLocalConfigurationManager.PerformInventoryOOB(): InventoryMOFPath */
+static MI_CONST MI_ParameterDecl MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_InventoryMOFPath_param =
+{
+    MI_FLAG_PARAMETER|MI_FLAG_IN, /* flags */
+    0x00696810, /* code */
+    MI_T("InventoryMOFPath"), /* name */
+    MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_InventoryMOFPath_quals, /* qualifiers */
+    MI_COUNT(MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_InventoryMOFPath_quals), /* numQualifiers */
+    MI_STRING, /* type */
+    NULL, /* className */
+    0, /* subscript */
+    offsetof(MSFT_DSCLocalConfigurationManager_PerformInventoryOOB, InventoryMOFPath), /* offset */
+};
+
+static MI_CONST MI_Boolean MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_MIReturn_Static_qual_value = 1;
+
+static MI_CONST MI_Qualifier MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_MIReturn_Static_qual =
+{
+    MI_T("Static"),
+    MI_BOOLEAN,
+    MI_FLAG_DISABLEOVERRIDE|MI_FLAG_TOSUBCLASS,
+    &MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_MIReturn_Static_qual_value
+};
+
+static MI_CONST MI_Char* MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_MIReturn_Description_qual_value = MI_T("75");
+
+static MI_CONST MI_Qualifier MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_MIReturn_Description_qual =
+{
+    MI_T("Description"),
+    MI_STRING,
+    MI_FLAG_ENABLEOVERRIDE|MI_FLAG_TOSUBCLASS|MI_FLAG_TRANSLATABLE,
+    &MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_MIReturn_Description_qual_value
+};
+
+static MI_Qualifier MI_CONST* MI_CONST MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_MIReturn_quals[] =
+{
+    &MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_MIReturn_Static_qual,
+    &MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_MIReturn_Description_qual,
+};
+
+/* parameter MSFT_DSCLocalConfigurationManager.PerformInventoryOOB(): MIReturn */
+static MI_CONST MI_ParameterDecl MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_MIReturn_param =
+{
+    MI_FLAG_PARAMETER|MI_FLAG_OUT, /* flags */
+    0x006D6E08, /* code */
+    MI_T("MIReturn"), /* name */
+    MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_MIReturn_quals, /* qualifiers */
+    MI_COUNT(MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_MIReturn_quals), /* numQualifiers */
+    MI_UINT32, /* type */
+    NULL, /* className */
+    0, /* subscript */
+    offsetof(MSFT_DSCLocalConfigurationManager_PerformInventoryOOB, MIReturn), /* offset */
+};
+
+static MI_ParameterDecl MI_CONST* MI_CONST MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_params[] =
+{
+    &MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_MIReturn_param,
+    &MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_InventoryMOFPath_param,
+};
+
+/* method MSFT_DSCLocalConfigurationManager.PerformInventoryOOB() */
+MI_CONST MI_MethodDecl MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_rtti =
+{
+    MI_FLAG_METHOD|MI_FLAG_STATIC, /* flags */
+    0x00706213, /* code */
+    MI_T("PerformInventoryOOB"), /* name */
+    MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_quals, /* qualifiers */
+    MI_COUNT(MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_quals), /* numQualifiers */
+    MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_params, /* parameters */
+    MI_COUNT(MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_params), /* numParameters */
+    sizeof(MSFT_DSCLocalConfigurationManager_PerformInventoryOOB), /* size */
+    MI_UINT32, /* returnType */
+    MI_T("MSFT_DSCLocalConfigurationManager"), /* origin */
+    MI_T("MSFT_DSCLocalConfigurationManager"), /* propagator */
+    &schemaDecl, /* schema */
+    (MI_ProviderFT_Invoke)MSFT_DSCLocalConfigurationManager_Invoke_PerformInventoryOOB, /* method */
+};
+
 static MI_MethodDecl MI_CONST* MI_CONST MSFT_DSCLocalConfigurationManager_meths[] =
 {
     &MSFT_DSCLocalConfigurationManager_SendConfiguration_rtti,
@@ -4855,6 +4973,7 @@ static MI_MethodDecl MI_CONST* MI_CONST MSFT_DSCLocalConfigurationManager_meths[
     &MSFT_DSCLocalConfigurationManager_PerformRequiredConfigurationChecks_rtti,
     &MSFT_DSCLocalConfigurationManager_StopConfiguration_rtti,
     &MSFT_DSCLocalConfigurationManager_PerformInventory_rtti,
+    &MSFT_DSCLocalConfigurationManager_PerformInventoryOOB_rtti,
 };
 
 static MI_CONST MI_ProviderFT MSFT_DSCLocalConfigurationManager_funcs =

--- a/LCM/scripts/PerformInventory.py
+++ b/LCM/scripts/PerformInventory.py
@@ -5,11 +5,74 @@ import subprocess
 import os
 from xml.dom.minidom import parse
 
+def usage():
+   print("""Usage: PerformInventory.py [OPTIONS]
+OPTIONS (case insensitive):
+ --InMOF PATH_TO_INVENTORY.MOF
+ --OutXML PATH_TO_OUTPUT_REPORT.XML
+ --help
+""")
+
+Variables = dict()
+
+# Parse command line arguments
+args = []
+optlist = []
+
+command_line_length = len(sys.argv)
+i = 0
+inArgument = False
+currentArgument = ""
+arg = ""
+while i < command_line_length:
+   arg = sys.argv[i]
+   if i == 0:
+      # skip the program name
+      i += 1
+      continue
+
+   if inArgument:
+      Variables[currentArgument] = arg
+      inArgument = False
+   else:
+      if arg[0:2] == "--":
+         inArgument = True
+         currentArgument = arg[2:].lower()
+      else:
+         # The rest are not options
+         args = sys.argv[i:]
+         break
+   i += 1
+   
+if inArgument:
+   Variables[currentArgument] = arg
+
+AcceptableOptions = ["inmof", "outxml", "help"]
+
+if "help" in Variables:
+   usage()
+   sys.exit(0)
+
+optionsValid = True
+for arg in Variables.keys():
+   if arg.lower() not in AcceptableOptions:
+      optionsValid = False
+      print("Error: %s is not a valid option" % arg)
+
+if optionsValid == False:
+   usage()
+   sys.exit(1)
+
 omi_bindir = "<CONFIG_BINDIR>"
 omi_sysconfdir = "<CONFIG_SYSCONFDIR>"
 dsc_sysconfdir = omi_sysconfdir + "/<CONFIG_SYSCONFDIR_DSC>"
 dsc_reportdir = dsc_sysconfdir + "/InventoryReports"
 omicli_path = omi_bindir + "/omicli"
+temp_report_path = dsc_sysconfdir + "/configuration/Inventory.xml.temp"
+report_path = dsc_sysconfdir + "/configuration/Inventory.xml"
+
+if "outxml" in Variables:
+    report_path = Variables["outxml"]
 
 parameters = []
 parameters.append(omicli_path)
@@ -18,13 +81,26 @@ parameters.append("<DSC_NAMESPACE>")
 parameters.append("{")
 parameters.append("MSFT_DSCLocalConfigurationManager")
 parameters.append("}")
-parameters.append("PerformInventory")
+
+if "inmof" in Variables:
+    parameters.append("PerformInventoryOOB")
+    parameters.append("{")
+    parameters.append("InventoryMOFPath")
+    parameters.append(Variables["inmof"])
+    parameters.append("}")
+else:
+    parameters.append("PerformInventory")
 
 if len(dsc_sysconfdir) < 10:
     # something has gone horribly wrong. error out before we attempt to remove the entire file system
     print("Error: Something has gone horribly wrong with the directory paths.")
     sys.exit(1)
-    
+
+if os.path.isfile(temp_report_path):
+    print("Error: Cannot perform inventory while another inventory is being performed. Please wait for the other to finish.  If it has finished, then please remove " + temp_report_path)
+    sys.exit(1)
+
+os.system("touch " + temp_report_path)
 os.system("rm -f " + dsc_reportdir + "/*")
 
 p = subprocess.Popen(parameters, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -48,9 +124,9 @@ for f in reportFiles:
 
 final_xml_report = final_xml_report + "".join(values) + "</VALUE.ARRAY></PROPERTY.ARRAY></INSTANCE>"
 
-f = open(dsc_sysconfdir + "/configuration/Inventory.xml.temp", "w")
+f = open(temp_report_path, "w")
 f.write(final_xml_report)
 f.close()
 os.system("rm -f " + dsc_reportdir + "/*")
-os.rename(dsc_sysconfdir + "/configuration/Inventory.xml.temp", dsc_sysconfdir + "/configuration/Inventory.xml")
+os.rename(temp_report_path, report_path)
 sys.exit(retval)


### PR DESCRIPTION
You can now specify the input inventory MOF and output report XML paths instead of only being able to use default paths.