### PR TITLE
Bug fix: Do not open zero size file to calculate checksum

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -439,7 +439,7 @@ nxOMSPlugin:
 
 nxFileInventory:
 	rm -rf output/staging; \
-	VERSION="1.0"; \
+	VERSION="1.1; \
 	PROVIDERS="nxFileInventory"; \
 	STAGINGDIR="output/staging/$@/DSCResources"; \
 	cat Providers/Modules/$@.psd1 | sed "s@<MODULE_VERSION>@$${VERSION}@" > intermediate/Modules/$@.psd1; \

--- a/Providers/Scripts/2.4x-2.5x/Scripts/Tests/test_nxProviders.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/Tests/test_nxProviders.py
@@ -5239,6 +5239,6 @@ if __name__ == '__main__':
     s24=unittest2.TestLoader().loadTestsFromTestCase(nxOMSAgentNPMConfigTestCases)
     s25=unittest2.TestLoader().loadTestsFromTestCase(nxOMSAutomationWorkerTestCases)
     s26=unittest2.TestLoader().loadTestsFromTestCase(nxOMSSudoCustomLogTestCases)
-    alltests = unittest2.TestSuite([s1,s2,s3,s4,s5,s6,s7,s8,s9,s10,s11,s12,s13,s14,s15,s16,s17,s18,s19,s20,s23,s24,s25,s26])
+    alltests = unittest2.TestSuite([s1,s2,s3,s4,s5,s6,s7,s8,s9,s10,s11,s12,s13,s14,s15,s16,s17,s18,s19,s20,s22,s23,s24,s25,s26])
     unittest2.TextTestRunner(stream=sys.stdout,verbosity=3).run(alltests)
     

--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxFileInventory.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxFileInventory.py
@@ -242,6 +242,18 @@ def GetFileInfo(fname, Links, MaxContentsReturnable, Checksum):
     d['ModifiedDate'] = int(stat_info.st_mtime)
     d['CreatedDate'] = int(stat_info.st_ctime)
     d['FileSize'] = stat_info.st_size
+    # if file size is 0 
+    # dont attempt to read the file
+    if stat_info.st_size == 0:
+       d['Contents'] = ''
+       if Checksum == 'md5' or Checksum == 'sha-256':
+        d['Checksum'] = 0
+       elif Checksum == "ctime":
+        d['Checksum']= str(int(stat_info.st_ctime))
+       else : # Checksum == "mtime":
+        d['Checksum']= str(int(stat_info.st_mtime))
+       return d
+
     if Checksum == 'md5' or Checksum == 'sha-256':
         d['Checksum'] = GetChecksum(fname,Checksum)
     elif Checksum == "ctime":

--- a/Providers/Scripts/2.6x-2.7x/Scripts/Tests/test_nxProviders.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/Tests/test_nxProviders.py
@@ -5232,5 +5232,5 @@ if __name__ == '__main__':
     s24=unittest2.TestLoader().loadTestsFromTestCase(nxOMSAgentNPMConfigTestCases)
     s25=unittest2.TestLoader().loadTestsFromTestCase(nxOMSAutomationWorkerTestCases)
     s26=unittest2.TestLoader().loadTestsFromTestCase(nxOMSSudoCustomLogTestCases)
-    alltests = unittest2.TestSuite([s1,s2,s3,s4,s5,s6,s7,s8,s9,s10,s11,s12,s13,s14,s15,s16,s17,s18,s19,s20,s23,s24,s25,s26])
+    alltests = unittest2.TestSuite([s1,s2,s3,s4,s5,s6,s7,s8,s9,s10,s11,s12,s13,s14,s15,s16,s17,s18,s19,s20,s22,s23,s24,s25,s26])
     unittest2.TextTestRunner(stream=sys.stdout,verbosity=3).run(alltests)

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxFileInventory.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxFileInventory.py
@@ -245,6 +245,18 @@ def GetFileInfo(fname, Links, MaxContentsReturnable, Checksum):
     d['ModifiedDate'] = int(stat_info.st_mtime)
     d['CreatedDate'] = int(stat_info.st_ctime)
     d['FileSize'] = stat_info.st_size
+    # if file size is 0 
+    # dont attempt to read the file
+    if stat_info.st_size == 0:
+       d['Contents'] = ''
+       if Checksum == 'md5' or Checksum == 'sha-256':
+        d['Checksum'] = 0
+       elif Checksum == "ctime":
+        d['Checksum']= str(int(stat_info.st_ctime))
+       else : # Checksum == "mtime":
+        d['Checksum']= str(int(stat_info.st_mtime))
+       return d
+
     if Checksum == 'md5' or Checksum == 'sha-256':
         d['Checksum'] = GetChecksum(fname,Checksum)
     elif Checksum == "ctime":

--- a/Providers/Scripts/3.x/Scripts/Tests/test_nxProviders.py
+++ b/Providers/Scripts/3.x/Scripts/Tests/test_nxProviders.py
@@ -5220,5 +5220,5 @@ if __name__ == '__main__':
     s24=unittest2.TestLoader().loadTestsFromTestCase(nxOMSAgentNPMConfigTestCases)
     s25 = unittest2.TestLoader().loadTestsFromTestCase(nxOMSAutomationWorkerTestCases)
     s26=unittest2.TestLoader().loadTestsFromTestCase(nxOMSSudoCustomLogTestCases)
-    alltests = unittest2.TestSuite([s1,s2,s3,s4,s5,s6,s7,s8,s9,s10,s11,s12,s13,s14,s15,s16,s17,s18,s19,s20,s23,s24,s25,s26])
+    alltests = unittest2.TestSuite([s1,s2,s3,s4,s5,s6,s7,s8,s9,s10,s11,s12,s13,s14,s15,s16,s17,s18,s19,s20,s22,s23,s24,s25,s26])
     unittest2.TextTestRunner(stream=sys.stdout,verbosity=1).run(alltests)

--- a/Providers/Scripts/3.x/Scripts/nxFileInventory.py
+++ b/Providers/Scripts/3.x/Scripts/nxFileInventory.py
@@ -245,8 +245,23 @@ def GetFileInfo(fname, Links, MaxContentsReturnable, Checksum):
     d['ModifiedDate'] = int(stat_info.st_mtime)
     d['CreatedDate'] = int(stat_info.st_ctime)
     d['FileSize'] = stat_info.st_size
+    # if file size is 0 
+    # dont attempt to read the file
+    if stat_info.st_size == 0:
+       d['Contents'] = ''
+       if Checksum == 'md5' or Checksum == 'sha-256':
+        d['Checksum'] = 0 
+       elif Checksum == "ctime":
+        d['Checksum']= str(int(stat_info.st_ctime))
+       else : # Checksum == "mtime":
+        d['Checksum']= str(int(stat_info.st_mtime))
+       return d
+
     if Checksum == 'md5' or Checksum == 'sha-256':
+       try:
         d['Checksum'] = GetChecksum(fname,Checksum)
+       except:
+        d['Checksum'] = 0 
     elif Checksum == "ctime":
         d['Checksum']= str(int(stat_info.st_ctime))
     else : # Checksum == "mtime":

--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -64,7 +64,7 @@ SHLIB_EXT: 'so'
 /opt/microsoft/omsconfig/module_packages/nxOMSGenerateInventoryMof_1.1.zip; release/nxOMSGenerateInventoryMof_1.1.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/${{SHORT_NAME}}/keys/dscgpgkey.asc; LCM/keys/dscgpgkey.asc; 644; ${{RUN_AS_USER}}; root
 /opt/microsoft/${{SHORT_NAME}}/keys/msgpgkey.asc; LCM/keys/msgpgkey.asc; 644; ${{RUN_AS_USER}}; root
-/opt/microsoft/omsconfig/module_packages/nxFileInventory_1.0.zip; release/nxFileInventory_1.0.zip; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/omsconfig/module_packages/nxFileInventory_1.1.zip; release/nxFileInventory_1.1.zip; 755; ${{RUN_AS_USER}}; root
 
 #else
 
@@ -268,7 +268,7 @@ su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microso
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSCustomLog_1.0.zip 0"
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSSudoCustomLog_1.0.zip 0"
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSGenerateInventoryMof_1.1.zip 0"
-su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxFileInventory_1.0.zip 0"
+su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxFileInventory_1.1.zip 0"
 
 #else
 /opt/microsoft/dsc/Scripts/InstallModule.py /opt/microsoft/dsc/module_packages/nx_1.0.zip 0


### PR DESCRIPTION
Bug fix to prevent opening zero size files to calculate checksum in file inventory resource
this fixes the issue in reading some zero size kernel files.
Update nxFileInventory version to 1.1.

@Microsoft/omsagent-devs 
@D1v38om83r 