### PR TITLE
Updated RemoveModule.py to properly handle nxOMSAutomationWorker removal

### DIFF
--- a/LCM/scripts/RemoveModule.py
+++ b/LCM/scripts/RemoveModule.py
@@ -50,6 +50,51 @@ if not os.path.isdir(modulePath):
 
 print("Removing module " + moduleName)
 
+# special section for nxOMSAutomationWorker module
+# the Linux Hybrid worker needs to be killed before the module is removed
+# also a good idea to remove the state.conf file
+# manually invoking RemoveModule.py will preserve worker.conf file in case the user wants to keep their settings
+# an uninstall or purge operation of the OMS agent installer will get rid of worker.conf file
+if moduleName == "nxOMSAutomationWorker":
+    registration_file_path = "/opt/microsoft/omsconfig/modules/nxOMSAutomationWorker/DSCResources/MSFT_nxOMSAutomationWorkerResource/automationworker/scripts/register_oms.py"
+    state_conf_location = "/var/opt/microsoft/omsagent/state/automationworker/state.conf"
+    config_state_section = "state"
+    config_pid_key = "pid"
+    workspace_id_key = "workspace_id"
+    automation_user = "nxautomation"
+    import signal
+    try:
+        import ConfigParser
+    except ImportError:
+        # ConfigParser is named configparser in python 3x
+        import configparser as ConfigParser
+
+    # invoke deregister when it becomes available
+
+    if os.path.isfile(state_conf_location):
+        state_conf = ConfigParser.ConfigParser()
+        try:
+            # try to read the PID of the worker and make a best effort attempt to kill it
+            # don't fail uninstall if it cannot be killed
+            state_conf.read(state_conf_location)
+            worker_process_id = state_conf.get(config_state_section, config_pid_key)
+            workspace_id = state_conf.get(config_state_section, workspace_id_key)
+            os.kill(int(worker_process_id), signal.SIGTERM)
+            # Typicallly the above kill should be sufficient becasue we should never reach as state where there are more
+            # than 1 workers. Since we introduced a new user to exclusively for worker, we can safely kill all processes
+            # that user which were started with the workspace id for additional safety
+            subprocess.call(["sudo", "pkill", "-u", automation_user, "--full", workspace_id])
+        except ConfigParser.NoSectionError:
+            pass
+        except ConfigParser.NoOptionError:
+            pass
+        except OSError:
+            pass
+        finally:
+            try:
+                os.remove(state_conf_location)
+            except:
+                pass
 
 resourcelist = os.listdir(modulePath + "/DSCResources")
 for resource in resourcelist:


### PR DESCRIPTION
RemoveModule.py script now kills the Linux Hybrid Worker and clears its
state file before removing the resource

@Microsoft/omsagent-devs 