### PR TITLE
Fix bug: OMS agent logs are filling the hard disk.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -394,7 +394,7 @@ nxOMSGenerateInventoryMof:
 
 nxOMSPlugin:
 	rm -rf output/staging; \
-	VERSION="2.13"; \
+	VERSION="2.14"; \
 	PROVIDERS="nxOMSPlugin"; \
 	STAGINGDIR="output/staging/$@/DSCResources"; \
 	cat Providers/Modules/$@.psd1 | sed "s@<MODULE_VERSION>@$${VERSION}@" > intermediate/Modules/$@.psd1; \

--- a/Providers/Modules/Plugins/SecurityBaseline/conf/security_baseline.conf
+++ b/Providers/Modules/Plugins/SecurityBaseline/conf/security_baseline.conf
@@ -10,7 +10,7 @@
 <source> 
     type exec
     tag oms.security_baseline
-    command /opt/microsoft/omsagent/plugin/omsbaseline -d /etc/opt/microsoft/omsagent/conf/omsagent.d/ 
+    command sleep 60 && /opt/microsoft/omsagent/plugin/omsbaseline -d /etc/opt/microsoft/omsagent/conf/omsagent.d/ 
     format json
     run_interval 24h
 </source>

--- a/Providers/nxOMSPlugin/MSFT_nxOMSPluginResource.schema.mof
+++ b/Providers/nxOMSPlugin/MSFT_nxOMSPluginResource.schema.mof
@@ -1,11 +1,11 @@
-[ClassVersion("2.13.0")]
+[ClassVersion("2.14.0")]
 class MSFT_nxOMSPlugin
 {
     [key] string PluginName;
     [write,ValueMap{"present", "absent"},Values{"Present", "Absent"}] string Ensure; 
 };
 
-[ClassVersion("2.13.0")] 
+[ClassVersion("2.14.0")] 
 class MSFT_nxOMSPluginResource : OMI_BaseResource
 {
     [key] string Name;

--- a/Providers/nxOMSPlugin/schema.c
+++ b/Providers/nxOMSPlugin/schema.c
@@ -921,7 +921,7 @@ static MI_PropertyDecl MI_CONST* MI_CONST MSFT_nxOMSPlugin_props[] =
     &MSFT_nxOMSPlugin_Ensure_prop,
 };
 
-static MI_CONST MI_Char* MSFT_nxOMSPlugin_ClassVersion_qual_value = MI_T("2.13.0");
+static MI_CONST MI_Char* MSFT_nxOMSPlugin_ClassVersion_qual_value = MI_T("2.14.0");
 
 static MI_CONST MI_Qualifier MSFT_nxOMSPlugin_ClassVersion_qual =
 {


### PR DESCRIPTION
Add Sleep to mitigate the error and log filling in case of old OMS Agent.
Increase nxOMSPlugin version to 2.14

@Microsoft/omsagent-devs 
@lagalbra 
