### PR TITLE
Fix SSL verification and bump nxOMSPlugin version to 2.17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -394,7 +394,7 @@ nxOMSGenerateInventoryMof:
 
 nxOMSPlugin:
 	rm -rf output/staging; \
-	VERSION="2.16"; \
+	VERSION="2.17"; \
 	PROVIDERS="nxOMSPlugin"; \
 	STAGINGDIR="output/staging/$@/DSCResources"; \
 	cat Providers/Modules/$@.psd1 | sed "s@<MODULE_VERSION>@$${VERSION}@" > intermediate/Modules/$@.psd1; \

--- a/Providers/Modules/Plugins/Common/plugin/oms_common.rb
+++ b/Providers/Modules/Plugins/Common/plugin/oms_common.rb
@@ -653,7 +653,6 @@ module OMS
                                 proxy[:addr], proxy[:port], proxy[:user], proxy[:pass])
         end
         http.use_ssl = true
-        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
         http.open_timeout = 30
         return http
       end # create_secure_http

--- a/Providers/Modules/Plugins/Zabbix/plugin/zabbix_client.rb
+++ b/Providers/Modules/Plugins/Zabbix/plugin/zabbix_client.rb
@@ -61,13 +61,11 @@ class ZabbixApi
 
         if uri.scheme == 'https'
           http.use_ssl = true
-          http.verify_mode = OpenSSL::SSL::VERIFY_NONE
         end
       else
         http = Net::HTTP.new(uri.host, uri.port)
         if uri.scheme == 'https'
           http.use_ssl = true
-          http.verify_mode = OpenSSL::SSL::VERIFY_NONE
         end
       end
       http.read_timeout = timeout


### PR DESCRIPTION
@Microsoft/omsagent-devs 

Will change in omsagent repo after testing the DSC resource change in INT. Not possible to test in only omsagent because the DSC resource overwrites these files.