### PR TITLE
Fix Makefile for 'make local'.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -503,8 +503,11 @@ endif
 
 
 # To build DSC without making kits (i.e. the old style), run 'make local'
-local: lcm providers
-
+local: 
+	rm -rf release/*.rpm release/*.deb
+	mkdir -p intermediate/Scripts
+	mkdir -p intermediate/Modules
+	$(MAKE) lcm providers
 lcm:
 	$(MAKE) -C omi-1.0.8
 	$(MAKE) -C LCM


### PR DESCRIPTION
@Microsoft/omi-devs 
@dantraMSFT 

This adds the same directory creation logic used in all: to the local: target.  Without this 'make reg' after 'make local' fails.
```
/bin/bash: line 15: intermediate/Scripts/GetDscConfiguration.py: No such file or directory
chmod: cannot access ‘intermediate/Scripts/GetDscConfiguration.py’: No such file or directory
/bin/bash: line 15: intermediate/Scripts/GetDscLocalConfigurationManager.py: No such file or directory
chmod: cannot access ‘intermediate/Scripts/GetDscLocalConfigurationManager.py’: No such file or directory
```