### PR TITLE
Fix constant /tmp folder cleanup by calling `service rcS status` from nxService.py

### DIFF
--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxService.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxService.py
@@ -1586,7 +1586,7 @@ def InitdGetAll(sc):
                     if code != 0: 
                         return False
                     # Now we know it will work.
-        cmd = initd_chkconfig + ' --list | grep -vE "based| off"'
+        cmd = initd_chkconfig + ' --list | grep on | grep -v based'
         code, txt = RunGetOutputNoStderr(cmd, False, False)
         services=txt.splitlines()
         for srv in services:

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxService.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxService.py
@@ -1602,7 +1602,7 @@ def InitdGetAll(sc):
                     if code != 0: 
                         return False
                     # Now we know it will work.
-        cmd = initd_chkconfig + ' --list | grep -vE "based| off"'
+        cmd = initd_chkconfig + ' --list | grep on | grep -v based'
         code, txt = RunGetOutputNoStderr(cmd, False, False)
         services=txt.splitlines()
         for srv in services:

--- a/Providers/Scripts/3.x/Scripts/nxService.py
+++ b/Providers/Scripts/3.x/Scripts/nxService.py
@@ -1598,7 +1598,7 @@ def InitdGetAll(sc):
                     if code != 0: 
                         return False
                     # Now we know it will work.
-        cmd = initd_chkconfig + ' --list | grep -vE "based| off"'
+        cmd = initd_chkconfig + ' --list | grep on | grep -v based'
         code, txt = RunGetOutputNoStderr(cmd, False, False)
         services=txt.splitlines()
         for srv in services:


### PR DESCRIPTION
Issue found in Linux OMS agent - https://github.com/Microsoft/OMS-Agent-for-Linux/issues/123 


nxService.py gets list of all services for which it wants to get status and one of them was rcS, example output with old grep command(`grep -vE "based| off"'`):

> \>chkconfig --list |grep -vE "based| off"
> acpid                     0:off  1:off  2:on   3:on   4:on   5:on   6:off
> apache2                   0:off  1:off  2:on   3:on   4:on   5:on   6:off
> atd                       0:off  1:off  2:on   3:on   4:on   5:on   6:off
> auditd                    0:off  1:off  2:on   3:on   4:on   5:on   6:off
> bootlogs                  0:off  1:on   2:on   3:on   4:on   5:on   6:off
> omid                      0:off  1:off  2:on   3:on   4:on   5:on   6:off
> omsagent                  0:off  1:off  2:on   3:on   4:on   5:on   6:off
> procps                    0:off  1:off  2:off  3:off  4:off  5:off  6:off  S:on
> rc.local                  0:off  1:off  2:on   3:on   4:on   5:on   6:off
> **rcS                       0:off  1:off  2:off  3:off  4:off  5:off  6:off**
> rmnologin                 0:off  1:off  2:on   3:on   4:on   5:on   6:off

Once it reaches rcS and runs
`service rcS status`

it causes to run `/etc/init.d/rc S` as /etc/init.d/rcS has following contents:
```
#! /bin/sh
#
# rcS
#
# Call all S??* scripts in /etc/rcS.d/ in numerical/alphabetical order
#

exec /etc/init.d/rc S
```

So, rc itself initializes boot procedures and one of them is /tmp folder cleanup.

That issue is blocking all other programs to work on Linux machines as /tmp folder is cleanup in this way as frequent as omsagent polls service statuses.
