### PR TITLE
Change os.rename to shutil.move in PerformInventory for SLES 12 error.

### DIFF
--- a/LCM/scripts/PerformInventory.py
+++ b/LCM/scripts/PerformInventory.py
@@ -4,6 +4,7 @@ import sys
 import subprocess
 import os
 import fcntl
+import shutil
 from xml.dom.minidom import parse
 
 def usage():
@@ -129,7 +130,7 @@ f = open(temp_report_path, "w")
 f.write(final_xml_report)
 f.close()
 os.system("rm -f " + dsc_reportdir + "/*")
-os.rename(temp_report_path, report_path)
+shutil.move(temp_report_path, report_path)
 
 # Release inventory file lock
 fcntl.flock(inventory_lock, fcntl.LOCK_UN)


### PR DESCRIPTION
This is for the sles12 PerformInventory.py crash.
I cannot replicate this on my sles12 - however the Python error we get from PerformInventory.py is fairly specific:
OSError: [Errno 18] Invalid cross-device link.
Although it's not clear to me why /tmp would be on another filesystem from itself...

The recommended Python solution to this is to use shutil.move, which will fall-back to doing copy of the new file if the rename fails (like shell mv).

I cannot replicate the error, but I think this change is safe to commit - and shutil.move should not break existing implementation.