### PR TITLE
Bumping nxOMSPlugin version to 2.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -417,7 +417,7 @@ nxOMSGenerateInventoryMof:
 
 nxOMSPlugin:
 	rm -rf output/staging; \
-	VERSION="2.17"; \
+	VERSION="2.18"; \
 	PROVIDERS="nxOMSPlugin"; \
 	STAGINGDIR="output/staging/$@/DSCResources"; \
 	cat Providers/Modules/$@.psd1 | sed "s@<MODULE_VERSION>@$${VERSION}@" > intermediate/Modules/$@.psd1; \


### PR DESCRIPTION
@NarineM @Microsoft/omsagent-devs 

PR https://github.com/Microsoft/PowerShell-DSC-for-Linux/pull/225 was merged, but I forgot to make the change to bump the nxOMSPlugin version in Makefile so the new module could be tested.