### PR TITLE
Fix nxOMSGenerateInventory get_marshall failure &Update version to 1.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -396,7 +396,7 @@ nxOMSSudoCustomLog:
 
 nxOMSGenerateInventoryMof:
 	rm -rf output/staging; \
-	VERSION="1.1"; \
+	VERSION="1.2"; \
 	PROVIDERS="nxOMSGenerateInventoryMof"; \
 	STAGINGDIR="output/staging/$@/DSCResources"; \
 	cat Providers/Modules/$@.psd1 | sed "s@<MODULE_VERSION>@$${VERSION}@" > intermediate/Modules/$@.psd1; \

--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSGenerateInventoryMof.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSGenerateInventoryMof.py
@@ -73,10 +73,7 @@ def Get_Marshall(FeatureName, Enable = False, Instances = None, RunIntervalInSec
     Format = protocol.MI_String(Format)
     FilterType = protocol.MI_String(FilterType)
 
-    if Configuration is None:
-        Configuration = []
-    if Configuration is not None and len(Configuration):
-        Configuration = protocol.MI_StringA(Configuration)
+    Configuration = protocol.MI_StringA(Configuration)
 
     retd = {}
     ld = locals()

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSGenerateInventoryMof.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSGenerateInventoryMof.py
@@ -68,10 +68,7 @@ def Get_Marshall(FeatureName, Enable = False, Instances = None, RunIntervalInSec
     Format = protocol.MI_String(Format)
     FilterType = protocol.MI_String(FilterType)
 
-    if Configuration is None:
-        Configuration = []
-    if Configuration is not None and len(Configuration):
-        Configuration = protocol.MI_StringA(Configuration)
+    Configuration = protocol.MI_StringA(Configuration)
 
     retd = {}
     ld = locals()

--- a/Providers/Scripts/3.x/Scripts/nxOMSGenerateInventoryMof.py
+++ b/Providers/Scripts/3.x/Scripts/nxOMSGenerateInventoryMof.py
@@ -68,10 +68,7 @@ def Get_Marshall(FeatureName, Enable = False, Instances = None, RunIntervalInSec
     Format = protocol.MI_String(Format)
     FilterType = protocol.MI_String(FilterType)
 
-    if Configuration is None:
-        Configuration = []
-    if Configuration is not None and len(Configuration):
-        Configuration = protocol.MI_StringA(Configuration)
+    Configuration = protocol.MI_StringA(Configuration)
 
     retd = {}
     ld = locals()

--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -61,7 +61,7 @@ SHLIB_EXT: 'so'
 /opt/microsoft/omsconfig/module_packages/nxOMSKeyMgmt_1.0.zip; release/nxOMSKeyMgmt_1.0.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSCustomLog_1.0.zip; release/nxOMSCustomLog_1.0.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSSudoCustomLog_1.0.zip; release/nxOMSSudoCustomLog_1.0.zip; 755; ${{RUN_AS_USER}}; root
-/opt/microsoft/omsconfig/module_packages/nxOMSGenerateInventoryMof_1.1.zip; release/nxOMSGenerateInventoryMof_1.1.zip; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/omsconfig/module_packages/nxOMSGenerateInventoryMof_1.2.zip; release/nxOMSGenerateInventoryMof_1.2.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/${{SHORT_NAME}}/keys/dscgpgkey.asc; LCM/keys/dscgpgkey.asc; 644; ${{RUN_AS_USER}}; root
 /opt/microsoft/${{SHORT_NAME}}/keys/msgpgkey.asc; LCM/keys/msgpgkey.asc; 644; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxFileInventory_1.1.zip; release/nxFileInventory_1.1.zip; 755; ${{RUN_AS_USER}}; root
@@ -267,7 +267,7 @@ su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microso
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSKeyMgmt_1.0.zip 0"
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSCustomLog_1.0.zip 0"
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSSudoCustomLog_1.0.zip 0"
-su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSGenerateInventoryMof_1.1.zip 0"
+su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSGenerateInventoryMof_1.2.zip 0"
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxFileInventory_1.1.zip 0"
 
 #else


### PR DESCRIPTION
This fixes the bug in get_marshall in nxOMSGenerateInventory  and update version to 1.2
@Microsoft/omsagent-devs 