### PR TITLE
Fixing resources which have inventory functions defined

### DIFF
--- a/LCM/GNUmakefile
+++ b/LCM/GNUmakefile
@@ -3,8 +3,6 @@ TOP = .
 include $(TOP)/config.mak
 
 DIRECTORIES = omiutils
-DIRECTORIES += codec/mof
-DIRECTORIES += codec/mof/parser
 DIRECTORIES += dsc/engine/EngineHelper
 DIRECTORIES += dsc/engine/ca/CAInfrastructure
 DIRECTORIES += dsc/engine/ca/CALogInfrastructure

--- a/Providers/Makefile
+++ b/Providers/Makefile
@@ -193,7 +193,7 @@ $(BIN_PATH)/libMSFT_$1Resource.so : \
 	$(addprefix $(BIN_PATH)/$1_,$(GENERATED_OBJS)) \
 	$(BIN_PATH)/MSFT_$1Resource.o
 	@echo ...linking: $(BIN_PATH)/libMSFT_$1Resource.so
-	$(CXX) -shared -o $$@ $$^ -L$(LIBDIR) -lmiapi -lprotocol -lomi_error -lxmlserializer -lbase -lpal
+	$(CXX) -shared -o $$@ $$^ -L$(LIBDIR) -lmiapi -lmicodec -lmofparser -lmofparsererror -lprotocol -lomi_error -lxmlserializer -lbase -lpal
 endef
 
 # instantiate per provider rules

--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -36,9 +36,6 @@ SHLIB_EXT: 'so'
 /opt/microsoft/${{SHORT_NAME}}/Scripts/StatusReport.sh; intermediate/Scripts/StatusReport.sh; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/${{SHORT_NAME}}/Scripts/helperlib.py; intermediate/Scripts/helperlib.py; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/${{SHORT_NAME}}/Scripts/ImportGPGKey.sh; intermediate/Scripts/ImportGPGKey.sh; 755; ${{RUN_AS_USER}}; root
-/opt/microsoft/${{SHORT_NAME}}/keys/dscgpgkey.asc; LCM/keys/dscgpgkey.asc; 644; ${{RUN_AS_USER}}; root
-/opt/microsoft/${{SHORT_NAME}}/keys/msgpgkey.asc; LCM/keys/msgpgkey.asc; 644; ${{RUN_AS_USER}}; root
-
 
 #if BUILD_OMS == 1
 
@@ -60,6 +57,8 @@ SHLIB_EXT: 'so'
 /opt/microsoft/omsconfig/module_packages/nx_1.0.zip; release/nx_1.0.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSAgent_1.0.zip; release/nxOMSAgent_1.0.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSCustomLog_1.0.zip; release/nxOMSCustomLog_1.0.zip; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/${{SHORT_NAME}}/keys/dscgpgkey.asc; LCM/keys/dscgpgkey.asc; 644; ${{RUN_AS_USER}}; root
+/opt/microsoft/${{SHORT_NAME}}/keys/msgpgkey.asc; LCM/keys/msgpgkey.asc; 644; ${{RUN_AS_USER}}; root
 
 #else
 
@@ -137,7 +136,7 @@ if [ "$base64hmac" != "C9eHLPTYnXyrYXLzmMsya2FWfCFNRlaq75stOI2wbLw=" ]; then
     PREREQ_ERROR=1
     exit 1
 fi
-#endif
+#else 
 
 # test for availablity of gpg
 which gpg 1> /dev/null 2> /dev/null
@@ -149,6 +148,8 @@ fi
 if [ $PREREQ_ERROR -eq 1 ]; then
     exit 1
 fi
+
+#endif
 
 %Preinstall_200
 tmpfile=`mktemp`
@@ -287,8 +288,6 @@ su - omsagent -c "/opt/microsoft/${{SHORT_NAME}}/Scripts/ImportGPGKey.sh /opt/mi
 su - omsagent -c "/opt/microsoft/${{SHORT_NAME}}/Scripts/ImportGPGKey.sh /opt/microsoft/${{SHORT_NAME}}/keys/dscgpgkey.asc keyring.gpg"
 #else
 /opt/microsoft/${{SHORT_NAME}}/Scripts/RegenerateInitFiles.py
-/opt/microsoft/${{SHORT_NAME}}/Scripts/ImportGPGKey.sh /opt/microsoft/${{SHORT_NAME}}/keys/msgpgkey.asc keymgmtring.gpg
-/opt/microsoft/${{SHORT_NAME}}/Scripts/ImportGPGKey.sh /opt/microsoft/${{SHORT_NAME}}/keys/dscgpgkey.asc keyring.gpg
 #endif
 
 


### PR DESCRIPTION
Because of some changes to omi's libraries, we no longer need to build the redundant LCM/codec directory, and we need to make sure our resources are linked against the proper mof parser/deserializer static libraries.

This also makes the gpg keys an OMS only feature (right now).