### PR TITLE
nxFileInventory - Remove xml printf in provider cpp.

### DIFF
--- a/Providers/nxFileInventory/MSFT_nxFileInventoryResource.cpp
+++ b/Providers/nxFileInventory/MSFT_nxFileInventoryResource.cpp
@@ -259,7 +259,7 @@ void MI_CALL MSFT_nxFileInventoryResource_Invoke_InventoryTargetResource(
 		if (result == MI_RESULT_OK)
 		{
 		    clientBuffer[clientBufferNeeded] = '\0';
-		    printf((char*)clientBuffer);
+		    // printf((char*)clientBuffer);
 		}
 		
 		{


### PR DESCRIPTION
This prevents a crash on unprintable chars.
@OpusDude 
@KrisBash 
