### PR TITLE
DSC provider version fixes

### DIFF
--- a/LCM/dsc/engine/lcm/module.c
+++ b/LCM/dsc/engine/lcm/module.c
@@ -45,7 +45,7 @@ MI_EXTERN_C MI_EXPORT MI_Module* MI_MAIN_CALL MI_Main(_In_ MI_Server* server)
     module.flags |= MI_MODULE_FLAG_BOOLEANS;
     module.flags |= MI_MODULE_FLAG_LOCALIZED;
     module.charSize = sizeof(MI_Char);
-    module.version = MI_VERSION;
+    module.version = MI_MAKE_VERSION(1,0,8);
     module.generatorVersion = MI_MAKE_VERSION(1,0,0);
     module.schemaDecl = &schemaDecl;
     module.Load = Load;

--- a/Makefile
+++ b/Makefile
@@ -134,10 +134,10 @@ omi100:
 	$(MAKE) -C omi-1.0.8/installbuilder SSL_VERSION=100 BUILD_RPM=$(BUILD_RPM) BUILD_DPKG=$(BUILD_DPKG)
 
 configureomi098:
-	(cd omi-1.0.8; chmod +x ./scripts/fixdist; ./scripts/fixdist; ./configure $(DEBUG_FLAGS) --enable-preexec --prefix=/opt/omi --outputdirname=output_openssl_0.9.8 --localstatedir=/var/opt/omi --sysconfdir=/etc/opt/omi/conf --certsdir=/etc/opt/omi/ssl --opensslcflags="$(openssl098_cflags)" --openssllibs="-L$(current_dir)/ext/curl/current_platform/lib $(openssl098_libs)" --openssllibdir="$(openssl098_libdir)")
+	(cd omi-1.0.8; ./configure $(DEBUG_FLAGS) --enable-preexec --prefix=/opt/omi --outputdirname=output_openssl_0.9.8 --localstatedir=/var/opt/omi --sysconfdir=/etc/opt/omi/conf --certsdir=/etc/opt/omi/ssl --opensslcflags="$(openssl098_cflags)" --openssllibs="-L$(current_dir)/ext/curl/current_platform/lib $(openssl098_libs)" --openssllibdir="$(openssl098_libdir)")
 
 configureomi100:
-	(cd omi-1.0.8; chmod +x ./scripts/fixdist; ./scripts/fixdist; ./configure $(DEBUG_FLAGS) --enable-preexec --prefix=/opt/omi --outputdirname=output_openssl_1.0.0 --localstatedir=/var/opt/omi --sysconfdir=/etc/opt/omi/conf --certsdir=/etc/opt/omi/ssl --opensslcflags="$(openssl100_cflags)" --openssllibs="-L$(current_dir)/ext/curl/current_platform/lib $(openssl100_libs)" --openssllibdir="$(openssl100_libdir)")
+	(cd omi-1.0.8; ./configure $(DEBUG_FLAGS) --enable-preexec --prefix=/opt/omi --outputdirname=output_openssl_1.0.0 --localstatedir=/var/opt/omi --sysconfdir=/etc/opt/omi/conf --certsdir=/etc/opt/omi/ssl --opensslcflags="$(openssl100_cflags)" --openssllibs="-L$(current_dir)/ext/curl/current_platform/lib $(openssl100_libs)" --openssllibdir="$(openssl100_libdir)")
 
 lcm098:
 	$(MAKE) -C LCM

--- a/Providers/nxArchive/module.c
+++ b/Providers/nxArchive/module.c
@@ -28,7 +28,7 @@ MI_EXTERN_C MI_EXPORT MI_Module* MI_MAIN_CALL MI_Main(_In_ MI_Server* server)
     module.flags |= MI_MODULE_FLAG_BOOLEANS;
     module.flags |= MI_MODULE_FLAG_LOCALIZED;
     module.charSize = sizeof(MI_Char);
-    module.version = MI_VERSION;
+    module.version = MI_MAKE_VERSION(1, 0, 8);
     module.generatorVersion = MI_MAKE_VERSION(1,0,0);
     module.schemaDecl = &schemaDecl;
     module.Load = Load;

--- a/Providers/nxAvailableUpdates/module.c
+++ b/Providers/nxAvailableUpdates/module.c
@@ -28,7 +28,7 @@ MI_EXTERN_C MI_EXPORT MI_Module* MI_MAIN_CALL MI_Main(_In_ MI_Server* server)
     module.flags |= MI_MODULE_FLAG_BOOLEANS;
     module.flags |= MI_MODULE_FLAG_LOCALIZED;
     module.charSize = sizeof(MI_Char);
-    module.version = MI_VERSION;
+    module.version = MI_MAKE_VERSION(1, 0, 8);
     module.generatorVersion = MI_MAKE_VERSION(1,0,0);
     module.schemaDecl = &schemaDecl;
     module.Load = Load;

--- a/Providers/nxComputer/module.c
+++ b/Providers/nxComputer/module.c
@@ -28,7 +28,7 @@ MI_EXTERN_C MI_EXPORT MI_Module* MI_MAIN_CALL MI_Main(_In_ MI_Server* server)
     module.flags |= MI_MODULE_FLAG_BOOLEANS;
     module.flags |= MI_MODULE_FLAG_LOCALIZED;
     module.charSize = sizeof(MI_Char);
-    module.version = MI_VERSION;
+    module.version = MI_MAKE_VERSION(1, 0, 8);
     module.generatorVersion = MI_MAKE_VERSION(1,0,0);
     module.schemaDecl = &schemaDecl;
     module.Load = Load;

--- a/Providers/nxDNSServerAddress/module.c
+++ b/Providers/nxDNSServerAddress/module.c
@@ -28,7 +28,7 @@ MI_EXTERN_C MI_EXPORT MI_Module* MI_MAIN_CALL MI_Main(_In_ MI_Server* server)
     module.flags |= MI_MODULE_FLAG_BOOLEANS;
     module.flags |= MI_MODULE_FLAG_LOCALIZED;
     module.charSize = sizeof(MI_Char);
-    module.version = MI_VERSION;
+    module.version = MI_MAKE_VERSION(1, 0, 8);
     module.generatorVersion = MI_MAKE_VERSION(1,0,0);
     module.schemaDecl = &schemaDecl;
     module.Load = Load;

--- a/Providers/nxEnvironment/module.c
+++ b/Providers/nxEnvironment/module.c
@@ -28,7 +28,7 @@ MI_EXTERN_C MI_EXPORT MI_Module* MI_MAIN_CALL MI_Main(_In_ MI_Server* server)
     module.flags |= MI_MODULE_FLAG_BOOLEANS;
     module.flags |= MI_MODULE_FLAG_LOCALIZED;
     module.charSize = sizeof(MI_Char);
-    module.version = MI_VERSION;
+    module.version = MI_MAKE_VERSION(1, 0, 8);
     module.generatorVersion = MI_MAKE_VERSION(1,0,0);
     module.schemaDecl = &schemaDecl;
     module.Load = Load;

--- a/Providers/nxFile/module.c
+++ b/Providers/nxFile/module.c
@@ -1,18 +1,3 @@
-/*
-   PowerShell Desired State Configuration for Linux
-
-   Copyright (c) Microsoft Corporation
-
-   All rights reserved. 
-
-   MIT License
-
-   Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ""Software""), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-   The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-   THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
 /* @migen@ */
 #include <MI.h>
 
@@ -43,7 +28,7 @@ MI_EXTERN_C MI_EXPORT MI_Module* MI_MAIN_CALL MI_Main(_In_ MI_Server* server)
     module.flags |= MI_MODULE_FLAG_BOOLEANS;
     module.flags |= MI_MODULE_FLAG_LOCALIZED;
     module.charSize = sizeof(MI_Char);
-    module.version = MI_VERSION;
+    module.version = MI_MAKE_VERSION(1, 0, 8);
     module.generatorVersion = MI_MAKE_VERSION(1,0,0);
     module.schemaDecl = &schemaDecl;
     module.Load = Load;

--- a/Providers/nxFileInventory/module.c
+++ b/Providers/nxFileInventory/module.c
@@ -28,7 +28,7 @@ MI_EXTERN_C MI_EXPORT MI_Module* MI_MAIN_CALL MI_Main(_In_ MI_Server* server)
     module.flags |= MI_MODULE_FLAG_BOOLEANS;
     module.flags |= MI_MODULE_FLAG_LOCALIZED;
     module.charSize = sizeof(MI_Char);
-    module.version = MI_VERSION;
+    module.version = MI_MAKE_VERSION(1, 0, 8);
     module.generatorVersion = MI_MAKE_VERSION(1,0,0);
     module.schemaDecl = &schemaDecl;
     module.Load = Load;

--- a/Providers/nxFileLine/module.c
+++ b/Providers/nxFileLine/module.c
@@ -28,7 +28,7 @@ MI_EXTERN_C MI_EXPORT MI_Module* MI_MAIN_CALL MI_Main(_In_ MI_Server* server)
     module.flags |= MI_MODULE_FLAG_BOOLEANS;
     module.flags |= MI_MODULE_FLAG_LOCALIZED;
     module.charSize = sizeof(MI_Char);
-    module.version = MI_VERSION;
+    module.version = MI_MAKE_VERSION(1, 0, 8);
     module.generatorVersion = MI_MAKE_VERSION(1,0,0);
     module.schemaDecl = &schemaDecl;
     module.Load = Load;

--- a/Providers/nxFirewall/module.c
+++ b/Providers/nxFirewall/module.c
@@ -28,7 +28,7 @@ MI_EXTERN_C MI_EXPORT MI_Module* MI_MAIN_CALL MI_Main(_In_ MI_Server* server)
     module.flags |= MI_MODULE_FLAG_BOOLEANS;
     module.flags |= MI_MODULE_FLAG_LOCALIZED;
     module.charSize = sizeof(MI_Char);
-    module.version = MI_VERSION;
+    module.version = MI_MAKE_VERSION(1, 0, 8);
     module.generatorVersion = MI_MAKE_VERSION(1,0,0);
     module.schemaDecl = &schemaDecl;
     module.Load = Load;

--- a/Providers/nxGroup/module.c
+++ b/Providers/nxGroup/module.c
@@ -1,18 +1,3 @@
-/*
-   PowerShell Desired State Configuration for Linux
-
-   Copyright (c) Microsoft Corporation
-
-   All rights reserved. 
-
-   MIT License
-
-   Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ""Software""), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-   The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-   THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
 /* @migen@ */
 #include <MI.h>
 
@@ -43,7 +28,7 @@ MI_EXTERN_C MI_EXPORT MI_Module* MI_MAIN_CALL MI_Main(_In_ MI_Server* server)
     module.flags |= MI_MODULE_FLAG_BOOLEANS;
     module.flags |= MI_MODULE_FLAG_LOCALIZED;
     module.charSize = sizeof(MI_Char);
-    module.version = MI_VERSION;
+    module.version = MI_MAKE_VERSION(1, 0, 8);
     module.generatorVersion = MI_MAKE_VERSION(1,0,0);
     module.schemaDecl = &schemaDecl;
     module.Load = Load;

--- a/Providers/nxIPAddress/module.c
+++ b/Providers/nxIPAddress/module.c
@@ -28,7 +28,7 @@ MI_EXTERN_C MI_EXPORT MI_Module* MI_MAIN_CALL MI_Main(_In_ MI_Server* server)
     module.flags |= MI_MODULE_FLAG_BOOLEANS;
     module.flags |= MI_MODULE_FLAG_LOCALIZED;
     module.charSize = sizeof(MI_Char);
-    module.version = MI_VERSION;
+    module.version = MI_MAKE_VERSION(1, 0, 8);
     module.generatorVersion = MI_MAKE_VERSION(1,0,0);
     module.schemaDecl = &schemaDecl;
     module.Load = Load;

--- a/Providers/nxLog/module.c
+++ b/Providers/nxLog/module.c
@@ -28,7 +28,7 @@ MI_EXTERN_C MI_EXPORT MI_Module* MI_MAIN_CALL MI_Main(_In_ MI_Server* server)
     module.flags |= MI_MODULE_FLAG_BOOLEANS;
     module.flags |= MI_MODULE_FLAG_LOCALIZED;
     module.charSize = sizeof(MI_Char);
-    module.version = MI_VERSION;
+    module.version = MI_MAKE_VERSION(1, 0, 8);
     module.generatorVersion = MI_MAKE_VERSION(1,0,0);
     module.schemaDecl = &schemaDecl;
     module.Load = Load;

--- a/Providers/nxMySqlDatabase/module.c
+++ b/Providers/nxMySqlDatabase/module.c
@@ -28,7 +28,7 @@ MI_EXTERN_C MI_EXPORT MI_Module* MI_MAIN_CALL MI_Main(_In_ MI_Server* server)
     module.flags |= MI_MODULE_FLAG_BOOLEANS;
     module.flags |= MI_MODULE_FLAG_LOCALIZED;
     module.charSize = sizeof(MI_Char);
-    module.version = MI_VERSION;
+    module.version = MI_MAKE_VERSION(1, 0, 8);
     module.generatorVersion = MI_MAKE_VERSION(1,0,0);
     module.schemaDecl = &schemaDecl;
     module.Load = Load;

--- a/Providers/nxMySqlGrant/module.c
+++ b/Providers/nxMySqlGrant/module.c
@@ -28,7 +28,7 @@ MI_EXTERN_C MI_EXPORT MI_Module* MI_MAIN_CALL MI_Main(_In_ MI_Server* server)
     module.flags |= MI_MODULE_FLAG_BOOLEANS;
     module.flags |= MI_MODULE_FLAG_LOCALIZED;
     module.charSize = sizeof(MI_Char);
-    module.version = MI_VERSION;
+    module.version = MI_MAKE_VERSION(1, 0, 8);
     module.generatorVersion = MI_MAKE_VERSION(1,0,0);
     module.schemaDecl = &schemaDecl;
     module.Load = Load;

--- a/Providers/nxMySqlUser/module.c
+++ b/Providers/nxMySqlUser/module.c
@@ -28,7 +28,7 @@ MI_EXTERN_C MI_EXPORT MI_Module* MI_MAIN_CALL MI_Main(_In_ MI_Server* server)
     module.flags |= MI_MODULE_FLAG_BOOLEANS;
     module.flags |= MI_MODULE_FLAG_LOCALIZED;
     module.charSize = sizeof(MI_Char);
-    module.version = MI_VERSION;
+    module.version = MI_MAKE_VERSION(1, 0, 8);
     module.generatorVersion = MI_MAKE_VERSION(1,0,0);
     module.schemaDecl = &schemaDecl;
     module.Load = Load;

--- a/Providers/nxOMSAgent/module.c
+++ b/Providers/nxOMSAgent/module.c
@@ -28,7 +28,7 @@ MI_EXTERN_C MI_EXPORT MI_Module* MI_MAIN_CALL MI_Main(_In_ MI_Server* server)
     module.flags |= MI_MODULE_FLAG_BOOLEANS;
     module.flags |= MI_MODULE_FLAG_LOCALIZED;
     module.charSize = sizeof(MI_Char);
-    module.version = MI_VERSION;
+    module.version = MI_MAKE_VERSION(1, 0, 8);
     module.generatorVersion = MI_MAKE_VERSION(1,0,0);
     module.schemaDecl = &schemaDecl;
     module.Load = Load;

--- a/Providers/nxOMSCustomLog/module.c
+++ b/Providers/nxOMSCustomLog/module.c
@@ -28,7 +28,7 @@ MI_EXTERN_C MI_EXPORT MI_Module* MI_MAIN_CALL MI_Main(_In_ MI_Server* server)
     module.flags |= MI_MODULE_FLAG_BOOLEANS;
     module.flags |= MI_MODULE_FLAG_LOCALIZED;
     module.charSize = sizeof(MI_Char);
-    module.version = MI_VERSION;
+    module.version = MI_MAKE_VERSION(1, 0, 8);
     module.generatorVersion = MI_MAKE_VERSION(1,0,0);
     module.schemaDecl = &schemaDecl;
     module.Load = Load;

--- a/Providers/nxOMSKeyMgmt/module.c
+++ b/Providers/nxOMSKeyMgmt/module.c
@@ -28,7 +28,7 @@ MI_EXTERN_C MI_EXPORT MI_Module* MI_MAIN_CALL MI_Main(_In_ MI_Server* server)
     module.flags |= MI_MODULE_FLAG_BOOLEANS;
     module.flags |= MI_MODULE_FLAG_LOCALIZED;
     module.charSize = sizeof(MI_Char);
-    module.version = MI_VERSION;
+    module.version = MI_MAKE_VERSION(1, 0, 8);
     module.generatorVersion = MI_MAKE_VERSION(1,0,0);
     module.schemaDecl = &schemaDecl;
     module.Load = Load;

--- a/Providers/nxOMSPlugin/module.c
+++ b/Providers/nxOMSPlugin/module.c
@@ -28,7 +28,7 @@ MI_EXTERN_C MI_EXPORT MI_Module* MI_MAIN_CALL MI_Main(_In_ MI_Server* server)
     module.flags |= MI_MODULE_FLAG_BOOLEANS;
     module.flags |= MI_MODULE_FLAG_LOCALIZED;
     module.charSize = sizeof(MI_Char);
-    module.version = MI_VERSION;
+    module.version = MI_MAKE_VERSION(1, 0, 8);
     module.generatorVersion = MI_MAKE_VERSION(1,0,0);
     module.schemaDecl = &schemaDecl;
     module.Load = Load;

--- a/Providers/nxOMSSyslog/module.c
+++ b/Providers/nxOMSSyslog/module.c
@@ -28,7 +28,7 @@ MI_EXTERN_C MI_EXPORT MI_Module* MI_MAIN_CALL MI_Main(_In_ MI_Server* server)
     module.flags |= MI_MODULE_FLAG_BOOLEANS;
     module.flags |= MI_MODULE_FLAG_LOCALIZED;
     module.charSize = sizeof(MI_Char);
-    module.version = MI_VERSION;
+    module.version = MI_MAKE_VERSION(1, 0, 8);
     module.generatorVersion = MI_MAKE_VERSION(1,0,0);
     module.schemaDecl = &schemaDecl;
     module.Load = Load;

--- a/Providers/nxPackage/module.c
+++ b/Providers/nxPackage/module.c
@@ -28,7 +28,7 @@ MI_EXTERN_C MI_EXPORT MI_Module* MI_MAIN_CALL MI_Main(_In_ MI_Server* server)
     module.flags |= MI_MODULE_FLAG_BOOLEANS;
     module.flags |= MI_MODULE_FLAG_LOCALIZED;
     module.charSize = sizeof(MI_Char);
-    module.version = MI_VERSION;
+    module.version = MI_MAKE_VERSION(1, 0, 8);
     module.generatorVersion = MI_MAKE_VERSION(1,0,0);
     module.schemaDecl = &schemaDecl;
     module.Load = Load;

--- a/Providers/nxScript/module.c
+++ b/Providers/nxScript/module.c
@@ -1,18 +1,3 @@
-/*
-   PowerShell Desired State Configuration for Linux
-
-   Copyright (c) Microsoft Corporation
-
-   All rights reserved. 
-
-   MIT License
-
-   Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ""Software""), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-   The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-   THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
 /* @migen@ */
 #include <MI.h>
 
@@ -43,7 +28,7 @@ MI_EXTERN_C MI_EXPORT MI_Module* MI_MAIN_CALL MI_Main(_In_ MI_Server* server)
     module.flags |= MI_MODULE_FLAG_BOOLEANS;
     module.flags |= MI_MODULE_FLAG_LOCALIZED;
     module.charSize = sizeof(MI_Char);
-    module.version = MI_VERSION;
+    module.version = MI_MAKE_VERSION(1, 0, 8);
     module.generatorVersion = MI_MAKE_VERSION(1,0,0);
     module.schemaDecl = &schemaDecl;
     module.Load = Load;

--- a/Providers/nxService/module.c
+++ b/Providers/nxService/module.c
@@ -1,18 +1,3 @@
-/*
-   PowerShell Desired State Configuration for Linux
-
-   Copyright (c) Microsoft Corporation
-
-   All rights reserved. 
-
-   MIT License
-
-   Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ""Software""), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-   The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-   THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
 /* @migen@ */
 #include <MI.h>
 
@@ -43,7 +28,7 @@ MI_EXTERN_C MI_EXPORT MI_Module* MI_MAIN_CALL MI_Main(_In_ MI_Server* server)
     module.flags |= MI_MODULE_FLAG_BOOLEANS;
     module.flags |= MI_MODULE_FLAG_LOCALIZED;
     module.charSize = sizeof(MI_Char);
-    module.version = MI_VERSION;
+    module.version = MI_MAKE_VERSION(1, 0, 8);
     module.generatorVersion = MI_MAKE_VERSION(1,0,0);
     module.schemaDecl = &schemaDecl;
     module.Load = Load;

--- a/Providers/nxSshAuthorizedKeys/module.c
+++ b/Providers/nxSshAuthorizedKeys/module.c
@@ -28,7 +28,7 @@ MI_EXTERN_C MI_EXPORT MI_Module* MI_MAIN_CALL MI_Main(_In_ MI_Server* server)
     module.flags |= MI_MODULE_FLAG_BOOLEANS;
     module.flags |= MI_MODULE_FLAG_LOCALIZED;
     module.charSize = sizeof(MI_Char);
-    module.version = MI_VERSION;
+    module.version = MI_MAKE_VERSION(1, 0, 8);
     module.generatorVersion = MI_MAKE_VERSION(1,0,0);
     module.schemaDecl = &schemaDecl;
     module.Load = Load;

--- a/Providers/nxUser/module.c
+++ b/Providers/nxUser/module.c
@@ -1,18 +1,3 @@
-/*
-   PowerShell Desired State Configuration for Linux
-
-   Copyright (c) Microsoft Corporation
-
-   All rights reserved. 
-
-   MIT License
-
-   Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ""Software""), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-   The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-   THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
 /* @migen@ */
 #include <MI.h>
 
@@ -43,7 +28,7 @@ MI_EXTERN_C MI_EXPORT MI_Module* MI_MAIN_CALL MI_Main(_In_ MI_Server* server)
     module.flags |= MI_MODULE_FLAG_BOOLEANS;
     module.flags |= MI_MODULE_FLAG_LOCALIZED;
     module.charSize = sizeof(MI_Char);
-    module.version = MI_VERSION;
+    module.version = MI_MAKE_VERSION(1, 0, 8);
     module.generatorVersion = MI_MAKE_VERSION(1,0,0);
     module.schemaDecl = &schemaDecl;
     module.Load = Load;


### PR DESCRIPTION
MI_VERSION is 1.1.0 now, but we want our providers to work with omi 1.0.8, which shouldn't be a problem since there is no incompatibility regarding the upgrade from 1.0.8 to 1.1.0.