### PR TITLE
Fixes for nxOMSAgentNPMConfig DSC module

### DIFF
--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSAgentNPMConfig.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSAgentNPMConfig.py
@@ -35,7 +35,7 @@ class INPMAgent:
 
 class NPMAgentUtil(IOMSAgent):
     def binary_setcap(self, binaryPath):
-        if os.system('sudo /opt/microsoft/omsconfig/Scripts/NPMAgentBinaryCap.sh ' + binaryPath) == 0:
+        if os.path.exists('/opt/microsoft/omsconfig/Scripts/NPMAgentBinaryCap.sh') and os.system('sudo /opt/microsoft/omsconfig/Scripts/NPMAgentBinaryCap.sh ' + binaryPath) == 0:
             return True
         else:
             LG().Log('ERROR', 'Error setting capabilities to npmd agent binary.')
@@ -258,7 +258,7 @@ def SetConfigUpdate(Contents):
         retval = -1
     else:
         retval = WriteFile(destFileFullPath, Contents)
-        if retval == 0:
+        if retval == 0 and os.path.exists(AGENT_RESOURCE_VERSION_PATH): #notify server only if plugin is present
             LG().Log('INFO', 'Updated the file, going to notify server')
             retval = NotifyServer(Commands.Config)
     return retval
@@ -284,9 +284,9 @@ def UpdateAgentBinary(newVersion):
         retval &= CopyAllFiles(src, AGENT_BINARY_PATH)
 
     # set capabilities to binary
-    src_files = os.listdir(AGENT_BINARY_PATH)
+    src_files = os.listdir(src)
     for file_name in src_files:
-        full_file_name = os.path.join(src, file_name) # assuming only file in directory
+        full_file_name = os.path.join(AGENT_BINARY_PATH, file_name) # assuming only file in directory
         break
     NPM_ACTION.binary_setcap(full_file_name)
 

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSAgentNPMConfig.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSAgentNPMConfig.py
@@ -35,7 +35,7 @@ class INPMAgent:
 
 class NPMAgentUtil(IOMSAgent):
     def binary_setcap(self, binaryPath):
-        if os.system('sudo /opt/microsoft/omsconfig/Scripts/NPMAgentBinaryCap.sh ' + binaryPath) == 0:
+        if os.path.exists('/opt/microsoft/omsconfig/Scripts/NPMAgentBinaryCap.sh') and os.system('sudo /opt/microsoft/omsconfig/Scripts/NPMAgentBinaryCap.sh ' + binaryPath) == 0:
             return True
         else:
             LG().Log('ERROR', 'Error setting capabilities to npmd agent binary.')
@@ -257,7 +257,7 @@ def SetConfigUpdate(Contents):
         retval = -1
     else:
         retval = WriteFile(destFileFullPath, Contents)
-        if retval == 0:
+        if retval == 0 and os.path.exists(AGENT_RESOURCE_VERSION_PATH): #notify server only if plugin is present
             LG().Log('INFO', 'Updated the file, going to notify server')
             retval = NotifyServer(Commands.Config)
     return retval
@@ -283,13 +283,13 @@ def UpdateAgentBinary(newVersion):
         retval &= CopyAllFiles(src, AGENT_BINARY_PATH)
 
     # set capabilities to binary
-    src_files = os.listdir(AGENT_BINARY_PATH)
+    src_files = os.listdir(src)
     for file_name in src_files:
-        full_file_name = os.path.join(src, file_name) # assuming only file in directory
+        full_file_name = os.path.join(AGENT_BINARY_PATH, file_name) # assuming only file in directory
         break
     NPM_ACTION.binary_setcap(full_file_name)
 
-    #Notify ruby plugin
+    # Notify ruby plugin
     #retval &= NotifyServer(Commands.RestartNPM)
 
     #Update version number

--- a/Providers/Scripts/3.x/Scripts/nxOMSAgentNPMConfig.py
+++ b/Providers/Scripts/3.x/Scripts/nxOMSAgentNPMConfig.py
@@ -36,7 +36,7 @@ class INPMAgent:
 
 class NPMAgentUtil(IOMSAgent):
     def binary_setcap(self, binaryPath):
-        if os.system('sudo /opt/microsoft/omsconfig/Scripts/NPMAgentBinaryCap.sh ' + binaryPath) == 0:
+        if os.path.exists('/opt/microsoft/omsconfig/Scripts/NPMAgentBinaryCap.sh') and os.system('sudo /opt/microsoft/omsconfig/Scripts/NPMAgentBinaryCap.sh ' + binaryPath) == 0:
             return True
         else:
             LG().Log('ERROR', 'Error setting capabilities to npmd agent binary.')
@@ -258,7 +258,7 @@ def SetConfigUpdate(Contents):
         retval = -1
     else:
         retval = WriteFile(destFileFullPath, Contents)
-        if retval == 0:
+        if retval == 0 and os.path.exists(AGENT_RESOURCE_VERSION_PATH): #notify server only if plugin is present
             LG().Log('INFO', 'Updated the file, going to notify server')
             retval = NotifyServer(Commands.Config)
     return retval
@@ -284,9 +284,9 @@ def UpdateAgentBinary(newVersion):
         retval &= CopyAllFiles(src, AGENT_BINARY_PATH)
 
     # set capabilities to binary
-    src_files = os.listdir(AGENT_BINARY_PATH)
+    src_files = os.listdir(src)
     for file_name in src_files:
-        full_file_name = os.path.join(src, file_name) # assuming only file in directory
+        full_file_name = os.path.join(AGENT_BINARY_PATH, file_name) # assuming only file in directory
         break
     NPM_ACTION.binary_setcap(full_file_name)
 

--- a/Providers/Scripts/NPMAgentBinaryCap.sh
+++ b/Providers/Scripts/NPMAgentBinaryCap.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+chmod 755 $1
 setcap cap_net_raw=ep $1
 
 


### PR DESCRIPTION
1. checks to see of script exists
2. not sending a notifyserver if plugin is not present
3. setting setcap on right file