### PR TITLE
OMSPlugin 2.2: Call PerformInventory.py with Params

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -300,7 +300,7 @@ nxOMSCustomLog:
 
 nxOMSPlugin:
 	rm -rf output/staging; \
-	VERSION="2.1"; \
+	VERSION="2.2"; \
 	PROVIDERS="nxOMSPlugin"; \
 	STAGINGDIR="output/staging/$@/DSCResources"; \
 	cat Providers/Modules/$@.psd1 | sed "s@<MODULE_VERSION>@$${VERSION}@" > intermediate/Modules/$@.psd1; \

--- a/Providers/Modules/Plugins/ChangeTracking/conf/change_tracking.conf
+++ b/Providers/Modules/Plugins/ChangeTracking/conf/change_tracking.conf
@@ -1,7 +1,7 @@
 <source>
   type exec
   tag oms.changetracking
-  command /opt/microsoft/omsconfig/Scripts/PerformInventory.py > /dev/null && cat /etc/opt/omi/conf/omsconfig/configuration/Inventory.xml
+  command /opt/microsoft/omsconfig/Scripts/PerformInventory.py --InMOF /etc/opt/microsoft/omsagent/conf/omsagent.d/change_tracking_inventory.mof --OutXML /etc/opt/omi/conf/omsconfig/configuration/ChangeTrackingInventory.xml > /dev/null && cat /etc/opt/omi/conf/omsconfig/configuration/ChangeTrackingInventory.xml
   format tsv
   keys xml
   run_interval 300s

--- a/Providers/Modules/Plugins/ChangeTracking/conf/change_tracking_inventory.mof
+++ b/Providers/Modules/Plugins/ChangeTracking/conf/change_tracking_inventory.mof
@@ -1,0 +1,38 @@
+/*
+@TargetNode='Localhost'
+*/
+
+instance of MSFT_nxPackageResource
+{
+                Name = "*";
+                ResourceId = "[MSFT_nxPackageResource]Inventory";
+                ModuleName = "PSDesiredStateConfiguration";
+                ModuleVersion = "1.0";
+
+
+};
+
+instance of MSFT_nxServiceResource
+{
+                Name = "*";
+                Controller = "*";
+                ResourceId = "[MSFT_nxServiceResource]Inventory";
+                ModuleName = "PSDesiredStateConfiguration";
+                ModuleVersion = "1.0";
+
+
+};
+
+
+instance of OMI_ConfigurationDocument
+{
+  DocumentType = "inventory";
+
+     Version="2.0.0";
+     MinimumCompatibleVersion = "2.0.0";
+     Name="InventoryConfig";
+
+
+};
+
+

--- a/Providers/nxOMSPlugin/MSFT_nxOMSPluginResource.schema.mof
+++ b/Providers/nxOMSPlugin/MSFT_nxOMSPluginResource.schema.mof
@@ -1,11 +1,11 @@
-[ClassVersion("2.1.0")]
+[ClassVersion("2.2.0")]
 class MSFT_nxOMSPlugin
 {
     [key] string PluginName;
     [write,ValueMap{"present", "absent"},Values{"Present", "Absent"}] string Ensure; 
 };
  
-[ClassVersion("2.1.0")] 
+[ClassVersion("2.2.0")] 
 class MSFT_nxOMSPluginResource : OMI_BaseResource
 {
     [key] string Name;

--- a/Providers/nxOMSPlugin/schema.c
+++ b/Providers/nxOMSPlugin/schema.c
@@ -921,7 +921,7 @@ static MI_PropertyDecl MI_CONST* MI_CONST MSFT_nxOMSPlugin_props[] =
     &MSFT_nxOMSPlugin_Ensure_prop,
 };
 
-static MI_CONST MI_Char* MSFT_nxOMSPlugin_ClassVersion_qual_value = MI_T("2.1.0");
+static MI_CONST MI_Char* MSFT_nxOMSPlugin_ClassVersion_qual_value = MI_T("2.2.0");
 
 static MI_CONST MI_Qualifier MSFT_nxOMSPlugin_ClassVersion_qual =
 {


### PR DESCRIPTION
Update the conf files for the ChangeTracking in the nxOMSPlugin
module to include the latest change_tracking.conf and
change_tracking_inventory.mof.
The change_tracking.conf will call the PerformInventory.py with
--InMOF and --OutXML parameters.
Update the module version to 2.2.
@Microsoft/omsagent-devs @johnkord 