### PR TITLE
nxService.py and nxOMSSyslog.py fixes.

### DIFF
--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSSyslog.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSSyslog.py
@@ -15,6 +15,7 @@ LG = nxDSCLog.DSCLog
 rsyslog_conf_path = '/etc/rsyslog.conf'
 rsyslog_inc_conf_path = '/etc/rsyslog.d/95-omsagent.conf'
 syslog_ng_conf_path = '/etc/syslog-ng/syslog-ng.conf'
+sysklog_conf_path='/etc/syslog.conf'
 oms_syslog_ng_conf_path = '/etc/opt/omi/conf/omsconfig/syslog-ng-oms.conf'
 oms_rsyslog_conf_path = '/etc/opt/omi/conf/omsconfig/rsyslog-oms.conf'
 conf_path = ''
@@ -42,6 +43,9 @@ def init_vars(SyslogSource):
 
 
 def Set_Marshall(SyslogSource):
+    if os.path.exists(sysklog_conf_path):
+        LG().Log('ERROR', 'Sysklogd is unsupported.')
+        return [0]
     init_vars(SyslogSource)
     retval = Set(SyslogSource)
     if retval is False:
@@ -52,11 +56,17 @@ def Set_Marshall(SyslogSource):
 
 
 def Test_Marshall(SyslogSource):
+    if os.path.exists(sysklog_conf_path):
+        LG().Log('ERROR', 'Sysklogd is unsupported.')
+        return [0]
     init_vars(SyslogSource)
     return Test(SyslogSource)
 
 
 def Get_Marshall(SyslogSource):
+    if os.path.exists(sysklog_conf_path):
+        LG().Log('ERROR', 'Sysklogd is unsupported.')
+        return 0, {'SyslogSource':protocol.MI_InstanceA([])}
     arg_names = list(locals().keys())
     init_vars(SyslogSource)
     retval = 0

--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxService.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxService.py
@@ -240,6 +240,78 @@ def RunGetOutput(cmd, no_output, chk_err=True):
     else:
         return 0, output.decode('utf-8').encode('ascii', 'ignore')
 
+def RunGetOutputNoStderr(cmd, no_output, chk_err=True):
+    """
+    Wrapper for subprocess.check_output without stderr.
+    Execute 'cmd'.  Returns return code and STDOUT,
+    trapping expected exceptions.
+    Reports exceptions to Error if chk_err parameter is True
+    """
+    def check_output(no_output, *popenargs, **kwargs):
+        r"""Backport from subprocess module from python 2.7"""
+        if 'stdout' in kwargs:
+            raise ValueError(
+                'stdout argument not allowed, it will be overridden.')
+        if no_output:
+            out_file = None
+        else:
+            out_file = subprocess.PIPE
+        process = subprocess.Popen(stdout=out_file, *popenargs, **kwargs)
+        output, unused_err = process.communicate()
+        retcode = process.poll()
+        if retcode:
+            cmd = kwargs.get("args")
+            if cmd is None:
+                cmd = popenargs[0]
+            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+        return output
+
+    # Exception classes used by this module.
+    class CalledProcessError(Exception):
+
+        def __init__(self, returncode, cmd, output=None):
+            self.returncode = returncode
+            self.cmd = cmd
+            self.output = output
+
+        def __str__(self):
+            return "Command '%s' returned non-zero exit status %d" \
+                   % (self.cmd, self.returncode)
+
+    subprocess.check_output = check_output
+    subprocess.CalledProcessError = CalledProcessError
+    devnull = open('/dev/null','w')
+    try:
+        output = subprocess.check_output(
+            no_output, cmd, stderr=devnull, shell=True)
+    except subprocess.CalledProcessError, e:
+        if chk_err:
+            Print('CalledProcessError.  Error Code is ' +
+                  str(e.returncode), file=sys.stderr)
+            LG().Log(
+                'ERROR', 'CalledProcessError.  Error Code is '
+                + str(e.returncode))
+            Print(
+                'CalledProcessError.  Command string was '
+                + e.cmd, file=sys.stderr)
+            LG().Log(
+                'ERROR', 'CalledProcessError.  Command string was ' + e.cmd)
+            Print('CalledProcessError.  Command result was ' +
+                  (e.output[:-1]).decode('utf-8').encode('ascii', 'ignore'),
+                  file=sys.stderr)
+            LG().Log('ERROR', 'CalledProcessError.  Command result was ' +
+                     (e.output[:-1]).decode('utf-8').encode('ascii', 'ignore'))
+        devnull.close()
+        if no_output:
+            return e.returncode, None
+        else:
+            return e.returncode, \
+                   e.output.decode('utf-8').encode('ascii', 'ignore')
+    if no_output:
+        return 0, None
+    else:
+        return 0, output.decode('utf-8').encode('ascii', 'ignore')
+
 
 systemctl_path = "/usr/bin/systemctl"
 upstart_start_path = "/sbin/start"
@@ -1376,7 +1448,7 @@ def SystemdGetAll(sc):
     # RunGetOutput(chk_err = True) will log the error message here if it
     # occurs.
     cmd = 'systemctl -a list-unit-files ' + Name
-    code, txt = RunGetOutput(cmd, False, True)
+    code, txt = RunGetOutputNoStderr(cmd, False, True)
     if code != 0:
         return False
     sname = ''
@@ -1385,12 +1457,12 @@ def SystemdGetAll(sc):
     if m is not None:
         sname = m.group(1)
     cmd = 'systemctl -a --no-pager --no-legend -p "Names,WantedBy,Description,SubState,FragmentPath,UnitFileState" show ' + sname
-    code, txt = RunGetOutput(cmd, False, True)
+    code, txt = RunGetOutputNoStderr(cmd, False, True)
     if code != 0: 
         return False
     # Now we know it will work.
     cmd = 'systemctl -a list-unit-files ' + Name +  '| grep \.service | grep -v "@" | awk \'{print $1}\' | xargs systemctl -a --no-pager --no-legend -p "Names,WantedBy,Description,SubState,FragmentPath,UnitFileState" show'
-    code, txt = RunGetOutput(cmd, False, False)
+    code, txt = RunGetOutputNoStderr(cmd, False, False)
     txt=txt.replace('\n\n','@@')
     txt=txt.replace('\n','|')
     services=txt.split('@@')
@@ -1429,19 +1501,19 @@ def UpstartGetAll(sc):
     # To keep from returning garbage, we must test the commands.
     # RunGetOutput(chk_err = True) will log the error message here if it occurs.
     cmd = 'initctl list'
-    code, txt = RunGetOutput(cmd, False, True)
+    code, txt = RunGetOutputNoStderr(cmd, False, True)
     if code != 0: 
         return False
     cmd = 'service --status-all'
-    code, txt = RunGetOutput(cmd, False, True)
+    code, txt = RunGetOutputNoStderr(cmd, False, True)
     if code != 0: 
         return False
     # Now we know it will work.
     cmd = "initctl list  | sed 's/[(].*[)] //g' | tr ', ' ' ' | awk '{print $1,$2}'"
-    code, txt = RunGetOutput(cmd, False, False)
+    code, txt = RunGetOutputNoStderr(cmd, False, False)
     services = txt.splitlines()
     cmd = "service --status-all &> /tmp/tmpfile ; cat /tmp/tmpfile ; rm /tmp/tmpfile"
-    code, txt = RunGetOutput(cmd, False, False)
+    code, txt = RunGetOutputNoStderr(cmd, False, False)
     txt = txt.replace('[','')
     txt = txt.replace(']','')
     services.extend(txt.splitlines())
@@ -1475,7 +1547,7 @@ def UpstartGetAll(sc):
             continue
         if len(s[1]) > 1:
             cmd = 'initctl show-config ' + d['Name'] + ' | grep -E "start |stop " | tr "\n" " " | tr -s " " '
-            code, out = RunGetOutput(cmd, False, False) 
+            code, out = RunGetOutputNoStderr(cmd, False, False) 
             d['Runlevels'] = out[1:]
         else:
             rld=GetRunlevels(sc,d['Name'])
@@ -1492,12 +1564,12 @@ def InitdGetAll(sc):
         # To keep from returning garbage, we must test the command.
         # RunGetOutput(chk_err = True) will log the error message here if it occurs.
         cmd = initd_chkconfig + ' --list '
-        code, txt = RunGetOutput(cmd, False, True)
+        code, txt = RunGetOutputNoStderr(cmd, False, True)
         if code != 0: 
             return False
         # Now we know it will work.
         cmd = initd_chkconfig + ' --list | grep -vE "based| off"'
-        code, txt = RunGetOutput(cmd, False, False)
+        code, txt = RunGetOutputNoStderr(cmd, False, False)
         services=txt.splitlines()
         for srv in services:
             if len(srv) == 0:
@@ -1510,7 +1582,7 @@ def InitdGetAll(sc):
             d['Description'] = ''
             d['State'] = 'stopped'
             cmd = 'service ' + s[0] + ' status'
-            code, txt = RunGetOutput(cmd, False, False)
+            code, txt = RunGetOutputNoStderr(cmd, False, False)
             if 'running' in txt:
                 d['State'] = 'running'
             if len(sc.State) and sc.State != d['State'].lower():
@@ -1529,12 +1601,12 @@ def InitdGetAll(sc):
         # To keep from returning garbage, we must test the command.
         # RunGetOutput(chk_err = True) will log the error message here if it occurs.
         cmd =  initd_service + ' --status-all '
-        code, txt = RunGetOutput(cmd, False, True)
+        code, txt = RunGetOutputNoStderr(cmd, False, True)
         if code != 0: 
             return False
         # Now we know it will work.
         cmd = initd_service + ' --status-all &> /tmp/tmpfile ; cat /tmp/tmpfile ; rm /tmp/tmpfile'
-        code, txt = RunGetOutput(cmd, False, False)
+        code, txt = RunGetOutputNoStderr(cmd, False, False)
         txt = txt.replace('[','')
         txt = txt.replace(']','')
         services = txt.splitlines()

--- a/Providers/Scripts/2.6x-2.7x/Scripts/Tests/test_nxProviders.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/Tests/test_nxProviders.py
@@ -1079,7 +1079,7 @@ class nxPackageTestCases(unittest2.TestCase):
         r=nxPackageBroken.Inventory_Marshall('','','*','',False,'',0)
         os.system('rm /tmp/nxPackageBroken.py')
         self.assertTrue(len(r[1]['__Inventory'].value) == 0,"nxPackageBroken.Inventory_Marshall('','','*','',False,'',0)  should return empty MI_INSTANCEA.")
-        print(repr(r[1]))
+        print repr(r[1])
 
 
 class nxFileTestCases(unittest2.TestCase):
@@ -2018,7 +2018,7 @@ class nxServiceTestCases(unittest2.TestCase):
         r=nxServiceBroken.Inventory_Marshall('*', self.controller, None,'')
         os.system('rm /tmp/nxServiceBroken.py')
         self.assertTrue(r[0] == -1,"nxServiceBroken.Inventory_Marshall('*', " + self.controller + ", None,'')  should return == -1")
-        print(repr(r[1]))
+        print repr(r[1])
 
     def testInventoryMarshallControllerWildcard(self):
         r=nxService.Inventory_Marshall('*', '*', None,'')
@@ -2048,7 +2048,7 @@ class nxServiceTestCases(unittest2.TestCase):
         self.assertTrue(self.CheckInventory('dummy?*ice', self.controller, None, '', r[1]) == True, \
                         'CheckInventory("dummy?*ice", ' + self.controller + ', None, "", r[1]) should == True')
 
-    @unittest2.skipIf(self.controller == 'upstart','Not implemented in upstart')
+    @unittest2.skipIf(nxService.UpstartExists() == True,'Not implemented in upstart')
     def testInventoryMarshallDummyServiceFilterEnabled(self):
         self.assertTrue(nxService.Set_Marshall("dummy_service", self.controller, True, "running")==
                         [0],'nxService.Set_Marshall("dummy_service", "'+self.controller+'", True, "running") should return ==[0]')
@@ -2097,7 +2097,12 @@ class nxServiceTestCases(unittest2.TestCase):
         self.assertTrue(self.CheckInventory('dummy?*ice', self.controller, None, 'stopped', r[1]) == False, \
                         'CheckInventory("dummy?*ice", ' + self.controller + ', None, "stopped", r[1]) should == False')
 
+    def testInventoryMarshallNoStderr(self):
+        code, out = nxService.RunGetOutputNoStderr('ls -l /tmp/bad/path', False, True)
+        self.assertTrue(code !=0 and len(out) == 0, "code, out = nxService.RunGetOutputNoStderr('ls -l /tmp/bad/path', False, True) \
+        should be code !=0 and len(out) == 0")
 
+ 
 class nxSshAuthorizedKeysTestCases(unittest2.TestCase):
     """
     Test cases for nxSshAuthorizedKeys.py
@@ -3153,8 +3158,7 @@ class nxOMSSyslogTestCases(unittest2.TestCase):
             d['SyslogSource'] = None
         else :
             for source in SyslogSource:
-                if source['Severities'] is not None:
-                    source['Severities'] = nxOMSSyslog.protocol.MI_StringA(source['Severities'])
+                source['Severities'] = nxOMSSyslog.protocol.MI_StringA(source['Severities'])
                 source['Facility']=nxOMSSyslog.protocol.MI_String(source['Facility'])
             d['SyslogSource'] = nxOMSSyslog.protocol.MI_InstanceA(SyslogSource)
         return retval,d
@@ -3169,11 +3173,13 @@ class nxOMSSyslogTestCases(unittest2.TestCase):
         self.assertTrue(nxOMSSyslog.Test_Marshall(**d) == [0],'Test_Marshall('+repr(d)+') should return == [0]') 
 
     def testGetOMSSyslog_add(self):
-        d={'SyslogSource': [{'Facility': 'auth','Severities': ['emerg','crit','warning']},{'Facility': 'kern','Severities': ['emerg','crit','warning']}] }
-        t={'SyslogSource': [{'Facility': 'auth','Severities': ['emerg','crit','warning']},{'Facility': 'kern','Severities': ['emerg','crit','warning']}] }
+        d={'SyslogSource': [{'Facility': 'auth','Severities': ['crit','emerg','warning']},{'Facility': 'kern','Severities': ['crit','emerg','warning']}] }
+        e=copy.deepcopy(d)
+        t=copy.deepcopy(d)
         self.assertTrue(nxOMSSyslog.Set_Marshall(**d) == [0],'Set('+repr(d)+') should return == [0]')
-        m=self.make_MI(0,**d)
+        m=self.make_MI(0,**e)
         g=nxOMSSyslog.Get_Marshall(**t)
+        print 'GET '+ repr(g) 
         self.assertTrue(check_values(g, m)  ==  True, \
         'Get('+repr(g)+' should return ==['+repr(m)+']')
 
@@ -3182,14 +3188,31 @@ class nxOMSSyslogTestCases(unittest2.TestCase):
         self.assertTrue(nxOMSSyslog.Set_Marshall(**d) == [0],'Set('+repr(d)+') should return == [0]') 
 
     def testGetOMSSyslog_del(self):
-        d={'SyslogSource': [{'Facility': 'kern','Severities': None },{'Facility': 'auth','Severities': None }] }
+        d={'SyslogSource': [{'Facility': 'auth','Severities': None },{'Facility': 'kern','Severities': None }] }
+        e=copy.deepcopy(d)
+        t=copy.deepcopy(d)
         self.assertTrue(nxOMSSyslog.Set_Marshall(**d) == [0],'Set('+repr(d)+') should return == [0]')
-        t={'SyslogSource': [{'Facility': 'auth','Severities': [] },{'Facility': 'kern','Severities': []}] }
         m=self.make_MI(0,**t)
-        g=nxOMSSyslog.Get_Marshall(**d)
+        g=nxOMSSyslog.Get_Marshall(**e)
         print 'GET '+ repr(g)
         self.assertTrue(check_values(g, m)  ==  True, \
         'Get('+repr(g)+' should return ==['+repr(m)+']')
+
+    def testTestSetOMSSyslog_addSysklogd(self):
+        sysklogd_exists = False
+        if not os.path.exists('/etc/syslog.conf'):
+            os.system('touch /etc/syslog.conf')
+        else:
+            sysklogd_exists = True
+        d={'SyslogSource': [{'Facility': 'kern','Severities': ['emerg','crit','warning']},{'Facility': 'auth','Severities': ['emerg','crit','warning']}] }
+        self.assertTrue(nxOMSSyslog.Set_Marshall(**d) == [0],'Set_Marshall('+repr(d)+') should return == [0]') 
+        self.assertTrue(nxOMSSyslog.Test_Marshall(**d) == [0],'Test_Marshall('+repr(d)+') should return == [0]') 
+        g=nxOMSSyslog.Get_Marshall(**d)
+        print 'GET '+ repr(g) 
+        self.assertTrue(g[0] == 0 and g[1]["SyslogSource"].value == [], \
+       'Get('+repr(g)+' should return g[0] == 0 and g[1]["SyslogSource"].value == []')
+        if sysklogd_exists == False:
+            os.system('rm /etc/syslog.conf')
 
 
 @unittest2.skipUnless(os.system('ps -ef | grep -v grep | grep omsagent') ==

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSSyslog.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSSyslog.py
@@ -15,6 +15,7 @@ LG = nxDSCLog.DSCLog
 rsyslog_conf_path = '/etc/rsyslog.conf'
 rsyslog_inc_conf_path = '/etc/rsyslog.d/95-omsagent.conf'
 syslog_ng_conf_path = '/etc/syslog-ng/syslog-ng.conf'
+sysklog_conf_path='/etc/syslog.conf'
 oms_syslog_ng_conf_path = '/etc/opt/omi/conf/omsconfig/syslog-ng-oms.conf'
 oms_rsyslog_conf_path = '/etc/opt/omi/conf/omsconfig/rsyslog-oms.conf'
 conf_path = ''
@@ -42,6 +43,9 @@ def init_vars(SyslogSource):
 
 
 def Set_Marshall(SyslogSource):
+    if os.path.exists(sysklog_conf_path):
+        LG().Log('ERROR', 'Sysklogd is unsupported.')
+        return [0]
     init_vars(SyslogSource)
     retval = Set(SyslogSource)
     if retval is False:
@@ -52,11 +56,17 @@ def Set_Marshall(SyslogSource):
 
 
 def Test_Marshall(SyslogSource):
+    if os.path.exists(sysklog_conf_path):
+        LG().Log('ERROR', 'Sysklogd is unsupported.')
+        return [0]
     init_vars(SyslogSource)
     return Test(SyslogSource)
 
 
 def Get_Marshall(SyslogSource):
+    if os.path.exists(sysklog_conf_path):
+        LG().Log('ERROR', 'Sysklogd is unsupported.')
+        return 0, {'SyslogSource':protocol.MI_InstanceA([])}
     arg_names = list(locals().keys())
     init_vars(SyslogSource)
     retval = 0

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxService.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxService.py
@@ -250,6 +250,80 @@ def RunGetOutput(cmd, no_output, chk_err=True):
         return 0, output.decode('utf-8').encode('ascii', 'ignore')
 
 
+def RunGetOutputNoStderr(cmd, no_output, chk_err=True):
+    """
+    Wrapper for subprocess.check_output without stderr.
+    Execute 'cmd'.  Returns return code and STDOUT,
+    trapping expected exceptions.
+    Reports exceptions to Error if chk_err parameter is True
+    """
+    def check_output(no_output, *popenargs, **kwargs):
+        r"""Backport from subprocess module from python 2.7"""
+        if 'stdout' in kwargs:
+            raise ValueError(
+                'stdout argument not allowed, it will be overridden.')
+        if no_output:
+            out_file = None
+        else:
+            out_file = subprocess.PIPE
+        process = subprocess.Popen(stdout=out_file, *popenargs, **kwargs)
+        output, unused_err = process.communicate()
+        retcode = process.poll()
+        if retcode:
+            cmd = kwargs.get("args")
+            if cmd is None:
+                cmd = popenargs[0]
+            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+        return output
+
+    # Exception classes used by this module.
+    class CalledProcessError(Exception):
+
+        def __init__(self, returncode, cmd, output=None):
+            self.returncode = returncode
+            self.cmd = cmd
+            self.output = output
+
+        def __str__(self):
+            return "Command '%s' returned non-zero exit status %d" \
+                   % (self.cmd, self.returncode)
+
+    subprocess.check_output = check_output
+    subprocess.CalledProcessError = CalledProcessError
+    devnull = open('/dev/null','w')
+    try:
+        output = subprocess.check_output(
+            no_output, cmd, stderr=devnull, shell=True)
+    except subprocess.CalledProcessError, e:
+        if chk_err:
+            Print('CalledProcessError.  Error Code is ' +
+                  str(e.returncode), file=sys.stderr)
+            LG().Log(
+                'ERROR', 'CalledProcessError.  Error Code is '
+                + str(e.returncode))
+            Print(
+                'CalledProcessError.  Command string was '
+                + e.cmd, file=sys.stderr)
+            LG().Log(
+                'ERROR', 'CalledProcessError.  Command string was ' + e.cmd)
+            Print('CalledProcessError.  Command result was ' +
+                  (e.output[:-1]).decode('utf-8').encode('ascii', 'ignore'),
+                  file=sys.stderr)
+            LG().Log('ERROR', 'CalledProcessError.  Command result was ' +
+                     (e.output[:-1]).decode('utf-8').encode('ascii', 'ignore'))
+        devnull.close()
+        if no_output:
+            return e.returncode, None
+        else:
+            return e.returncode, \
+                   e.output.decode('utf-8').encode('ascii', 'ignore')
+
+    if no_output:
+        return 0, None
+    else:
+        return 0, output.decode('utf-8').encode('ascii', 'ignore')
+
+
 systemctl_path = "/usr/bin/systemctl"
 upstart_start_path = "/sbin/start"
 upstart_stop_path = "/sbin/stop"
@@ -1390,7 +1464,7 @@ def SystemdGetAll(sc):
     # RunGetOutput(chk_err = True) will log the error message here if it
     # occurs.
     cmd = 'systemctl -a list-unit-files ' + Name
-    code, txt = RunGetOutput(cmd, False, True)
+    code, txt = RunGetOutputNoStderr(cmd, False, True)
     if code != 0:
         return False
     sname = ''
@@ -1399,12 +1473,12 @@ def SystemdGetAll(sc):
     if m is not None:
         sname = m.group(1)
     cmd = 'systemctl -a --no-pager --no-legend -p "Names,WantedBy,Description,SubState,FragmentPath,UnitFileState" show ' + sname
-    code, txt = RunGetOutput(cmd, False, True)
+    code, txt = RunGetOutputNoStderr(cmd, False, True)
     if code != 0: 
         return False
     # Now we know it will work.
     cmd = 'systemctl -a list-unit-files ' + Name +  '| grep \.service | grep -v "@" | awk \'{print $1}\' | xargs systemctl -a --no-pager --no-legend -p "Names,WantedBy,Description,SubState,FragmentPath,UnitFileState" show'
-    code, txt = RunGetOutput(cmd, False, False)
+    code, txt = RunGetOutputNoStderr(cmd, False, False)
     txt=txt.replace('\n\n','@@')
     txt=txt.replace('\n','|')
     services=txt.split('@@')
@@ -1443,19 +1517,19 @@ def UpstartGetAll(sc):
     # To keep from returning garbage, we must test the commands.
     # RunGetOutput(chk_err = True) will log the error message here if it occurs.
     cmd = 'initctl list'
-    code, txt = RunGetOutput(cmd, False, True)
+    code, txt = RunGetOutputNoStderr(cmd, False, True)
     if code != 0: 
         return False
     cmd = 'service --status-all'
-    code, txt = RunGetOutput(cmd, False, True)
+    code, txt = RunGetOutputNoStderr(cmd, False, True)
     if code != 0: 
         return False
     # Now we know it will work.
     cmd = "initctl list  | sed 's/[(].*[)] //g' | tr ', ' ' ' | awk '{print $1,$2}'"
-    code, txt = RunGetOutput(cmd, False, False)
+    code, txt = RunGetOutputNoStderr(cmd, False, False)
     services = txt.splitlines()
     cmd = "service --status-all &> /tmp/tmpfile ; cat /tmp/tmpfile ; rm /tmp/tmpfile"
-    code, txt = RunGetOutput(cmd, False, False)
+    code, txt = RunGetOutputNoStderr(cmd, False, False)
     txt = txt.replace('[','')
     txt = txt.replace(']','')
     services.extend(txt.splitlines())
@@ -1489,7 +1563,7 @@ def UpstartGetAll(sc):
             continue
         if len(s[1]) > 1:
             cmd = 'initctl show-config ' + d['Name'] + ' | grep -E "start |stop " | tr "\n" " " | tr -s " " '
-            code, out = RunGetOutput(cmd, False, False) 
+            code, out = RunGetOutputNoStderr(cmd, False, False) 
             d['Runlevels'] = out[1:]
         else:
             rld=GetRunlevels(sc,d['Name'])
@@ -1506,12 +1580,12 @@ def InitdGetAll(sc):
         # To keep from returning garbage, we must test the command.
         # RunGetOutput(chk_err = True) will log the error message here if it occurs.
         cmd = initd_chkconfig + ' --list '
-        code, txt = RunGetOutput(cmd, False, True)
+        code, txt = RunGetOutputNoStderr(cmd, False, True)
         if code != 0: 
             return False
         # Now we know it will work.
         cmd = initd_chkconfig + ' --list | grep -vE "based| off"'
-        code, txt = RunGetOutput(cmd, False, False)
+        code, txt = RunGetOutputNoStderr(cmd, False, False)
         services=txt.splitlines()
         for srv in services:
             if len(srv) == 0:
@@ -1524,7 +1598,7 @@ def InitdGetAll(sc):
             d['Description'] = ''
             d['State'] = 'stopped'
             cmd = 'service ' + s[0] + ' status'
-            code, txt = RunGetOutput(cmd, False, False)
+            code, txt = RunGetOutputNoStderr(cmd, False, False)
             if 'running' in txt:
                 d['State'] = 'running'
             if len(sc.State) and sc.State != d['State'].lower():
@@ -1543,12 +1617,12 @@ def InitdGetAll(sc):
         # To keep from returning garbage, we must test the command.
         # RunGetOutput(chk_err = True) will log the error message here if it occurs.
         cmd =  initd_service + ' --status-all '
-        code, txt = RunGetOutput(cmd, False, True)
+        code, txt = RunGetOutputNoStderr(cmd, False, True)
         if code != 0: 
             return False
         # Now we know it will work.
         cmd = initd_service + ' --status-all &> /tmp/tmpfile ; cat /tmp/tmpfile ; rm /tmp/tmpfile'
-        code, txt = RunGetOutput(cmd, False, False)
+        code, txt = RunGetOutputNoStderr(cmd, False, False)
         txt = txt.replace('[','')
         txt = txt.replace(']','')
         services = txt.splitlines()

--- a/Providers/Scripts/3.x/Scripts/Tests/test_nxProviders.py
+++ b/Providers/Scripts/3.x/Scripts/Tests/test_nxProviders.py
@@ -2097,7 +2097,12 @@ class nxServiceTestCases(unittest2.TestCase):
         self.assertTrue(self.CheckInventory('dummy?*ice', self.controller, None, 'stopped', r[1]) == False, \
                         'CheckInventory("dummy?*ice", ' + self.controller + ', None, "stopped", r[1]) should == False')
 
+    def testInventoryMarshallNoStderr(self):
+        code, out = nxService.RunGetOutputNoStderr('ls -l /tmp/bad/path', False, True)
+        self.assertTrue(code !=0 and len(out) == 0, "code, out = nxService.RunGetOutputNoStderr('ls -l /tmp/bad/path', False, True) \
+        should be code !=0 and len(out) == 0")
 
+ 
 class nxSshAuthorizedKeysTestCases(unittest2.TestCase):
     """
     Test cases for nxSshAuthorizedKeys.py
@@ -3153,8 +3158,7 @@ class nxOMSSyslogTestCases(unittest2.TestCase):
             d['SyslogSource'] = None
         else :
             for source in SyslogSource:
-                if source['Severities'] is not None:
-                    source['Severities'] = nxOMSSyslog.protocol.MI_StringA(source['Severities'])
+                source['Severities'] = nxOMSSyslog.protocol.MI_StringA(source['Severities'])
                 source['Facility']=nxOMSSyslog.protocol.MI_String(source['Facility'])
             d['SyslogSource'] = nxOMSSyslog.protocol.MI_InstanceA(SyslogSource)
         return retval,d
@@ -3169,11 +3173,13 @@ class nxOMSSyslogTestCases(unittest2.TestCase):
         self.assertTrue(nxOMSSyslog.Test_Marshall(**d) == [0],'Test_Marshall('+repr(d)+') should return == [0]') 
 
     def testGetOMSSyslog_add(self):
-        d={'SyslogSource': [{'Facility': 'auth','Severities': ['emerg','crit','warning']},{'Facility': 'kern','Severities': ['emerg','crit','warning']}] }
-        t={'SyslogSource': [{'Facility': 'auth','Severities': ['emerg','crit','warning']},{'Facility': 'kern','Severities': ['emerg','crit','warning']}] }
+        d={'SyslogSource': [{'Facility': 'auth','Severities': ['crit','emerg','warning']},{'Facility': 'kern','Severities': ['crit','emerg','warning']}] }
+        e=copy.deepcopy(d)
+        t=copy.deepcopy(d)
         self.assertTrue(nxOMSSyslog.Set_Marshall(**d) == [0],'Set('+repr(d)+') should return == [0]')
-        m=self.make_MI(0,**d)
+        m=self.make_MI(0,**e)
         g=nxOMSSyslog.Get_Marshall(**t)
+        print('GET '+ repr(g))
         self.assertTrue(check_values(g, m)  ==  True, \
         'Get('+repr(g)+' should return ==['+repr(m)+']')
 
@@ -3183,13 +3189,30 @@ class nxOMSSyslogTestCases(unittest2.TestCase):
 
     def testGetOMSSyslog_del(self):
         d={'SyslogSource': [{'Facility': 'kern','Severities': None },{'Facility': 'auth','Severities': None }] }
+        e=copy.deepcopy(d)
+        t=copy.deepcopy(d)
         self.assertTrue(nxOMSSyslog.Set_Marshall(**d) == [0],'Set('+repr(d)+') should return == [0]')
-        t={'SyslogSource': [{'Facility': 'kern','Severities': [] },{'Facility': 'auth','Severities': []}] }
         m=self.make_MI(0,**t)
-        g=nxOMSSyslog.Get_Marshall(**d)
+        g=nxOMSSyslog.Get_Marshall(**e)
         print('GET '+ repr(g))
         self.assertTrue(check_values(g, m)  ==  True, \
         'Get('+repr(g)+' should return ==['+repr(m)+']')
+
+    def testTestSetOMSSyslog_addSysklogd(self):
+        sysklogd_exists = False
+        if not os.path.exists('/etc/syslog.conf'):
+            os.system('touch /etc/syslog.conf')
+        else:
+            sysklogd_exists = True
+        d={'SyslogSource': [{'Facility': 'kern','Severities': ['emerg','crit','warning']},{'Facility': 'auth','Severities': ['emerg','crit','warning']}] }
+        self.assertTrue(nxOMSSyslog.Set_Marshall(**d) == [0],'Set_Marshall('+repr(d)+') should return == [0]') 
+        self.assertTrue(nxOMSSyslog.Test_Marshall(**d) == [0],'Test_Marshall('+repr(d)+') should return == [0]') 
+        g=nxOMSSyslog.Get_Marshall(**d)
+        print('GET '+ repr(g))
+        self.assertTrue(g[0] == 0 and g[1]["SyslogSource"].value == [], \
+       'Get('+repr(g)+' should return g[0] == 0 and g[1]["SyslogSource"].value == []')
+        if sysklogd_exists == False:
+            os.system('rm /etc/syslog.conf')
 
 
 @unittest2.skipUnless(os.system('ps -ef | grep -v grep | grep omsagent') ==
@@ -3492,4 +3515,3 @@ if __name__ == '__main__':
     s20=unittest2.TestLoader().loadTestsFromTestCase(nxOMSCustomLogTestCases)
     alltests = unittest2.TestSuite([s1,s2,s3,s4,s5,s6,s7,s8,s9,s10,s11,s12,s13,s14,s15,s16,s17,s18,s19,s20])
     unittest2.TextTestRunner(stream=sys.stdout,verbosity=3).run(alltests)
-

--- a/Providers/Scripts/3.x/Scripts/nxOMSSyslog.py
+++ b/Providers/Scripts/3.x/Scripts/nxOMSSyslog.py
@@ -16,6 +16,7 @@ LG = nxDSCLog.DSCLog
 rsyslog_conf_path = '/etc/rsyslog.conf'
 rsyslog_inc_conf_path = '/etc/rsyslog.d/95-omsagent.conf'
 syslog_ng_conf_path = '/etc/syslog-ng/syslog-ng.conf'
+sysklog_conf_path='/etc/syslog.conf'
 oms_syslog_ng_conf_path = '/etc/opt/omi/conf/omsconfig/syslog-ng-oms.conf'
 oms_rsyslog_conf_path = '/etc/opt/omi/conf/omsconfig/rsyslog-oms.conf'
 conf_path = ''
@@ -40,6 +41,9 @@ def init_vars(SyslogSource):
 
 
 def Set_Marshall(SyslogSource):
+    if os.path.exists(sysklog_conf_path):
+        LG().Log('ERROR', 'Sysklogd is unsupported.')
+        return [0]
     init_vars(SyslogSource)
     retval = Set(SyslogSource)
     if retval is False:
@@ -50,11 +54,17 @@ def Set_Marshall(SyslogSource):
 
 
 def Test_Marshall(SyslogSource):
+    if os.path.exists(sysklog_conf_path):
+        LG().Log('ERROR', 'Sysklogd is unsupported.')
+        return [0]
     init_vars(SyslogSource)
     return Test(SyslogSource)
 
 
 def Get_Marshall(SyslogSource):
+    if os.path.exists(sysklog_conf_path):
+        LG().Log('ERROR', 'Sysklogd is unsupported.')
+        return 0, {'SyslogSource':protocol.MI_InstanceA([])}
     arg_names = list(locals().keys())
     init_vars(SyslogSource)
     retval = 0


### PR DESCRIPTION
nxService.py - Create RunGetOutputNoStderr() to prevent any stderr in Inventory output.
nxOMSSyslog.py - If sysklogd is the syslog system, complain to log it is unsupported but return success for Test, Set, and Get.
test_nxProviders.py - add testcases for RunGetOutputNoStderr() and sysklogd.

@KrisBash 
@johnkord 