### PR TITLE
Exclude omsadmin.conf from file inventory resource processing

### DIFF
--- a/Providers/Scripts/2.4x-2.5x/Scripts/Tests/test_nxProviders.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/Tests/test_nxProviders.py
@@ -3923,6 +3923,8 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         os.makedirs(cls.basepath+'joedir0/joedir1/joedir2/')
         open(cls.basepath+'basedirfile1.txt','w+').write(\
             'Contents of basedirfile1.txt\n')
+        open(cls.basepath+'omsadmin.conf','w+').write(\
+            'Contents of omsadmin.conf\n')
         open(cls.basepath+'basedirfile2.txt','w+').write(\
             'Contents of basedirfile2.txt\n')
         open(cls.basepath+'basedirfile3.bin','wb+').write(\
@@ -4069,6 +4071,22 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallSingleFile')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
+        for d in r[1]['__Inventory'].value:
+            print d['DestinationPath'], d['Contents']
+
+    def testFileInventoryInventory_MarshallSingleFile_omsadminconf(self):
+        print('Using path:' + self.basepath + 'omsadmin.conf')
+        d = {'Links': u'ignore', 'MaxOutputSize': None, \
+             'Checksum': u'md5', 'Recurse': False, \
+             'MaxContentsReturnable': None, \
+             'DestinationPath': self.basepath + 'omsadmin.conf', 'UseSudo': True, 'Type': u'file'}
+        r = nxFileInventory.Inventory_Marshall(**d)
+        self.assertTrue(r[0] == 0,'Inventory_Marshall('+repr(d)+')[0] should return == 0')
+        if self.create_files:
+            self.SerializeInventoryObject('testFileInventoryInventory_MarshallSingleFile',r)
+        l = self.MakeList(r)
+        g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallSingleFile')
+        self.assertFalse(g == l, repr(g) + '\n should be == to \n' + repr(l))
         for d in r[1]['__Inventory'].value:
             print d['DestinationPath'], d['Contents']
 

--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxFileInventory.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxFileInventory.py
@@ -219,6 +219,10 @@ def GetFileInfo(fname, Links, MaxContentsReturnable, Checksum):
     If file is link and 'Links' == 'ignore' {} is returned.
     """
     d = {}
+
+    if fname.endswith("omsadmin.conf"):
+        return d
+
     if os.path.islink(fname):
         d['Type'] = 'link'
     else :

--- a/Providers/Scripts/2.6x-2.7x/Scripts/Tests/test_nxProviders.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/Tests/test_nxProviders.py
@@ -3919,6 +3919,8 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         os.makedirs(cls.basepath+'joedir0/joedir1/joedir2/')
         open(cls.basepath+'basedirfile1.txt','w+').write(\
             'Contents of basedirfile1.txt\n')
+        open(cls.basepath+'omsadmin.conf','w+').write(\
+            'Contents of omsadmin.conf\n')
         open(cls.basepath+'basedirfile2.txt','w+').write(\
             'Contents of basedirfile2.txt\n')
         open(cls.basepath+'basedirfile3.bin','wb+').write(\
@@ -4062,6 +4064,22 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallSingleFile')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
+        for d in r[1]['__Inventory'].value:
+            print d['DestinationPath'], d['Contents']
+
+    def testFileInventoryInventory_MarshallSingleFile_omsadminconf(self):
+        print('Using path:' + self.basepath + 'omsadmin.conf') 
+        d = {'Links': u'ignore', 'MaxOutputSize': None, \
+             'Checksum': u'md5', 'Recurse': False, \
+             'MaxContentsReturnable': None, \
+             'DestinationPath': self.basepath + 'omsadmin.conf', 'UseSudo': True, 'Type': u'file'}
+        r = nxFileInventory.Inventory_Marshall(**d)
+        self.assertTrue(r[0] == 0,'Inventory_Marshall('+repr(d)+')[0] should return == 0')
+        if self.create_files:
+            self.SerializeInventoryObject('testFileInventoryInventory_MarshallSingleFile',r)
+        l = self.MakeList(r)
+        g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallSingleFile')
+        self.assertTrue(l == [], repr(g) + '\n should be == to \n' + repr(l))
         for d in r[1]['__Inventory'].value:
             print d['DestinationPath'], d['Contents']
 

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxFileInventory.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxFileInventory.py
@@ -222,6 +222,9 @@ def GetFileInfo(fname, Links, MaxContentsReturnable, Checksum):
     If file is link and 'Links' == 'ignore' {} is returned.
     """
     d = {}
+    if fname.endswith("omsadmin.conf"):
+       return d
+
     if os.path.islink(fname):
         d['Type'] = 'link'
     else :

--- a/Providers/Scripts/3.x/Scripts/Tests/test_nxProviders.py
+++ b/Providers/Scripts/3.x/Scripts/Tests/test_nxProviders.py
@@ -3915,6 +3915,8 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         os.makedirs(cls.basepath+'joedir0/joedir1/joedir2/')
         open(cls.basepath+'basedirfile1.txt','w+').write(\
             'Contents of basedirfile1.txt\n')
+        open(cls.basepath+'omsadmin.conf','w+').write(\
+            'Contents of omsadmin.conf\n')
         open(cls.basepath+'basedirfile2.txt','w+').write(\
             'Contents of basedirfile2.txt\n')
         open(cls.basepath+'basedirfile3.bin','wb+').write(\
@@ -4045,7 +4047,7 @@ class nxFileInventoryTestCases(unittest2.TestCase):
             print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallSingleFile(self):
-        print('Using path:' + self.basepath + 'basedirfile1.txt') 
+        print('Using path:' + self.basepath + 'basedirfile1.txt')
         d = {'Links': u'ignore', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -4060,6 +4062,30 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         for d in r[1]['__Inventory'].value:
             print(d['DestinationPath'], d['Contents'])
 
+    def testFileInventoryInventory_MarshallSingleFile_omsadminconf(self):
+        print('Using path:' + self.basepath + 'omsadmin.conf')
+        d = {'Links': u'ignore', 'MaxOutputSize': None, \
+             'Checksum': u'md5', 'Recurse': False, \
+             'MaxContentsReturnable': None, \
+             'DestinationPath': self.basepath + 'omsadmin.conf', 'UseSudo': True, 'Type': u'file'}
+        r = nxFileInventory.Inventory_Marshall(**d)
+        self.assertTrue(r[0] == 0,'Inventory_Marshall('+repr(d)+')[0] should return == 0')
+        if self.create_files:
+            self.SerializeInventoryObject('testFileInventoryInventory_MarshallSingleFile',r)
+        l = self.MakeList(r)
+        g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallSingleFile')
+        self.assertTrue(l == [], repr(g) + '\n should be == to \n' + repr(l))
+        for d in r[1]['__Inventory'].value:
+            print(d['DestinationPath'], d['Contents'])
+
+    def testFileInventoryInventory_MarshallTypeWild(self):
+        print('Using path:' + self.basepath) 
+        d = {'Links': u'ignore', 'MaxOutputSize': None, \
+             'Checksum': u'md5', 'Recurse': False, \
+             'MaxContentsReturnable': None, \
+             'DestinationPath': self.basepath, 'UseSudo': True, 'Type': u'*'}
+        r = nxFileInventory.Inventory_Marshall(**d)
+        self.assertTrue(r[0] == 0,'Inventory_Marshall('+repr(d)+')[0] should return == 0') 
     def testFileInventoryInventory_MarshallTypeWild(self):
         print('Using path:' + self.basepath) 
         d = {'Links': u'ignore', 'MaxOutputSize': None, \

--- a/Providers/Scripts/3.x/Scripts/nxFileInventory.py
+++ b/Providers/Scripts/3.x/Scripts/nxFileInventory.py
@@ -222,6 +222,10 @@ def GetFileInfo(fname, Links, MaxContentsReturnable, Checksum):
     If file is link and 'Links' == 'ignore' {} is returned.
     """
     d = {}
+
+    if fname.endswith("omsadmin.conf"):
+       return d
+
     if os.path.islink(fname):
         d['Type'] = 'link'
     else :


### PR DESCRIPTION
This change excludes omsadmin.conf file from being considered in File Inventory.
This is a fix, to prevent changes in omsadmin.conf from showing up in change tracking. This file is being updated every 5 mins and produces noise in the change tracking results.

since we want this change to apply to all agents, we are fixing it here in the resource.
@Microsoft/omsagent-devs 