### PR TITLE
nxFileInventory - Force file Contents to ascii.

### DIFF
--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxFileInventory.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxFileInventory.py
@@ -319,7 +319,7 @@ def ReadFileLimited(path, MaxContentsReturnable):
         except:
             pass
     F.close()
-    return d, error
+    return d.encode('ascii', 'ignore'), error
 
 def Print(s, file=sys.stderr):
     file.write(s.encode('utf8') + '\n')

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxFileInventory.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxFileInventory.py
@@ -334,7 +334,7 @@ def ReadFileLimited(path, MaxContentsReturnable):
                 d = F.read(MaxContentsReturnable)
             except:
                 F.close()
-    return d, error
+    return d.encode('ascii', 'ignore'), error
 
 
 def LStatFile(path):

--- a/Providers/Scripts/3.x/Scripts/nxFileInventory.py
+++ b/Providers/Scripts/3.x/Scripts/nxFileInventory.py
@@ -334,7 +334,7 @@ def ReadFileLimited(path, MaxContentsReturnable):
                 d = F.read(MaxContentsReturnable)
             except:
                 F.close()
-    return d, error
+    return d.encode().decode('ascii','ignore'), error
 
 
 def LStatFile(path):


### PR DESCRIPTION
This prevents a crash when file contents contain chars over 128.
@johnkord 
@OpusDude 
