### PR TITLE
Bug Fix: Split Json for different change tracking types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -350,7 +350,7 @@ nxOMSCustomLog:
 
 nxOMSGenerateInventoryMof:
 	rm -rf output/staging; \
-	VERSION="1.0"; \
+	VERSION="1.1"; \
 	PROVIDERS="nxOMSGenerateInventoryMof"; \
 	STAGINGDIR="output/staging/$@/DSCResources"; \
 	cat Providers/Modules/$@.psd1 | sed "s@<MODULE_VERSION>@$${VERSION}@" > intermediate/Modules/$@.psd1; \
@@ -371,7 +371,7 @@ nxOMSGenerateInventoryMof:
 
 nxOMSPlugin:
 	rm -rf output/staging; \
-	VERSION="2.10"; \
+	VERSION="2.11"; \
 	PROVIDERS="nxOMSPlugin"; \
 	STAGINGDIR="output/staging/$@/DSCResources"; \
 	cat Providers/Modules/$@.psd1 | sed "s@<MODULE_VERSION>@$${VERSION}@" > intermediate/Modules/$@.psd1; \

--- a/Providers/Modules/Plugins/ChangeTracking/conf/change_tracking.conf
+++ b/Providers/Modules/Plugins/ChangeTracking/conf/change_tracking.conf
@@ -1,15 +1,12 @@
 <source>
   type exec
-  tag oms.changetracking
-  command /opt/microsoft/omsconfig/Scripts/PerformInventory.py --InMOF /etc/opt/microsoft/omsagent/conf/omsagent.d/change_tracking_inventory.mof --OutXML /etc/opt/omi/conf/omsconfig/configuration/ChangeTrackingInventory.xml > /dev/null && cat /etc/opt/omi/conf/omsconfig/configuration/ChangeTrackingInventory.xml
-  format tsv
-  keys xml
-  run_interval 300s
+  tag oms.changetracking.package
+  command /opt/microsoft/omsconfig/Scripts/PerformInventory.py --InMOF /etc/opt/microsoft/omsagent/conf/omsagent.d/change_tracking_inventory.mof --OutXML /var/opt/microsoft/omsagent/tmp/Changetrackinginventory.xml > /dev/null && /opt/microsoft/omsagent/ruby/bin/ruby /opt/microsoft/omsagent/plugin/change_tracking_runner.rb /var/opt/microsoft/omsagent/tmp/Changetrackinginventory.xml
+  format json
+  run_interval 5m
 </source>
 
-<filter oms.changetracking>
+<filter oms.changetracking.package>
   type filter_changetracking
-  # Force upload even if the data has not changed
-  force_send_run_interval 24h
   log_level warn
 </filter>

--- a/Providers/Modules/Plugins/ChangeTracking/conf/service_change_tracking.conf
+++ b/Providers/Modules/Plugins/ChangeTracking/conf/service_change_tracking.conf
@@ -1,0 +1,14 @@
+<source>
+  type exec
+  tag oms.changetracking.service
+  command /opt/microsoft/omsconfig/Scripts/PerformInventory.py --InMOF /etc/opt/microsoft/omsagent/conf/omsagent.d/service_change_tracking_inventory.mof --OutXML  /var/opt/microsoft/omsagent/tmp/ServiceChangeTrackingInventory.xml > /dev/null && /opt/microsoft/omsagent/ruby/bin/ruby /opt/microsoft/omsagent/plugin/change_tracking_runner.rb  /var/opt/microsoft/omsagent/tmp/ServiceChangeTrackingInventory.xml
+  format json
+  run_interval 5m
+</source>
+
+<filter oms.changetracking.service>
+  type filter_changetracking
+  # Force upload even if the data has not changed
+  force_send_run_interval 24h
+  log_level warn
+</filter>

--- a/Providers/Modules/Plugins/ChangeTracking/conf/service_change_tracking_inventory.mof
+++ b/Providers/Modules/Plugins/ChangeTracking/conf/service_change_tracking_inventory.mof
@@ -2,15 +2,17 @@
 @TargetNode='Localhost'
 */
 
-instance of MSFT_nxPackageResource
+instance of MSFT_nxServiceResource
 {
                 Name = "*";
-                ResourceId = "[MSFT_nxPackageResource]Inventory";
+                Controller = "*";
+                ResourceId = "[MSFT_nxServiceResource]Inventory";
                 ModuleName = "PSDesiredStateConfiguration";
                 ModuleVersion = "1.0";
 
 
 };
+
 
 instance of OMI_ConfigurationDocument
 {

--- a/Providers/Modules/Plugins/ChangeTracking/plugin/change_tracking_runner.rb
+++ b/Providers/Modules/Plugins/ChangeTracking/plugin/change_tracking_runner.rb
@@ -1,0 +1,100 @@
+require "rexml/document"
+require "cgi"
+require 'logger'
+require 'digest'
+require 'json'
+
+require_relative 'changetracking_lib'
+require_relative 'oms_common'
+
+
+class ChangeTrackingRunner 
+	CHANGE_TRACKING_FILE = ARGV[0] 
+	CHANGE_TRACKING_STATE_FILE = CHANGE_TRACKING_FILE + ".hash"
+	PREV_HASH = "PREV_HASH"
+	LAST_UPLOAD_TIME = "LAST_UPLOAD_TIME"
+
+	@@log =  Logger.new(STDERR) #nil
+	@@log.formatter = proc do |severity, time, progname, msg|
+	        "#{severity} #{msg}\n"
+	end
+
+	def self.transform_and_wrap()
+		if File.exist?(CHANGE_TRACKING_FILE)
+			@@log.debug ("Found the change tracking inventory file.")
+
+			# Get the parameters ready.
+			time = Time.now
+			force_send_run_interval_hours = 24
+			force_send_run_interval = force_send_run_interval_hours.to_i * 3600
+			@hostname = OMS::Common.get_hostname or "Unknown host"
+
+			# Read the inventory XML.
+			file = File.open(CHANGE_TRACKING_FILE, "rb")
+			xml_string = file.read; nil # To top the output to show up on STDOUT.
+
+			#Transform the XML to HashMap
+			transformed_hash_map = ChangeTracking.transform(xml_string, @@log)
+			output = ChangeTracking.wrap(transformed_hash_map, @hostname, time)
+			hash = Digest::SHA256.hexdigest(output.to_json)
+
+			previousSnapshot = getHash()
+
+			# If there is a previous hash
+			if !previousSnapshot.nil?
+				# If you need to force send
+				if force_send_run_interval > 0 and 
+					Time.now.to_i - previousSnapshot[LAST_UPLOAD_TIME].to_i > force_send_run_interval
+					setHash(hash, Time.now)
+				# If the content changed.
+				elsif hash != previousSnapshot[PREV_HASH]
+					setHash(hash, Time.now)
+				else
+					return {}
+				end
+			else # Previous Hash did not exist. Write it
+				# and the return the output.
+				setHash(hash, Time.now)
+			end
+			return output
+		else
+			@@log.warn ("The ChangeTracking File does not exists. Make sure it is present at the correct")
+			return {}
+		end 
+	end
+
+	def self.getHash()
+		ret = {}
+		if File.exist?(CHANGE_TRACKING_STATE_FILE) # If file exists
+			@@log.debug "Found the file {CHANGE_TRACKING_STATE_FILE}. Fetching the Hash"
+	        File.open(CHANGE_TRACKING_STATE_FILE, "r") do |f| # Open file
+	        	f.each_line do |line|
+	            	line.split(/\r?\n/).reject{ |l|  
+	                	!l.include? "=" }.map { |s|  
+	                    	s.split("=")}.map { |key, value| 
+	                    		ret[key] = value 
+	                    	}
+	        	end
+			end
+	        return ret
+	    else
+	    	@@log.debug "Could not find the file #{CHANGE_TRACKING_STATE_FILE}"
+	        return nil
+	    end
+	end
+
+	def self.setHash(prev_hash, last_upload_time)
+		# File.write('/path/to/file', 'Some glorious content')
+		if File.exist?(CHANGE_TRACKING_STATE_FILE) # If file exists
+			File.open(CHANGE_TRACKING_STATE_FILE, "w") do |f| # Open file
+				f.puts "#{PREV_HASH}=#{prev_hash}"
+				f.puts "#{LAST_UPLOAD_TIME}=#{last_upload_time}"
+			end
+		else
+			File.write(CHANGE_TRACKING_STATE_FILE, "#{PREV_HASH}=#{prev_hash}\n#{LAST_UPLOAD_TIME}=#{last_upload_time}")
+		end
+	end
+end
+
+ret = ChangeTrackingRunner.transform_and_wrap()
+puts ret.to_json if !ret.nil?

--- a/Providers/Modules/Plugins/ChangeTracking/plugin/filter_changetracking.rb
+++ b/Providers/Modules/Plugins/ChangeTracking/plugin/filter_changetracking.rb
@@ -23,7 +23,6 @@ module Fluent
       super
       # This is the first method to be called when it starts running
       # Use it to allocate resources, etc.
-      ChangeTracking.log = @log
     end
 
     def shutdown
@@ -33,10 +32,8 @@ module Fluent
     end
 
     def filter(tag, time, record)
-      xml_string = record['xml']
-      @log.debug "ChangeTracking : Filtering xml size=#{xml_string.size}"
-      return ChangeTracking.transform_and_wrap(xml_string, @hostname, time, @force_send_run_interval)
+      @log.debug "ChangeTracking: Got new data to send"
+      return record
     end # filter
-
   end # class
 end # module

--- a/Providers/Scripts/2.4x-2.5x/Scripts/Tests/test_mofs/nxOMSGenerateInventoryMof_test.mof
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/Tests/test_mofs/nxOMSGenerateInventoryMof_test.mof
@@ -28,7 +28,7 @@ instance of MSFT_nxOMSGenerateInventoryMofResource as $MSFT_nxOMSGenerateInvento
     $MSFT_nxOMSGenerateInventoryMofInstance1ref
   };
   RunIntervalInSeconds = 30;
-  Tag = "oms.linuxfilechangetracking";
+  Tag = "oms.changetracking.file";
   Format = "tsv";
   FilterType = "filter_changetracking";
 };

--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSGenerateInventoryMof.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSGenerateInventoryMof.py
@@ -22,7 +22,7 @@ except ImportError:
     md5const = md5.md5
 
 inventoryMof_path = '/etc/opt/microsoft/omsagent/conf/omsagent.d/'
-outputxml_path = '/etc/opt/omi/conf/omsconfig/configuration/'
+outputxml_path = '/var/opt/microsoft/omsagent/tmp/'
 
 def init_vars(Instances):
     new_instances = []
@@ -142,9 +142,8 @@ def GenerateInventoyConfContents(FeatureName, Instances, RunIntervalInSeconds, T
 <source> \n \
   type exec \n \
   tag ' + Tag + ' \n \
-  command /opt/microsoft/omsconfig/Scripts/PerformInventory.py --InMOF ' + mof_file_path + ' --OutXML ' + outputxml_path + FeatureName + '.xml > /dev/null && cat ' + outputxml_path + FeatureName + '.xml \n \
+  command /opt/microsoft/omsconfig/Scripts/PerformInventory.py --InMOF ' + mof_file_path + ' --OutXML ' + outputxml_path + FeatureName + '.xml > /dev/null && /opt/microsoft/omsagent/ruby/bin/ruby /opt/microsoft/omsagent/plugin/change_tracking_runner.rb ' + outputxml_path + FeatureName + '.xml \n \
   format '+ Format + '\n \
-  keys xml \n \
   run_interval ' + str(RunIntervalInSeconds) + 's \n \
 </source> \n \
 <filter '+ Tag + '> \n \

--- a/Providers/Scripts/2.6x-2.7x/Scripts/Tests/test_mofs/nxOMSGenerateInventoryMof_test.mof
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/Tests/test_mofs/nxOMSGenerateInventoryMof_test.mof
@@ -28,7 +28,7 @@ instance of MSFT_nxOMSGenerateInventoryMofResource as $MSFT_nxOMSGenerateInvento
     $MSFT_nxOMSGenerateInventoryMofInstance1ref
   };
   RunIntervalInSeconds = 30;
-  Tag = "oms.linuxfilechangetracking";
+  Tag = "oms.changetracking.file";
   Format = "tsv";
   FilterType = "filter_changetracking";
 };

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSGenerateInventoryMof.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSGenerateInventoryMof.py
@@ -17,7 +17,7 @@ nxDSCLog = imp.load_source('nxDSCLog', '../nxDSCLog.py')
 LG = nxDSCLog.DSCLog
 
 inventoryMof_path = '/etc/opt/microsoft/omsagent/conf/omsagent.d/'
-outputxml_path = '/etc/opt/omi/conf/omsconfig/configuration/'
+outputxml_path = '/var/opt/microsoft/omsagent/tmp/'
 
 def init_vars(Instances):
     new_instances = []
@@ -137,9 +137,8 @@ def GenerateInventoyConfContents(FeatureName, Instances, RunIntervalInSeconds, T
 <source> \n \
   type exec \n \
   tag ' + Tag + ' \n \
-  command /opt/microsoft/omsconfig/Scripts/PerformInventory.py --InMOF ' + mof_file_path + ' --OutXML ' + outputxml_path + FeatureName + '.xml > /dev/null && cat ' + outputxml_path + FeatureName + '.xml \n \
+  command /opt/microsoft/omsconfig/Scripts/PerformInventory.py --InMOF ' + mof_file_path + ' --OutXML ' + outputxml_path + FeatureName + '.xml > /dev/null && /opt/microsoft/omsagent/ruby/bin/ruby /opt/microsoft/omsagent/plugin/change_tracking_runner.rb ' + outputxml_path + FeatureName + '.xml \n \
   format '+ Format + '\n \
-  keys xml \n \
   run_interval ' + str(RunIntervalInSeconds) + 's \n \
 </source> \n \
 <filter '+ Tag + '> \n \

--- a/Providers/Scripts/3.x/Scripts/Tests/test_mofs/nxOMSGenerateInventoryMof_test.mof
+++ b/Providers/Scripts/3.x/Scripts/Tests/test_mofs/nxOMSGenerateInventoryMof_test.mof
@@ -28,7 +28,7 @@ instance of MSFT_nxOMSGenerateInventoryMofResource as $MSFT_nxOMSGenerateInvento
     $MSFT_nxOMSGenerateInventoryMofInstance1ref
   };
   RunIntervalInSeconds = 30;
-  Tag = "oms.linuxfilechangetracking";
+  Tag = "oms.changetracking.file";
   Format = "tsv";
   FilterType = "filter_changetracking";
 };

--- a/Providers/Scripts/3.x/Scripts/nxOMSGenerateInventoryMof.py
+++ b/Providers/Scripts/3.x/Scripts/nxOMSGenerateInventoryMof.py
@@ -17,7 +17,7 @@ nxDSCLog = imp.load_source('nxDSCLog', '../nxDSCLog.py')
 LG = nxDSCLog.DSCLog
 
 inventoryMof_path = '/etc/opt/microsoft/omsagent/conf/omsagent.d/'
-outputxml_path = '/etc/opt/omi/conf/omsconfig/configuration/'
+outputxml_path = '/var/opt/microsoft/omsagent/tmp/'
 
 def init_vars(Instances):
     new_instances = []
@@ -137,9 +137,8 @@ def GenerateInventoyConfContents(FeatureName, Instances, RunIntervalInSeconds, T
 <source> \n \
   type exec \n \
   tag ' + Tag + ' \n \
-  command /opt/microsoft/omsconfig/Scripts/PerformInventory.py --InMOF ' + mof_file_path + ' --OutXML ' + outputxml_path + FeatureName + '.xml > /dev/null && cat ' + outputxml_path + FeatureName + '.xml \n \
+  command /opt/microsoft/omsconfig/Scripts/PerformInventory.py --InMOF ' + mof_file_path + ' --OutXML ' + outputxml_path + FeatureName + '.xml > /dev/null && /opt/microsoft/omsagent/ruby/bin/ruby /opt/microsoft/omsagent/plugin/change_tracking_runner.rb ' + outputxml_path + FeatureName + '.xml \n \
   format '+ Format + '\n \
-  keys xml \n \
   run_interval ' + str(RunIntervalInSeconds) + 's \n \
 </source> \n \
 <filter '+ Tag + '> \n \

--- a/Providers/nxOMSGenerateInventoryMof/MSFT_nxOMSGenerateInventoryMofResource.schema.mof
+++ b/Providers/nxOMSGenerateInventoryMof/MSFT_nxOMSGenerateInventoryMofResource.schema.mof
@@ -1,4 +1,4 @@
-[ClassVersion("1.0.0")]
+[ClassVersion("1.1.0")]
 class MSFT_nxOMSGenerateInventoryMofInstance
 {
     [key] string InstanceName;
@@ -6,7 +6,7 @@ class MSFT_nxOMSGenerateInventoryMofInstance
     [write] string Properties[];
 };
 
-[ClassVersion("1.0.0")]
+[ClassVersion("1.1.0")]
 class MSFT_nxOMSGenerateInventoryMofResource : OMI_BaseResource
 {
         [key] string FeatureName;

--- a/Providers/nxOMSGenerateInventoryMof/schema.c
+++ b/Providers/nxOMSGenerateInventoryMof/schema.c
@@ -754,7 +754,7 @@ static MI_CONST MI_Qualifier OMI_BaseResource_Abstract_qual =
     &OMI_BaseResource_Abstract_qual_value
 };
 
-static MI_CONST MI_Char* OMI_BaseResource_ClassVersion_qual_value = MI_T("1.0.0");
+static MI_CONST MI_Char* OMI_BaseResource_ClassVersion_qual_value = MI_T("1.1.0");
 
 static MI_CONST MI_Qualifier OMI_BaseResource_ClassVersion_qual =
 {
@@ -912,7 +912,7 @@ static MI_PropertyDecl MI_CONST* MI_CONST MSFT_nxOMSGenerateInventoryMofInstance
     &MSFT_nxOMSGenerateInventoryMofInstance_Properties_prop,
 };
 
-static MI_CONST MI_Char* MSFT_nxOMSGenerateInventoryMofInstance_ClassVersion_qual_value = MI_T("1.0.0");
+static MI_CONST MI_Char* MSFT_nxOMSGenerateInventoryMofInstance_ClassVersion_qual_value = MI_T("1.1.0");
 
 static MI_CONST MI_Qualifier MSFT_nxOMSGenerateInventoryMofInstance_ClassVersion_qual =
 {
@@ -1990,7 +1990,7 @@ static MI_CONST MI_Qualifier MSFT_nxOMSGenerateInventoryMofResource_Description_
     &MSFT_nxOMSGenerateInventoryMofResource_Description_qual_value
 };
 
-static MI_CONST MI_Char* MSFT_nxOMSGenerateInventoryMofResource_ClassVersion_qual_value = MI_T("1.0.0");
+static MI_CONST MI_Char* MSFT_nxOMSGenerateInventoryMofResource_ClassVersion_qual_value = MI_T("1.1.0");
 
 static MI_CONST MI_Qualifier MSFT_nxOMSGenerateInventoryMofResource_ClassVersion_qual =
 {

--- a/Providers/nxOMSPlugin/MSFT_nxOMSPluginResource.schema.mof
+++ b/Providers/nxOMSPlugin/MSFT_nxOMSPluginResource.schema.mof
@@ -1,11 +1,11 @@
-[ClassVersion("2.10.0")]
+[ClassVersion("2.11.0")]
 class MSFT_nxOMSPlugin
 {
     [key] string PluginName;
     [write,ValueMap{"present", "absent"},Values{"Present", "Absent"}] string Ensure; 
 };
- 
-[ClassVersion("2.10.0")] 
+
+[ClassVersion("2.11.0")] 
 class MSFT_nxOMSPluginResource : OMI_BaseResource
 {
     [key] string Name;

--- a/Providers/nxOMSPlugin/schema.c
+++ b/Providers/nxOMSPlugin/schema.c
@@ -921,7 +921,7 @@ static MI_PropertyDecl MI_CONST* MI_CONST MSFT_nxOMSPlugin_props[] =
     &MSFT_nxOMSPlugin_Ensure_prop,
 };
 
-static MI_CONST MI_Char* MSFT_nxOMSPlugin_ClassVersion_qual_value = MI_T("2.10.0");
+static MI_CONST MI_Char* MSFT_nxOMSPlugin_ClassVersion_qual_value = MI_T("2.11.0");
 
 static MI_CONST MI_Qualifier MSFT_nxOMSPlugin_ClassVersion_qual =
 {

--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -59,7 +59,7 @@ SHLIB_EXT: 'so'
 /opt/microsoft/omsconfig/module_packages/nxOMSSyslog_1.0.zip; release/nxOMSSyslog_1.0.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSKeyMgmt_1.0.zip; release/nxOMSKeyMgmt_1.0.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSCustomLog_1.0.zip; release/nxOMSCustomLog_1.0.zip; 755; ${{RUN_AS_USER}}; root
-/opt/microsoft/omsconfig/module_packages/nxOMSGenerateInventoryMof_1.0.zip; release/nxOMSGenerateInventoryMof_1.0.zip; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/omsconfig/module_packages/nxOMSGenerateInventoryMof_1.1.zip; release/nxOMSGenerateInventoryMof_1.1.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/${{SHORT_NAME}}/keys/dscgpgkey.asc; LCM/keys/dscgpgkey.asc; 644; ${{RUN_AS_USER}}; root
 /opt/microsoft/${{SHORT_NAME}}/keys/msgpgkey.asc; LCM/keys/msgpgkey.asc; 644; ${{RUN_AS_USER}}; root
 


### PR DESCRIPTION
Bug fix for change tracking. 
After inventory mof for file change tracking was introduced, the json produced
by filter_changetracking either contains service and package changes togather or only 
file changes. This confuses the back end into thinking that there are changes
across all types. The fix is to split the json for each change type