### PR TITLE
Add tests for python 2.4x and 3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: required # A sudo enabled, full VM is used for building instead of a docke
 
 branches:
   only:
-  - master
+    - master
 
 addons:
   apt:
@@ -20,6 +20,9 @@ addons:
       - libmysqlclient-dev
       - curl
       - libcurl4-gnutls-dev
+      - zlib1g
+      - zlib1g-dev
+      - openssl
 
 script:
   - # Fetch the Build-PowerShell-DSC-for-Linux repository for dependencies to build from
@@ -40,5 +43,31 @@ script:
   - sudo make install
   - cd ../
   - sudo make reg
+  - # Python tests for 2.6x-2.7x
   - cd /opt/omi-*/share/dsc/Scripts/2.6x-2.7x/Scripts/Tests/
-  - sudo python ./test_nxProviders.py
+  - sudo python ./test_nxProviders.py 2> /dev/null
+  - # Python tests for 3.x
+  - cd /opt/omi-*/share/dsc/Scripts/3.x/Scripts/Tests/
+  - sudo python3 ./test_nxProviders.py 2> /dev/null
+  - # Python tests for 2.4x-2.5x
+  - cd /tmp
+  - wget -q https://www.python.org/ftp/python/2.4.6/Python-2.4.6.tgz
+  - tar -xzf Python-2.4.6.tgz
+  - cd Python-2.4.6
+  - ./configure  &> /dev/null
+  - sed -i "s/#zlib/zlib/" Modules/Setup
+  - sed -i "s/#_socket/_socket/" Modules/Setup
+  - sed -i "s/#_ssl _ssl/_ssl _ssl/" Modules/Setup
+  - sed -i "s/#\t-DUSE_SSL/\t-DUSE_SSL/" Modules/Setup
+  - sed -i "s/#\t-L\$(SSL)/\t-L\$(SSL)/" Modules/Setup
+  - sed -i "s/#md5/md5/" Modules/Setup
+  - sed -i "s/#sha/sha/" Modules/Setup
+  - make &> /dev/null
+  - sudo make altinstall &> /dev/null
+  - cd ..
+  - wget -q https://sourceforge.net/projects/ctypes/files/ctypes/1.0.2/ctypes-1.0.2.tar.gz
+  - tar -xzf ctypes-1.0.2.tar.gz
+  - cd ctypes-1.0.2
+  - sudo python2.4 ./setup.py build install &> /dev/null
+  - cd /opt/omi-*/share/dsc/Scripts/2.4x-2.5x/Scripts/Tests/
+  - sudo python2.4 ./test_nxProviders.py 2> /dev/null

--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxPackage.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxPackage.py
@@ -294,16 +294,16 @@ class Params:
         self.cmds['dpkg'][
             'absent'] = 'DEBIAN_FRONTEND=noninteractive dpkg % -r '
         self.cmds['dpkg'][
-            'stat'] = "dpkg-query -W -f='${{Description}}{0}${{Maintainer}}{0}'Unknown'{0}${{Installed-Size}}{0}${{Version}}{0}${{Status}}{0}${{Architecture}}\n' ".format(self.field_delimiter)
+            'stat'] = "dpkg-query -W -f='${Description}{0}${Maintainer}{0}'Unknown'{0}${Installed-Size}{0}${Version}{0}${Status}{0}${Architecture}\n' ".replace('{0}',self.field_delimiter)
         self.cmds['dpkg'][
-            'stat_all'] = "dpkg-query -W -f='${{Package}}{0}${{Description}}{0}${{Maintainer}}{0}'Unknown'{0}${{Installed-Size}}{0}${{Version}}{0}${{Status}}{0}${{Architecture}}\n{1}' ".format(self.field_delimiter, self.record_delimiter)
+            'stat_all'] = "dpkg-query -W -f='${Package}{0}${Description}{0}${Maintainer}{0}'Unknown'{0}${Installed-Size}{0}${Version}{0}${Status}{0}${Architecture}\n{1}'".replace('{0}',self.field_delimiter).replace('{1}',self.record_delimiter)
         self.cmds['dpkg']['stat_group'] = None
         self.cmds['rpm']['present'] = 'rpm % -i '
         self.cmds['rpm']['absent'] = 'rpm % -e '
         self.cmds['rpm'][
-            'stat'] = 'rpm -q --queryformat "%{{SUMMARY}}{0}%{{PACKAGER}}{0}%{{INSTALLTIME}}{0}%{{SIZE}}{0}%{{EPOCH}}:%{{VERSION}}-%{{RELEASE}}{0}installed{0}%{{ARCH}}\n" '.format(self.field_delimiter)
+            'stat'] = 'rpm -q --queryformat "%{SUMMARY}{0}%{PACKAGER}{0}%{INSTALLTIME}{0}%{SIZE}{0}%{EPOCH}:%{VERSION}-%{RELEASE}{0}installed{0}%{ARCH}\n" '.replace('{0}',self.field_delimiter)
         self.cmds['rpm'][
-            'stat_all'] = 'rpm -qa --queryformat "%{{NAME}}{0}%{{SUMMARY}}{0}%{{PACKAGER}}{0}%{{INSTALLTIME}}{0}%{{SIZE}}{0}%{{EPOCH}}:%{{VERSION}}-%{{RELEASE}}{0}installed{0}%{{ARCH}}\n{1}" | sed "s/(none)/0/g" '.format(self.field_delimiter, self.record_delimiter)
+            'stat_all'] = 'rpm -qa --queryformat "%{NAME}{0}%{SUMMARY}{0}%{PACKAGER}{0}%{INSTALLTIME}{0}%{SIZE}{0}%{EPOCH}:%{VERSION}-%{RELEASE}{0}installed{0}%{ARCH}\n{1}" | sed "s/(none)/0/g" '.replace('{0}',self.field_delimiter).replace('{1}',self.record_delimiter)
         self.cmds['rpm']['stat_group'] = None
         self.cmds['apt'][
             'present'] = 'DEBIAN_FRONTEND=noninteractive apt-get % install ^ --allow-unauthenticated --yes '
@@ -842,6 +842,13 @@ def MakeDirs(path):
         LG().Log('ERROR',  "Exception making dir" +
                  path + " Error: " + str(error))
     return error
+
+def opened_bin_w_error(filename, mode="rb"):
+    try:
+        f = open(filename, mode)
+    except IOError, err:
+        return None, err
+    return f, None
 
 def ReadFile(path):
     """

--- a/Providers/Scripts/2.6x-2.7x/Scripts/Tests/test_nxProviders.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/Tests/test_nxProviders.py
@@ -41,7 +41,7 @@ def opened_w_error(filename, mode="r"):
 try:
     import unittest2
 except:
-    os.system('tar -zxvf ./unittest2-0.5.1.tar.gz')
+    os.system('tar -zxf ./unittest2-0.5.1.tar.gz')
     sys.path.append(os.path.realpath('./unittest2-0.5.1'))
     import unittest2
 
@@ -187,10 +187,10 @@ class nxUserTestCases(unittest2.TestCase):
         """
         Setup test resources
         """
-        if not os.system('grep jojoma /etc/passwd'):
-            os.system('userdel -r jojoma &> /dev/null')
-        if not os.system('grep jojoma /etc/group'):
-            os.system('groupdel jojoma &> /dev/null')
+        if not os.system('grep -q jojoma /etc/passwd'):
+            os.system('userdel -r jojoma 2> /dev/null')
+        if not os.system('grep -q jojoma /etc/group'):
+            os.system('groupdel jojoma 2> /dev/null')
         time.sleep(1)
         nxUser.SetShowMof(True)
         print self.id() + '\n'
@@ -199,10 +199,10 @@ class nxUserTestCases(unittest2.TestCase):
         """
         Remove test resources.
         """
-        if not os.system('grep jojoma /etc/passwd'):
-            os.system('userdel -r jojoma &> /dev/null')
-        if not os.system('grep jojoma /etc/group'):
-            os.system('groupdel jojoma &> /dev/null')
+        if not os.system('grep -q jojoma /etc/passwd'):
+            os.system('userdel -r jojoma 2> /dev/null')
+        if not os.system('grep -q jojoma /etc/group'):
+            os.system('groupdel jojoma 2> /dev/null')
         time.sleep(1)
 
     def pswd_hash(self,pswd):
@@ -224,7 +224,6 @@ class nxUserTestCases(unittest2.TestCase):
             if Description != None and len(Description) and not fnmatch.fnmatch(i['Description'].value,Description):
                 print 'Description:' + Description + ' != ' + i['Description'].value
                 return False
-            print 'Inventory Matched: ' + repr(i)
         return True
 
     def make_MI(self,retval,UserName, Ensure, FullName, Description, Password, Disabled, PasswordChangeRequired, HomeDirectory, GroupID, UserID):
@@ -425,7 +424,6 @@ class nxUserTestCases(unittest2.TestCase):
     def testUserInventoryMarshal(self):
         d=nxUser.Inventory_Marshall("", "", "", "", "", False, False, "", "" )
         self.assertTrue(d[0] == 0,'Inventory_Marshall("", "", "", "", "", False, False, "", "" ) should return == [0]')
-        print repr(d)
 
     def testInventoryMarshallUser(self):
         pswd=self.pswd_hash('jojoma')
@@ -491,10 +489,10 @@ class nxGroupTestCases(unittest2.TestCase):
         """
         Setup test resources
         """
-        if not os.system('grep jojomamas /etc/group &> /dev/null'):
-            os.system('groupdel jojomamas &> /dev/null')
-        if os.system('grep jojoma /etc/passwd'):
-            os.system('useradd -m jojoma &> /dev/null')
+        if not os.system('grep -q jojomamas /etc/group'):
+            os.system('groupdel jojomamas 2> /dev/null')
+        if os.system('grep -q jojoma /etc/passwd'):
+            os.system('useradd -m jojoma 2> /dev/null')
         time.sleep(1)
         nxGroup.SetShowMof(False)
         print self.id() + '\n'
@@ -503,8 +501,8 @@ class nxGroupTestCases(unittest2.TestCase):
         """
         Remove test resources.
         """
-        os.system('userdel -r jojoma &> /dev/null')
-        os.system('groupdel jojomamas &> /dev/null')
+        os.system('userdel -r jojoma 2> /dev/null')
+        os.system('groupdel jojomamas 2> /dev/null')
         time.sleep(1)
         nxGroup.SetShowMof(False)
         print self.id() + '\n'
@@ -523,7 +521,6 @@ class nxGroupTestCases(unittest2.TestCase):
             if GroupName != None and len(GroupName) and not fnmatch.fnmatch(i['GroupName'].value,GroupName):
                 print 'GroupName:' + GroupName + ' != ' + i['GroupName'].value
                 return False
-        print 'Inventory Matched: ' + repr(i)
         return True
 
     def make_MI(self,retval,GroupName, Ensure, Members, MembersToInclude, MembersToExclude, PreferredGroupID, GroupID):
@@ -629,7 +626,6 @@ class nxGroupTestCases(unittest2.TestCase):
 
     def testInventory_Marshall(self):
         d=nxGroup.Inventory_Marshall("*", "", "", "", "", "")
-        print repr(d)
 
     def testSetInventory_MarshallFilterGroup(self):
         self.assertTrue(nxGroup.Set_Marshall("jojomamas", "Present", "", "", "", "1101" ) ==
@@ -653,7 +649,7 @@ class nxScriptTestCases(unittest2.TestCase):
         """
         Setup test resources
         """
-        os.system('useradd -m jojoma ')
+        os.system('useradd -m jojoma  2> /dev/null')
         time.sleep(1)
         self.get_script='#!/bin/bash \ncat /tmp/testfile\n'
         self.test_script='#!/bin/bash \ngrep  "set script successfull" /tmp/testfile\n'
@@ -663,8 +659,8 @@ class nxScriptTestCases(unittest2.TestCase):
         """
         Remove test resources.
         """
-        os.system('userdel -r jojoma ')
-        os.system('rm /tmp/testfile')
+        os.system('userdel -r jojoma  2> /dev/null')
+        os.system('rm /tmp/testfile 2> /dev/null')
         time.sleep(1)
     
     def make_MI(self,retval,GetScript, SetScript, TestScript, User, Group, Result):
@@ -698,69 +694,57 @@ class nxScriptTestCases(unittest2.TestCase):
     def testGetScriptUser(self):
         nxScript.Set_Marshall(self.get_script,self.set_script,self.test_script, "jojoma", "" )
         r=nxScript.Get_Marshall(self.get_script,self.set_script,self.test_script, "jojoma", "" )
-        print 'GET='+repr(r)
         self.assertTrue(check_values(r,self.make_MI(0,self.get_script,self.set_script,self.test_script, "jojoma", "", "set script successfull\n" )) == True,'nxScript.Get_Marshall(self.get_script,self.set_script,self.test_script, "jojoma", "" )[0] should return == 0')
 
     def testTestScriptUser(self):
         nxScript.Set_Marshall(self.get_script,self.set_script,self.test_script, "jojoma", "" )
         r=nxScript.Test_Marshall(self.get_script,self.set_script,self.test_script, "jojoma", "" )
-        print 'TEST='+repr(r)
         self.assertTrue(r == [0],'nxScript.Test_Marshall(self.get_script,self.set_script,self.test_script, "jojoma", "" )[0] should return == 0')
 
     def testSetScriptUser(self):
         r=nxScript.Set_Marshall(self.get_script,self.set_script,self.test_script, "jojoma", "" )
-        print 'SET='+repr(r)
         self.assertTrue(r[0] == 0,'nxScript.Set_Marshall(self.get_script,self.set_script,self.test_script, "jojoma", "" )[0] should return == 0')
 
     def testGetScriptGroup(self):
         nxScript.Set_Marshall(self.get_script,self.set_script,self.test_script, "", "mail" )
         r=nxScript.Get_Marshall(self.get_script,self.set_script,self.test_script, "", "mail" )
-        print 'GET='+repr(r)
         self.assertTrue(check_values(r,self.make_MI(0,self.get_script,self.set_script,self.test_script, "", "mail", "set script successfull\n" )) == True,'nxScript.Get_Marshall(self.get_script,self.set_script,self.test_script, "", "mail" )[0] should return == 0')
 
     def testTestScriptGroup(self):
         nxScript.Set_Marshall(self.get_script,self.set_script,self.test_script, "", "mail" )
         r=nxScript.Test_Marshall(self.get_script,self.set_script,self.test_script, "", "mail" )
-        print 'TEST='+repr(r)
         self.assertTrue(r == [0],'nxScript.Test_Marshall(self.get_script,self.set_script,self.test_script, "", "mail" )[0] should return == 0')
 
     def testSetScriptGroup(self):
         r=nxScript.Set_Marshall(self.get_script,self.set_script,self.test_script, "", "mail" )
-        print 'SET='+repr(r)
         self.assertTrue(r[0] == 0,'nxScript.Set_Marshall(self.get_script,self.set_script,self.test_script, "", "mail" )[0] should return == 0')
 
     def testGetScriptUserError(self):
         nxScript.Set_Marshall(self.get_script,self.set_script,self.test_script, "jojoma", "" )
         r=nxScript.Get_Marshall(self.get_script,self.set_script,self.test_script, "ojoma", "" )
-        print 'GET='+repr(r)
         self.assertTrue(check_values(r,self.make_MI(0,self.get_script,self.set_script,self.test_script, "ojoma", "", "set script successfull\n") ) == False,'nxScript.Get_Marshall(self.get_script,self.set_script,self.test_script, "ojoma", "" )[-1] should return == -1')
 
     def testTestScriptUserError(self):
         nxScript.Set_Marshall(self.get_script,self.set_script,self.test_script, "jojoma", "" )
         r=nxScript.Test_Marshall(self.get_script,self.set_script,self.test_script, "ojoma", "" )
-        print 'TEST='+repr(r)
         self.assertTrue(r == [-1],'nxScript.Test_Marshall(self.get_script,self.set_script,self.test_script, "ojoma", "" )[-1] should return == -1')
 
     def testSetScriptUserError(self):
         r=nxScript.Set_Marshall(self.get_script,self.set_script,self.test_script, "ojoma", "" )
-        print 'SET='+repr(r)
         self.assertTrue(r[0] == -1,'nxScript.Set_Marshall(self.get_script,self.set_script,self.test_script, "ojoma", "" )[-1] should return == -1')
 
     def testGetScriptGroupError(self):
         nxScript.Set_Marshall(self.get_script,self.set_script,self.test_script, "", "ojoma" )
         r=nxScript.Get_Marshall(self.get_script,self.set_script,self.test_script, "", "ojoma" )
-        print 'GET='+repr(r)
         self.assertTrue(check_values(r,self.make_MI(0,self.get_script,self.set_script,self.test_script, "", "ojoma" , "set script successfull\n")) == False,'nxScript.Get_Marshall(self.get_script,self.set_script,self.test_script, "", "ojoma" )[-1] should return == -1')
 
     def testTestScriptGroupError(self):
         nxScript.Set_Marshall(self.get_script,self.set_script,self.test_script, "", "ojoma" )
         r=nxScript.Test_Marshall(self.get_script,self.set_script,self.test_script, "", "ojoma" )
-        print 'TEST='+repr(r)
         self.assertTrue(r == [-1],'nxScript.Test_Marshall(self.get_script,self.set_script,self.test_script, "", "ojoma" )[-1] should return == -1')
 
     def testSetScriptGroupError(self):
         r=nxScript.Set_Marshall(self.get_script,self.set_script,self.test_script, "", "ojoma" )
-        print 'SET='+repr(r)
         self.assertTrue(r[0] == -1,'nxScript.Set_Marshall(self.get_script,self.set_script,self.test_script, "", "ojoma" )[-1] should return == -1')
 
 
@@ -776,15 +760,15 @@ class nxPackageTestCases(unittest2.TestCase):
         self.pkg = 'nano'
         if platform.dist()[0].lower() == 'suse':
             self.pkg = 'gvim'
-        if os.system('which dpkg ') == 0 :
-            os.system('dpkg -r ' + self.pkg + ' &> /dev/null')
+        if os.system('which dpkg') == 0 :
+            os.system('dpkg -r ' + self.pkg + ' 2> /dev/null')
             if os.path.exists('/usr/bin/dummy.sh'):
-                os.system('dpkg -r dummy &> /dev/null')
+                os.system('dpkg -r dummy 2> /dev/null')
             self.package_path='./Scripts/Tests/dummy-1.0.deb'
         else :
-            os.system('rpm -e ' + self.pkg + ' &> /dev/null')
+            os.system('rpm -e ' + self.pkg + ' 2> /dev/null')
             if os.path.exists('/usr/bin/dummy.sh'):
-                os.system('rpm -e dummy &> /dev/null')
+                os.system('rpm -e dummy 2> /dev/null')
             self.package_path='./Scripts/Tests/dummy-1.0-1.x86_64.rpm'
         time.sleep(3)
         print self.id() + '\n'
@@ -794,14 +778,14 @@ class nxPackageTestCases(unittest2.TestCase):
         Remove test resources.
         """
         time.sleep(4)
-        if os.system('which dpkg ') == 0 :
-            os.system('dpkg -r ' + self.pkg + ' &> /dev/null')
+        if os.system('which dpkg') == 0 :
+            os.system('dpkg -r ' + self.pkg + ' 2> /dev/null')
             if os.path.exists('/usr/bin/dummy.sh'):
-                os.system('dpkg -r dummy &> /dev/null')
+                os.system('dpkg -r dummy 2> /dev/null')
         else :
-            os.system('rpm -e ' + self.pkg + ' &> /dev/null')
+            os.system('rpm -e ' + self.pkg + ' 2> /dev/null')
             if os.path.exists('/usr/bin/dummy.sh'):
-                os.system('rpm -e dummy &> /dev/null')
+                os.system('rpm -e dummy 2> /dev/null')
         time.sleep(3)
 
     def CheckInventory(self, Name, Inventory):
@@ -811,7 +795,6 @@ class nxPackageTestCases(unittest2.TestCase):
             if Name != None and len(Name) and not fnmatch.fnmatch(i['Name'].value,Name):
                 print 'Name:' + Name + ' != ' + i['Name'].value
                 return False
-            print 'Inventory Matched: ' + repr(i)
         return True
 
     def make_MI(self, retval, Ensure, PackageManager, Name, FilePath, PackageGroup, Arguments,
@@ -925,7 +908,7 @@ class nxPackageTestCases(unittest2.TestCase):
         self.assertTrue(nxPackage.Set_Marshall('Present','',self.pkg,'',False,'',0)==
                         [0],"nxPackage.Set_Marshall('Present','','" + self.pkg + "','',False,'',0) should return ==[0]")
         r=nxPackage.Get_Marshall('Present','',self.pkg,'',False,'',0)
-        print 'GET:'+repr(r)
+
 
         self.assertTrue(check_values(r,self.make_MI(0,'present', None,self.pkg,'',False,'',0,  None, None, None, None, None, None, None )) == True
                         ,"nxPackage.Get_Marshall('Present','','" + self.pkg + "','',False,'',0)[0] should return == 0")
@@ -933,7 +916,7 @@ class nxPackageTestCases(unittest2.TestCase):
     def testTestEnableNameDefaultProviderBadReturnCodeError(self):
         self.assertTrue(nxPackage.Set_Marshall('Present','',self.pkg,'',False,'',0)==
                         [0],"nxPackage.Set_Marshall('Present','','" + self.pkg + "','',False,'',0) should return ==[0]")
-        print 'TEST:'+repr(nxPackage.Test_Marshall('Present','',self.pkg,'',False,'',6))
+
 
         self.assertTrue(nxPackage.Test_Marshall('Present','',self.pkg,'',False,'',6)==
                         [-1],"nxPackage.Test_Marshall('Present','','" + self.pkg + "','',False,'',True,6) should return == [-1]")
@@ -942,19 +925,19 @@ class nxPackageTestCases(unittest2.TestCase):
         self.assertTrue(nxPackage.Set_Marshall('Present','',self.pkg,'',False,'',0)==
                         [0],"nxPackage.Set_Marshall('Present','','" + self.pkg + "','',False,'',0) should return ==[0]")
         r=nxPackage.Get_Marshall('Present','',self.pkg,'',False,'',6)
-        print 'GET:'+repr(r)
+
         self.assertTrue(check_values(r,self.make_MI(0,'present', None,self.pkg,'',False,'',6,  None, None, None, None, None, None, None )) == True
                         ,"nxPackage.Get_Marshall('Present','','" + self.pkg + "','',False,'',True,6)[0] should return == 0")
 
     def testTestEnableNameDefaultProvider(self):
         self.assertTrue(nxPackage.Set_Marshall('Present','',self.pkg,'',False,'',0)==
                         [0],"nxPackage.Set_Marshall('Present','','" + self.pkg + "','',False,'',0) should return ==[0]")
-        print 'TEST:'+repr(nxPackage.Test_Marshall('Present','',self.pkg,'',False,'',0))
+
 
         self.assertTrue(nxPackage.Test_Marshall('Present','',self.pkg,'',False,'',0)==
                         [0],"nxPackage.Test_Marshall('Present','','" + self.pkg + "','',False,'',0) should return == [0]")
 
-    @unittest2.skipUnless(os.system('which yum ') ==
+    @unittest2.skipUnless(os.system('which yum') ==
                           0,'groupmode is not implemented.')
     def testSetEnableGroupDefaultProvider(self):
         self.assertTrue(nxPackage.Set_Marshall('Present','','Remote Desktop Clients','',True,'',0)==
@@ -979,7 +962,7 @@ class nxPackageTestCases(unittest2.TestCase):
                         [0],"nxPackage.Set_Marshall('Absent','','" + self.pkg + "','',False,'',0) should return ==[0]")
         time.sleep(4)
         r=nxPackage.Get_Marshall('Absent','',self.pkg,'',False,'',0)
-        print 'GET:'+repr(r)
+
         self.assertTrue(check_values(r,self.make_MI(0,'absent', None,self.pkg,'',False,'',0, None, None, None, None, None, None, None )) == True
                         ,"nxPackage.Get_Marshall('Absent','','" + self.pkg + "','',False,'',0)[0] should return == 0")
 
@@ -990,12 +973,12 @@ class nxPackageTestCases(unittest2.TestCase):
         self.assertTrue(nxPackage.Set_Marshall('Absent','',self.pkg,'',False,'',0)==
                         [0],"nxPackage.Set_Marshall('Absent','','" + self.pkg + "','',False,'',0) should return ==[0]")
         time.sleep(4)
-        print 'TEST:'+repr(nxPackage.Test_Marshall('Absent','',self.pkg,'',False,'',0))
+
 
         self.assertTrue(nxPackage.Test_Marshall('Absent','',self.pkg,'',False,'',0)==
                         [0],"nxPackage.Test_Marshall('Absent','','" + self.pkg + "','',False,'',0) should return == [0]")
 
-    @unittest2.skipUnless(os.system('which yum ') ==
+    @unittest2.skipUnless(os.system('which yum') ==
                           0,'groupmode is not implemented.')
     def testSetDisableGroupDefaultProvider(self):
         self.assertTrue(nxPackage.Set_Marshall('Present','','Remote Desktop Clients','',True,'',0)==
@@ -1014,13 +997,11 @@ class nxPackageTestCases(unittest2.TestCase):
 
     def testGetEnableBadNameDefaultProvider(self):
         r=nxPackage.Get_Marshall('Present','','nanoo','',False,'',0)
-        print 'GET:'+repr(r)
+
         self.assertTrue(check_values(r,self.make_MI(0,'present', None,'nanoo','',False,'',0, None, None, None, None, None, None, None )) == True
                         ,"nxPackage.Get_Marshall('Present','','nanoo','',False,'',0)[-1] should return == 0")
 
     def testTestEnableBadNameDefaultProvider(self):
-        print 'TEST:'+repr(nxPackage.Test_Marshall('Present','','nanoo','',False,'',0))
-
         self.assertTrue(nxPackage.Test_Marshall('Present','','nanoo','',False,'',0)==
                         [-1],"nxPackage.Test_Marshall('Present','','nanoo','',False,'',0) should return == [-1]")
 
@@ -1034,13 +1015,11 @@ class nxPackageTestCases(unittest2.TestCase):
 
     def testGetDisableBadNameDefaultProvider(self):
         r=nxPackage.Get_Marshall('Absent','','nanoo','',False,'',0)
-        print 'GET:'+repr(r)
+
         self.assertTrue(check_values(r,self.make_MI(0,'absent', None,'nanoo','',False,'',0, None, None, None, None, None, None, None )) == True
                         ,"nxPackage.Get_Marshall('Absent','','nanoo','',False,'',0)[0] should return == 0")
 
     def testTestDisableBadNameDefaultProvider(self):
-        print 'TEST:'+repr(nxPackage.Test_Marshall('Absent','','nanoo','',False,'',0))
-
         self.assertTrue(nxPackage.Test_Marshall('Absent','','nanoo','',False,'',0)==
                         [0],"nxPackage.Test_Marshall('Absent','','nanoo','',False,'',0) should return == [0]")
 
@@ -1051,7 +1030,7 @@ class nxPackageTestCases(unittest2.TestCase):
     def testInventoryMarshall(self):
         r=nxPackage.Inventory_Marshall('','','*','',False,'',0)
         self.assertTrue(r[0] == 0,"Inventory_Marshall('','','*','',False,'',0)  should return == [0]")
-        print repr(r[1])
+
 
     def testInventoryMarshallFilterName(self):
         self.assertTrue(nxPackage.Set_Marshall('Present','',self.pkg,'',False,'',0)==
@@ -1079,7 +1058,7 @@ class nxPackageTestCases(unittest2.TestCase):
         r=nxPackageBroken.Inventory_Marshall('','','*','',False,'',0)
         os.system('rm /tmp/nxPackageBroken.py')
         self.assertTrue(len(r[1]['__Inventory'].value) == 0,"nxPackageBroken.Inventory_Marshall('','','*','',False,'',0)  should return empty MI_INSTANCEA.")
-        print repr(r[1])
+
 
 
 class nxFileTestCases(unittest2.TestCase):
@@ -1090,8 +1069,8 @@ class nxFileTestCases(unittest2.TestCase):
         """
         Setup test resources
         """
-        os.system('rm -rf /tmp/*pp*')
-        os.system('rm -rf /tmp/Python-2.4.6.tgz')
+        os.system('rm -rf /tmp/*pp* 2> /dev/null')
+        os.system('rm -rf /tmp/Python-2.4.6.tgz 2> /dev/null')
         nxFile.SetShowMof(False)
         print self.id() + '\n'
         
@@ -1099,8 +1078,8 @@ class nxFileTestCases(unittest2.TestCase):
         """
         Remove test resources.
         """
-        os.system('rm -rf /tmp/*pp*')
-        os.system('rm -rf /tmp/Python-2.4.6.tgz')
+        os.system('rm -rf /tmp/*pp* 2> /dev/null')
+        os.system('rm -rf /tmp/Python-2.4.6.tgz 2> /dev/null')
 
     def make_MI(self,retval,DestinationPath, SourcePath, Ensure, Type, Force, Contents, Checksum, Recurse, Links, Owner, Group, Mode, ModifiedDate):
         d=dict();
@@ -1485,7 +1464,6 @@ class nxFileTestCases(unittest2.TestCase):
                "https://www.python.org/ftp/python/2.4.6/Python-2.4.6.nope", "Present", "File", "", "", "md5", "", "", "", "", '776') ==
                [-1],'nxFile.Test(_Marshall("/tmp/Python-2.4.6.tgz",'+\
                '"https://www.python.org/ftp/python/2.4.6/Python-2.4.6.tgz", "Present", "File", "", "", "md5", "", "", "", "", 776) should return [-1]')
-
 
 dummy_service_file=r"""#!/usr/bin/env python
 from __future__ import with_statement
@@ -1923,7 +1901,7 @@ class nxServiceTestCases(unittest2.TestCase):
                 os.chmod('/usr/sbin/dummy_service.py',0744)
             except:
                 print repr(sys.exc_info())
-            os.system('systemctl --system daemon-reload &> /dev/null')
+            os.system('systemctl --system daemon-reload 2> /dev/null')
         elif nxService.UpstartExists():
             self.controller='upstart'
             try:
@@ -1954,22 +1932,22 @@ class nxServiceTestCases(unittest2.TestCase):
         """
         dist=platform.dist()[0].lower()
         if nxService.SystemdExists():
-            os.system('systemctl disable dummy_service &> /dev/null')
+            os.system('systemctl disable dummy_service 2> /dev/null')
             if 'ubuntu' in dist or 'debian' in dist  or 'cent' in dist:
                 os.system('rm /usr/sbin/dummy_service.py /lib/systemd/system/dummy_service.' + \
-                          'service /etc/systemd/system/multi-user.target.wants/dummy_service.service &> /dev/null')
+                          'service /etc/systemd/system/multi-user.target.wants/dummy_service.service 2> /dev/null')
             else:
-                os.system('rm /usr/sbin/dummy_service.py /etc/rc.d/dummy_service &> /dev/null')
-            os.system('systemctl --system daemon-reload &> /dev/null')
+                os.system('rm /usr/sbin/dummy_service.py /etc/rc.d/dummy_service 2> /dev/null')
+            os.system('systemctl --system daemon-reload 2> /dev/null')
         elif nxService.UpstartExists():
-            os.system('update-rc.d -f dummy_service remove &> /dev/null')
-            os.system('rm /usr/sbin/dummy_service.py /etc/init/dummy_service.conf /etc/init.d/dummy_service /etc/default/dummy_service &> /dev/null')
+            os.system('update-rc.d -f dummy_service remove 2> /dev/null')
+            os.system('rm /usr/sbin/dummy_service.py /etc/init/dummy_service.conf /etc/init.d/dummy_service /etc/default/dummy_service 2> /dev/null')
         elif nxService.InitExists():
-            os.system('chkconfig --del dummy_service &> /dev/null')
-            os.system('rm /usr/sbin/dummy_service.py /etc/init.d/dummy_service &> /dev/null')
+            os.system('chkconfig --del dummy_service 2> /dev/null')
+            os.system('rm /usr/sbin/dummy_service.py /etc/init.d/dummy_service 2> /dev/null')
             
         time.sleep(1)
-        os.system("ps -ef | grep -v grep | grep dummy_service | awk '{print $2}' | xargs -L1 kill &> /dev/null")
+        os.system("ps -ef | grep -v grep | grep dummy_service | awk '{print $2}' | xargs -L1 kill 2> /dev/null")
 
     def CheckInventory(self, Name, Controller, Enabled, State, Inventory):
         if len(Inventory['__Inventory'].value) < 1:
@@ -1984,7 +1962,6 @@ class nxServiceTestCases(unittest2.TestCase):
             if State != None and len(State) and not fnmatch.fnmatch(i['State'].value,State):
                 print 'State:' + State + ' != ' + i['State'].value
                 return False
-            print 'Inventory Matched: ' + repr(i)
         return True
 
     def make_MI(self,retval, Name, Controller, Enabled, State, Path, Description, Runlevels):
@@ -2046,7 +2023,7 @@ class nxServiceTestCases(unittest2.TestCase):
         self.assertTrue(nxService.Set_Marshall("dummy_service", controller, True, "running")==
                         [0],'nxService.Set_Marshall("dummy_service", "'+controller+'", True, "running") should return ==[0]')
         r=nxService.Get_Marshall("dummy_service", controller, True, "running")
-        print repr(r[1])
+
         self.assertTrue(check_values(r,self.make_MI(0,"dummy_service", controller, True, "running",None,None,None)) == True
                         ,'nxService.Get_Marshall("dummy_service", "'+controller+'", True, "running") should return ==[0]')
 
@@ -2057,7 +2034,7 @@ class nxServiceTestCases(unittest2.TestCase):
         self.assertTrue(nxService.Set_Marshall("dummy_service", controller, False, "stopped")==
                         [0],'nxService.Set_Marshall("dummy_service", "'+controller+'", False, "stopped") should return ==[0]')
         r=nxService.Get_Marshall("dummy_service", controller, False, "stopped")
-        print 'GET:'+repr(r)
+
         self.assertTrue(check_values(r,self.make_MI(0,"dummy_service", controller, False, "stopped", None, None, None)) == True
                         ,'nxService.Get_Marshall("dummy_service", "'+controller+'", False, "stopped") should return ==[0,"dummy_service", controller, False, "stopped"]')
 
@@ -2066,7 +2043,7 @@ class nxServiceTestCases(unittest2.TestCase):
         self.assertTrue(nxService.Set_Marshall("yummyservice", controller, True, "running")==
                         [-1],'nxService.Set_Marshall("yummyservice", "'+controller+'", True, "running") should return ==[-1]')
         r=nxService.Get_Marshall("yummyservice", controller, True, "running")
-        print 'GET:'+repr(r)
+
         self.assertTrue(check_values(r,self.make_MI(0,"yummyservice", controller, True, "running", None, None, None)) == False
                         ,'nxService.Get_Marshall("yummyservice", "'+controller+'", True, "running")[0:5] should return ==[-1,"yummyservice", controller, True, "running"]')
 
@@ -2075,14 +2052,14 @@ class nxServiceTestCases(unittest2.TestCase):
         self.assertTrue(nxService.Set_Marshall("yummyservice", controller, False, "stopped")==
                         [-1],'nxService.Set_Marshall("yummyservice", "'+controller+'", False, "stopped") should return ==[-1]')
         r=nxService.Get_Marshall("yummyservice", controller, False, "stopped")
-        print 'GET:'+repr(r)
+
         self.assertTrue(check_values(r,self.make_MI(0,"yummyservice", controller, False, "stopped", None, None, None)) == False
                         ,'nxService.Get_Marshall("yummyservice", "'+controller+'", False, "stopped")[0:5] should return ==[-1,"yummyservice", controller, False, "stopped"]')
 
     def testInventoryMarshall(self):
         r=nxService.Inventory_Marshall('*', self.controller, None,'')
         self.assertTrue(r[0] == 0,"Inventory_Marshall('*', " + self.controller + ", None,'')  should return == 0")
-        print repr(r[1])
+
 
     def testInventoryMarshallCmdlineError(self):
         os.system('cp  ./Scripts/nxService.py /tmp/nxServiceBroken.py')
@@ -2094,19 +2071,19 @@ class nxServiceTestCases(unittest2.TestCase):
         r=nxServiceBroken.Inventory_Marshall('*', self.controller, None,'')
         os.system('rm /tmp/nxServiceBroken.py')
         self.assertTrue(r[0] == -1,"nxServiceBroken.Inventory_Marshall('*', " + self.controller + ", None,'')  should return == -1")
-        print repr(r[1])
+
 
     def testInventoryMarshallControllerWildcard(self):
         r=nxService.Inventory_Marshall('*', '*', None,'')
         self.assertTrue(r[0] == 0,"Inventory_Marshall('*', '*', None,'')  should return == 0")
-        print repr(r[1])
+
 
     def testInventoryMarshallControllerError(self):
         controllers = ['systemd', 'upstart', 'init']
         controllers.remove(self.controller)
         r=nxService.Inventory_Marshall('*', controllers[0], None,'')
         self.assertTrue(r[0] == -1,"Inventory_Marshall('*', " + self.controller + ", None,'')  should return == -1")
-        print repr(r[1])
+
 
     def testInventoryMarshallDummyService(self):
         self.assertTrue(nxService.Set_Marshall("dummy_service", self.controller, True, "running")==
@@ -2188,7 +2165,7 @@ class nxSshAuthorizedKeysTestCases(unittest2.TestCase):
         Setup test resources
         """
         self.mykey='MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDLXp6PkCtbpV+P1gwFQWH6Ez0U83uEmS8IGnpeI8Fk8rY/vHOZzZZaxRCw+loyc342qCDIQheMOCNm5Fkevz06q757/oooiLR3yryYGKiKG1IZIiplmtsC95oKrzUSKk60wuI1mbgpMUP5LKi/Tvxes5PmkUtXfimz2qgkeUcPpQIDAQAB'
-        if os.system('grep jojoma /etc/passwd'):
+        if os.system('grep -q jojoma /etc/passwd'):
             nxUser.Set_Marshall("jojoma", "Present", "JO JO MA", "JOJOMA", 'badpass', False, False, "/home/jojoma", "mail" )    
         path='/home/jojoma/.ssh/authorized_keys'
         if not os.path.isfile(path):
@@ -2202,7 +2179,7 @@ class nxSshAuthorizedKeysTestCases(unittest2.TestCase):
         Remove test resources.
         """
         path='/home/jojoma/.ssh/authorized_keys'
-        os.system('rm -rf ' + path)
+        os.system('rm -rf ' + path + ' 2> /dev/null')
 
     def make_MI(self,retval, KeyComment, Ensure, UserName, Key):
         d=dict();
@@ -2286,7 +2263,7 @@ class nxEnvironmentTestCases(unittest2.TestCase):
         """
         Setup test resources
         """
-        os.system('rm /tmp/environment /tmp/DSCEnvironment.sh')
+        os.system('rm /tmp/environment /tmp/DSCEnvironment.sh 2> /dev/null')
         path='/etc/environment'
         if os.path.isfile(path) :
             os.system('cp -p ' + path + ' /tmp/')
@@ -2301,11 +2278,6 @@ class nxEnvironmentTestCases(unittest2.TestCase):
         """
         Remove test resources.
         """
-        print "TEARDOWN"
-        os.system('echo "Contents of /etc/environment are: " 1>&2' )
-        os.system('cat /etc/environment 1>&2')
-        os.system('echo "Contents of /etc/profile.d/DSCEnvironment.sh are: " 1>&2')
-        os.system('cat /etc/profile.d/DSCEnvironment.sh 1>&2')
         path='/etc/environment'
         if os.path.isfile('/tmp/environment') :
             os.system('mv ' + ' /tmp/environment ' + path)
@@ -2375,7 +2347,7 @@ class nxEnvironmentTestCases(unittest2.TestCase):
         self.assertTrue(nxEnvironment.Set_Marshall('MYVAR','/tmp','Present',False) ==
                         [0],"assert nxEnvironment.Set_Marshall('MYVAR','/tmp','Present',False) should == [0]")
         r=nxEnvironment.Get_Marshall('MYVAR','/tmp','Present',False)
-        print 'GET:'+repr(r)
+
         self.assertTrue(check_values(r,self.make_MI(0,'MYVAR','/tmp','present',False)) == True
                         ,"assert nxEnvironment.Get_Marshall('MYVAR','/tmp','Present',False)[0] should == [0]")
         
@@ -2418,13 +2390,13 @@ class nxEnvironmentTestCases(unittest2.TestCase):
         self.assertTrue(nxEnvironment.Set_Marshall('','/tmp','Present',True) ==
                         [0],"assert nxEnvironment.Set_Marshall('','/tmp','Present',True) should == [0]")
         r=nxEnvironment.Get_Marshall('','/tmp','Present',True)
-        print 'GET:'+repr(r)
+
         self.assertTrue(check_values(r,self.make_MI(0,'','/tmp','present',True)) == True
                         ,"assert nxEnvironment.Get_Marshall('','/tmp','Present',True) should == [0]")
         
     def testGetPathPresentError(self):
         r=nxEnvironment.Get_Marshall('','/tp','Present',True)
-        print 'GET:'+repr(r)
+
         self.assertTrue(check_values(r,self.make_MI(0,'','/tp','present',True)) == False
                         ,"assert nxEnvironment.Get_Marshall('','/tmp','Present',True)[0] should == [-1]")
 
@@ -2483,7 +2455,7 @@ def StartFirewall(firewall):
     t['ufw']='yes | ufw enable '
     t['SuSEfirewall2']='SuSEfirewall2 start'
     t['firewalld']='service firewalld start'
-    os.system(t[firewall])
+    os.system(t[firewall] + ' 2> /dev/null')
 
 def StopFirewall(firewall):
     if firewall == 'iptables':
@@ -2492,7 +2464,7 @@ def StopFirewall(firewall):
     t['ufw']='ufw disable'
     t['SuSEfirewall2']='SuSEfirewall2 stop'
     t['firewalld']='service firewalld stop'
-    os.system(t[firewall])
+    os.system(t[firewall] + ' 2> /dev/null')
 
 
 @unittest2.skipUnless(FirewallTypeIs() != 
@@ -2840,7 +2812,7 @@ class nxDNSServerAddressTestCases(unittest2.TestCase):
     def testGetDNSServerAddressPresent(self):
         d=ParseMOF('./Scripts/Tests/test_mofs/nxDNSServerAddress_add.mof')
         self.assertTrue(nxDNSServerAddress.Set_Marshall(**d) == [0],'Set('+repr(d)+') should return == [0]')
-        print "HERE "+repr(nxDNSServerAddress.Get_Marshall(**d))
+
         self.assertTrue(check_values(nxDNSServerAddress.Get_Marshall(**d), \
         self.make_MI(0,**d))  ==  True, \
         'Get('+repr(d)+' should return [0,'+ repr(d) + ']')
@@ -2953,7 +2925,7 @@ class nxArchiveTestCases(unittest2.TestCase):
         self.assertTrue(nxArchive.Set_Marshall(**d) == [0],'Set('+repr(d)+') should return == [0]')
 
 
-@unittest2.skipUnless(os.system('ps -ef | grep -v grep | grep mysqld') ==
+@unittest2.skipUnless(os.system('ps -ef | grep -v grep | grep -q mysqld') ==
                       0,'Skipping nxMySqlUserTestCases.   mysqld is not running.')
 class nxMySqlUserTestCases(unittest2.TestCase):
     """
@@ -2964,7 +2936,7 @@ class nxMySqlUserTestCases(unittest2.TestCase):
         cmd = "DROP USER " + Name + ";"
         cmd='mysql -u root -e "' + cmd + ' FLUSH PRIVILEGES;"'
         os.environ['MYSQL_PWD'] = 'root'
-        os.system(cmd)
+        os.system(cmd + ' 2> /dev/null')
         os.environ['MYSQL_PWD'] = ''
 
     def setUp(self):
@@ -3035,7 +3007,7 @@ class nxMySqlUserTestCases(unittest2.TestCase):
         'Get('+repr(d)+' should return ==['+repr(d)+']')
 
 
-@unittest2.skipUnless(os.system('ps -ef | grep -v grep | grep mysqld') ==
+@unittest2.skipUnless(os.system('ps -ef | grep -v grep | grep -q mysqld') ==
                       0,'Skipping nxMySqlDatabaseTestCases.   mysqld is not running.')
 class nxMySqlDatabaseTestCases(unittest2.TestCase):
     """
@@ -3047,7 +3019,7 @@ class nxMySqlDatabaseTestCases(unittest2.TestCase):
         cmd = "DROP DATABASE " + Name + ";"
         cmd='mysql -u root -e "' + cmd + '"'
         os.environ['MYSQL_PWD'] = 'root'
-        os.system(cmd)
+        os.system(cmd + ' 2> /dev/null')
         os.environ['MYSQL_PWD'] = ''
 
     def setUp(self):
@@ -3102,7 +3074,7 @@ class nxMySqlDatabaseTestCases(unittest2.TestCase):
         'Get('+repr(d)+' should return ==['+repr(d)+']')
 
 
-@unittest2.skipUnless(os.system('ps -ef | grep -v grep | grep mysqld') ==
+@unittest2.skipUnless(os.system('ps -ef | grep -v grep | grep -q mysqld') ==
                       0,'Skipping nxMySqlGrantTestCases.   mysqld is not running.')
 class nxMySqlGrantTestCases(unittest2.TestCase):
     """
@@ -3116,7 +3088,7 @@ class nxMySqlGrantTestCases(unittest2.TestCase):
         cmd = "REVOKE "+ PermissionType + " ON " + DatabaseName + ".* FROM '" + UserName+"'@'" + Host  + "';"
         cmd='mysql -u root -e "' + cmd + ' FLUSH PRIVILEGES;"'
         os.environ['MYSQL_PWD'] = 'root'
-        os.system(cmd)
+        os.system(cmd + ' 2> /dev/null')
         os.environ['MYSQL_PWD'] = ''
 
     def setUp(self):
@@ -3202,7 +3174,7 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         """
         cls.create_files = False
         cls.linkfarm = '/tmp/linkfarm/'
-        os.system('rm -rf ' + cls.linkfarm)
+        os.system('rm -rf ' + cls.linkfarm + ' 2> /dev/null')
         os.makedirs(cls.linkfarm+'joe')
         os.makedirs(cls.linkfarm+'bob')
         open(cls.linkfarm+'joe/linkfarmjoefile1.txt','w+').write(\
@@ -3214,7 +3186,7 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         open(cls.linkfarm+'bob/linkfarmbobfile2.txt','w+').write(\
             'Contents of linkfarmbobfile2.txt\n')
         cls.basepath = '/tmp/FileInventory/'
-        os.system('rm -rf ' + cls.basepath)
+        os.system('rm -rf ' + cls.basepath + ' 2> /dev/null')
         os.makedirs(cls.basepath+'joedir0/joedir1/joedir2/')
         open(cls.basepath+'basedirfile1.txt','w+').write(\
             'Contents of basedirfile1.txt\n')
@@ -3279,7 +3251,8 @@ class nxFileInventoryTestCases(unittest2.TestCase):
 
     @classmethod    
     def tearDownClass(cls):
-        os.system('rm -rf ' + cls.basepath)
+        os.system('rm -rf ' + cls.basepath + ' 2> /dev/null')
+        os.system('rm -rf ' + cls.linkfarm + ' 2> /dev/null')
     
     def setUp(self):
         """
@@ -3293,7 +3266,6 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         Remove test resources.
         """
         pass
-
 
     def SerializeInventoryObject(self, fname, ob):
         # Persist the results of correct results for future tests.
@@ -3320,7 +3292,6 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         return l
     
     def testFileInventoryInventory_MarshallDir(self):
-        print 'Using path:' + self.basepath 
         d = {'Links': u'ignore', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3335,7 +3306,6 @@ class nxFileInventoryTestCases(unittest2.TestCase):
 
     
     def testFileInventoryInventory_MarshallFile(self):
-        print 'Using path:' + self.basepath 
         d = {'Links': u'ignore', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3347,11 +3317,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallFile')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallSingleFile(self):
-        print('Using path:' + self.basepath + 'basedirfile1.txt') 
         d = {'Links': u'ignore', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3363,11 +3332,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallSingleFile')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallSingleFile_omsadminconf(self):
-        print('Using path:' + self.basepath + 'omsadmin.conf') 
         d = {'Links': u'ignore', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3379,11 +3347,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallSingleFile')
         self.assertTrue(l == [], repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallTypeWild(self):
-        print 'Using path:' + self.basepath 
         d = {'Links': u'ignore', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3395,11 +3362,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallTypeWild')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallDirRecurse(self):
-        print 'Using path:' + self.basepath 
         d = {'Links': u'ignore', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3411,11 +3377,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallDirRecurse')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallFileRecurse(self):
-        print 'Using path:' + self.basepath 
         d = {'Links': u'ignore', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3427,11 +3392,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallFileRecurse')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallTypeWildRecurse(self):
-        print 'Using path:' + self.basepath 
         d = {'Links': u'ignore', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3443,11 +3407,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallTypeWildRecurse')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallWildDir(self):
-        print 'Using path:' + self.basepath +'*dir*'
         d = {'Links': u'ignore', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3459,11 +3422,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildDir')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallWildFile(self):
-        print 'Using path:' + self.basepath +'*/*file*'
         d = {'Links': u'ignore', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3475,11 +3437,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildFile')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallWildTypeWild(self):
-        print 'Using path:' + self.basepath +'*/*'
         d = {'Links': u'ignore', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3491,11 +3452,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildTypeWild')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallWildDirRecurse(self):
-        print 'Using path:' + self.basepath +'*/*dir*'
         d = {'Links': u'ignore', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3507,11 +3467,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildDirRecurse')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallWildFileRecurse(self):
-        print 'Using path:' + self.basepath +'*/*file*'
         d = {'Links': u'ignore', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3523,11 +3482,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildFileRecurse')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallWildTypeWildRecurse(self):
-        print 'Using path:' + self.basepath +'*/*'
         d = {'Links': u'ignore', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3539,11 +3497,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildTypeWildRecurse')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallDirFollowLink(self):
-        print 'Using path:' + self.basepath 
         d = {'Links': u'follow', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3555,11 +3512,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallDirFollowLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallFileFollowLink(self):
-        print 'Using path:' + self.basepath 
         d = {'Links': u'follow', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3571,11 +3527,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallFileFollowLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallTypeWildFollowLink(self):
-        print 'Using path:' + self.basepath 
         d = {'Links': u'follow', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3587,11 +3542,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallTypeWildFollowLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallDirRecurseFollowLink(self):
-        print 'Using path:' + self.basepath 
         d = {'Links': u'follow', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3603,11 +3557,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallDirRecurseFollowLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallFileRecurseFollowLink(self):
-        print 'Using path:' + self.basepath 
         d = {'Links': u'follow', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3619,11 +3572,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallFileRecurseFollowLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallTypeWildRecurseFollowLink(self):
-        print 'Using path:' + self.basepath 
         d = {'Links': u'follow', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3635,11 +3587,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallTypeWildRecurseFollowLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallWildDirFollowLink(self):
-        print 'Using path:' + self.basepath +'*dir*'
         d = {'Links': u'follow', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3651,11 +3602,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildDirFollowLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallWildFileFollowLink(self):
-        print 'Using path:' + self.basepath +'*/*file*'
         d = {'Links': u'follow', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3667,11 +3617,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildFileFollowLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallWildTypeWildFollowLink(self):
-        print 'Using path:' + self.basepath +'*/*'
         d = {'Links': u'follow', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3683,11 +3632,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildTypeWildFollowLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallWildDirRecurseFollowLink(self):
-        print 'Using path:' + self.basepath +'*/*dir*'
         d = {'Links': u'follow', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3699,11 +3647,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildDirRecurseFollowLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallWildFileRecurseFollowLink(self):
-        print 'Using path:' + self.basepath +'*/*file*'
         d = {'Links': u'follow', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3715,11 +3662,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildFileRecurseFollowLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallWildTypeWildRecurseFollowLink(self):
-        print 'Using path:' + self.basepath +'*/*'
         d = {'Links': u'follow', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3731,12 +3677,11 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildTypeWildRecurseFollowLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
 
     def testFileInventoryInventory_MarshallDirManageLink(self):
-        print 'Using path:' + self.basepath 
         d = {'Links': u'manage', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3748,11 +3693,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallDirManageLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallFileManageLink(self):
-        print 'Using path:' + self.basepath 
         d = {'Links': u'manage', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3764,11 +3708,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallFileManageLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallTypeWildManageLink(self):
-        print 'Using path:' + self.basepath 
         d = {'Links': u'manage', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3780,11 +3723,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallTypeWildManageLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallDirRecurseManageLink(self):
-        print 'Using path:' + self.basepath 
         d = {'Links': u'manage', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3796,11 +3738,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallDirRecurseManageLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallFileRecurseManageLink(self):
-        print 'Using path:' + self.basepath 
         d = {'Links': u'manage', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3812,11 +3753,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallFileRecurseManageLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallTypeWildRecurseManageLink(self):
-        print 'Using path:' + self.basepath 
         d = {'Links': u'manage', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3828,11 +3768,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallTypeWildRecurseManageLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallWildDirManageLink(self):
-        print 'Using path:' + self.basepath +'*dir*'
         d = {'Links': u'manage', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3844,11 +3783,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildDirManageLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallWildFileManageLink(self):
-        print 'Using path:' + self.basepath +'*/*file*'
         d = {'Links': u'manage', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3860,11 +3798,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildFileManageLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallWildTypeWildManageLink(self):
-        print 'Using path:' + self.basepath +'*/*'
         d = {'Links': u'manage', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3876,11 +3813,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildTypeWildManageLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallWildDirRecurseManageLink(self):
-        print 'Using path:' + self.basepath +'*/*dir*'
         d = {'Links': u'manage', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3892,11 +3828,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildDirRecurseManageLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallWildFileRecurseManageLink(self):
-        print 'Using path:' + self.basepath +'*/*file*'
         d = {'Links': u'manage', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3908,11 +3843,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildFileRecurseManageLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
     def testFileInventoryInventory_MarshallWildTypeWildRecurseManageLink(self):
-        print 'Using path:' + self.basepath +'*/*'
         d = {'Links': u'manage', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3924,8 +3858,8 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildTypeWildRecurseManageLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print d['DestinationPath'], d['Contents']
+#        for d in r[1]['__Inventory'].value:
+#            print d['DestinationPath'], d['Contents']
 
 
 
@@ -3950,5 +3884,5 @@ if __name__ == '__main__':
     s17=unittest2.TestLoader().loadTestsFromTestCase(nxMySqlGrantTestCases)
     s18=unittest2.TestLoader().loadTestsFromTestCase(nxFileInventoryTestCases)
     alltests = unittest2.TestSuite([s1,s2,s3,s4,s5,s6,s7,s8,s9,s10,s11,s12,s13,s14,s15,s16,s17,s18])
-    if not unittest2.TextTestRunner(stream=sys.stdout,verbosity=3).run(alltests).wasSuccessful():
+    if not unittest2.TextTestRunner(stream=sys.stdout,verbosity=0).run(alltests).wasSuccessful():
         sys.exit(1)

--- a/Providers/Scripts/3.x/Scripts/Tests/test_nxProviders.py
+++ b/Providers/Scripts/3.x/Scripts/Tests/test_nxProviders.py
@@ -187,10 +187,10 @@ class nxUserTestCases(unittest2.TestCase):
         """
         Setup test resources
         """
-        if not os.system('grep jojoma /etc/passwd'):
-            os.system('userdel -r jojoma &> /dev/null')
-        if not os.system('grep jojoma /etc/group'):
-            os.system('groupdel jojoma &> /dev/null')
+        if not os.system('grep -q jojoma /etc/passwd'):
+            os.system('userdel -r jojoma 2> /dev/null')
+        if not os.system('grep -q jojoma /etc/group'):
+            os.system('groupdel jojoma 2> /dev/null')
         time.sleep(1)
         nxUser.SetShowMof(True)
         print(self.id() + '\n')
@@ -199,10 +199,10 @@ class nxUserTestCases(unittest2.TestCase):
         """
         Remove test resources.
         """
-        if not os.system('grep jojoma /etc/passwd'):
-            os.system('userdel -r jojoma &> /dev/null')
-        if not os.system('grep jojoma /etc/group'):
-            os.system('groupdel jojoma &> /dev/null')
+        if not os.system('grep -q jojoma /etc/passwd'):
+            os.system('userdel -r jojoma 2> /dev/null')
+        if not os.system('grep -q jojoma /etc/group'):
+            os.system('groupdel jojoma 2> /dev/null')
         time.sleep(1)
 
     def pswd_hash(self,pswd):
@@ -224,7 +224,6 @@ class nxUserTestCases(unittest2.TestCase):
             if Description != None and len(Description) and not fnmatch.fnmatch(i['Description'].value,Description):
                 print('Description:' + Description + ' != ' + i['Description'].value)
                 return False
-            print('Inventory Matched: ' + repr(i))
         return True
 
     def make_MI(self,retval,UserName, Ensure, FullName, Description, Password, Disabled, PasswordChangeRequired, HomeDirectory, GroupID, UserID):
@@ -425,7 +424,6 @@ class nxUserTestCases(unittest2.TestCase):
     def testUserInventoryMarshal(self):
         d=nxUser.Inventory_Marshall("", "", "", "", "", False, False, "", "" )
         self.assertTrue(d[0] == 0,'Inventory_Marshall("", "", "", "", "", False, False, "", "" ) should return == [0]')
-        print(repr(d))
 
     def testInventoryMarshallUser(self):
         pswd=self.pswd_hash('jojoma')
@@ -491,10 +489,10 @@ class nxGroupTestCases(unittest2.TestCase):
         """
         Setup test resources
         """
-        if not os.system('grep jojomamas /etc/group &> /dev/null'):
-            os.system('groupdel jojomamas &> /dev/null')
-        if os.system('grep jojoma /etc/passwd'):
-            os.system('useradd -m jojoma &> /dev/null')
+        if not os.system('grep -q jojomamas /etc/group'):
+            os.system('groupdel jojomamas 2> /dev/null')
+        if os.system('grep -q jojoma /etc/passwd'):
+            os.system('useradd -m jojoma 2> /dev/null')
         time.sleep(1)
         nxGroup.SetShowMof(False)
         print(self.id() + '\n')
@@ -503,8 +501,8 @@ class nxGroupTestCases(unittest2.TestCase):
         """
         Remove test resources.
         """
-        os.system('userdel -r jojoma &> /dev/null')
-        os.system('groupdel jojomamas &> /dev/null')
+        os.system('userdel -r jojoma 2> /dev/null')
+        os.system('groupdel jojomamas 2> /dev/null')
         time.sleep(1)
         nxGroup.SetShowMof(False)
         print(self.id() + '\n')
@@ -523,7 +521,6 @@ class nxGroupTestCases(unittest2.TestCase):
             if GroupName != None and len(GroupName) and not fnmatch.fnmatch(i['GroupName'].value,GroupName):
                 print('GroupName:' + GroupName + ' != ' + i['GroupName'].value)
                 return False
-        print('Inventory Matched: ' + repr(i))
         return True
 
     def make_MI(self,retval,GroupName, Ensure, Members, MembersToInclude, MembersToExclude, PreferredGroupID, GroupID):
@@ -629,7 +626,6 @@ class nxGroupTestCases(unittest2.TestCase):
 
     def testInventory_Marshall(self):
         d=nxGroup.Inventory_Marshall("*", "", "", "", "", "")
-        print(repr(d))
 
     def testSetInventory_MarshallFilterGroup(self):
         self.assertTrue(nxGroup.Set_Marshall("jojomamas", "Present", "", "", "", "1101" ) ==
@@ -653,7 +649,7 @@ class nxScriptTestCases(unittest2.TestCase):
         """
         Setup test resources
         """
-        os.system('useradd -m jojoma ')
+        os.system('useradd -m jojoma 2> /dev/null')
         time.sleep(1)
         self.get_script='#!/bin/bash \ncat /tmp/testfile\n'
         self.test_script='#!/bin/bash \ngrep  "set script successfull" /tmp/testfile\n'
@@ -663,8 +659,8 @@ class nxScriptTestCases(unittest2.TestCase):
         """
         Remove test resources.
         """
-        os.system('userdel -r jojoma ')
-        os.system('rm /tmp/testfile')
+        os.system('userdel -r jojoma  2> /dev/null')
+        os.system('rm /tmp/testfile 2> /dev/null')
         time.sleep(1)
     
     def make_MI(self,retval,GetScript, SetScript, TestScript, User, Group, Result):
@@ -698,69 +694,57 @@ class nxScriptTestCases(unittest2.TestCase):
     def testGetScriptUser(self):
         nxScript.Set_Marshall(self.get_script,self.set_script,self.test_script, "jojoma", "" )
         r=nxScript.Get_Marshall(self.get_script,self.set_script,self.test_script, "jojoma", "" )
-        print('GET='+repr(r))
         self.assertTrue(check_values(r,self.make_MI(0,self.get_script,self.set_script,self.test_script, "jojoma", "", "set script successfull\n" )) == True,'nxScript.Get_Marshall(self.get_script,self.set_script,self.test_script, "jojoma", "" )[0] should return == 0')
 
     def testTestScriptUser(self):
         nxScript.Set_Marshall(self.get_script,self.set_script,self.test_script, "jojoma", "" )
         r=nxScript.Test_Marshall(self.get_script,self.set_script,self.test_script, "jojoma", "" )
-        print('TEST='+repr(r))
         self.assertTrue(r == [0],'nxScript.Test_Marshall(self.get_script,self.set_script,self.test_script, "jojoma", "" )[0] should return == 0')
 
     def testSetScriptUser(self):
         r=nxScript.Set_Marshall(self.get_script,self.set_script,self.test_script, "jojoma", "" )
-        print('SET='+repr(r))
         self.assertTrue(r[0] == 0,'nxScript.Set_Marshall(self.get_script,self.set_script,self.test_script, "jojoma", "" )[0] should return == 0')
 
     def testGetScriptGroup(self):
         nxScript.Set_Marshall(self.get_script,self.set_script,self.test_script, "", "mail" )
         r=nxScript.Get_Marshall(self.get_script,self.set_script,self.test_script, "", "mail" )
-        print('GET='+repr(r))
         self.assertTrue(check_values(r,self.make_MI(0,self.get_script,self.set_script,self.test_script, "", "mail", "set script successfull\n" )) == True,'nxScript.Get_Marshall(self.get_script,self.set_script,self.test_script, "", "mail" )[0] should return == 0')
 
     def testTestScriptGroup(self):
         nxScript.Set_Marshall(self.get_script,self.set_script,self.test_script, "", "mail" )
         r=nxScript.Test_Marshall(self.get_script,self.set_script,self.test_script, "", "mail" )
-        print('TEST='+repr(r))
         self.assertTrue(r == [0],'nxScript.Test_Marshall(self.get_script,self.set_script,self.test_script, "", "mail" )[0] should return == 0')
 
     def testSetScriptGroup(self):
         r=nxScript.Set_Marshall(self.get_script,self.set_script,self.test_script, "", "mail" )
-        print('SET='+repr(r))
         self.assertTrue(r[0] == 0,'nxScript.Set_Marshall(self.get_script,self.set_script,self.test_script, "", "mail" )[0] should return == 0')
 
     def testGetScriptUserError(self):
         nxScript.Set_Marshall(self.get_script,self.set_script,self.test_script, "jojoma", "" )
         r=nxScript.Get_Marshall(self.get_script,self.set_script,self.test_script, "ojoma", "" )
-        print('GET='+repr(r))
         self.assertTrue(check_values(r,self.make_MI(0,self.get_script,self.set_script,self.test_script, "ojoma", "", "set script successfull\n") ) == False,'nxScript.Get_Marshall(self.get_script,self.set_script,self.test_script, "ojoma", "" )[-1] should return == -1')
 
     def testTestScriptUserError(self):
         nxScript.Set_Marshall(self.get_script,self.set_script,self.test_script, "jojoma", "" )
         r=nxScript.Test_Marshall(self.get_script,self.set_script,self.test_script, "ojoma", "" )
-        print('TEST='+repr(r))
         self.assertTrue(r == [-1],'nxScript.Test_Marshall(self.get_script,self.set_script,self.test_script, "ojoma", "" )[-1] should return == -1')
 
     def testSetScriptUserError(self):
         r=nxScript.Set_Marshall(self.get_script,self.set_script,self.test_script, "ojoma", "" )
-        print('SET='+repr(r))
         self.assertTrue(r[0] == -1,'nxScript.Set_Marshall(self.get_script,self.set_script,self.test_script, "ojoma", "" )[-1] should return == -1')
 
     def testGetScriptGroupError(self):
         nxScript.Set_Marshall(self.get_script,self.set_script,self.test_script, "", "ojoma" )
         r=nxScript.Get_Marshall(self.get_script,self.set_script,self.test_script, "", "ojoma" )
-        print('GET='+repr(r))
         self.assertTrue(check_values(r,self.make_MI(0,self.get_script,self.set_script,self.test_script, "", "ojoma" , "set script successfull\n")) == False,'nxScript.Get_Marshall(self.get_script,self.set_script,self.test_script, "", "ojoma" )[-1] should return == -1')
 
     def testTestScriptGroupError(self):
         nxScript.Set_Marshall(self.get_script,self.set_script,self.test_script, "", "ojoma" )
         r=nxScript.Test_Marshall(self.get_script,self.set_script,self.test_script, "", "ojoma" )
-        print('TEST='+repr(r))
         self.assertTrue(r == [-1],'nxScript.Test_Marshall(self.get_script,self.set_script,self.test_script, "", "ojoma" )[-1] should return == -1')
 
     def testSetScriptGroupError(self):
         r=nxScript.Set_Marshall(self.get_script,self.set_script,self.test_script, "", "ojoma" )
-        print('SET='+repr(r))
         self.assertTrue(r[0] == -1,'nxScript.Set_Marshall(self.get_script,self.set_script,self.test_script, "", "ojoma" )[-1] should return == -1')
 
 
@@ -776,15 +760,15 @@ class nxPackageTestCases(unittest2.TestCase):
         self.pkg = 'nano'
         if platform.dist()[0].lower() == 'suse':
             self.pkg = 'gvim'
-        if os.system('which dpkg ') == 0 :
-            os.system('dpkg -r ' + self.pkg + ' &> /dev/null')
+        if os.system('which dpkg') == 0 :
+            os.system('dpkg -r ' + self.pkg + ' 2> /dev/null')
             if os.path.exists('/usr/bin/dummy.sh'):
-                os.system('dpkg -r dummy &> /dev/null')
+                os.system('dpkg -r dummy 2> /dev/null')
             self.package_path='./Scripts/Tests/dummy-1.0.deb'
         else :
-            os.system('rpm -e ' + self.pkg + ' &> /dev/null')
+            os.system('rpm -e ' + self.pkg + ' 2> /dev/null')
             if os.path.exists('/usr/bin/dummy.sh'):
-                os.system('rpm -e dummy &> /dev/null')
+                os.system('rpm -e dummy 2> /dev/null')
             self.package_path='./Scripts/Tests/dummy-1.0-1.x86_64.rpm'
         time.sleep(3)
         print(self.id() + '\n')
@@ -794,14 +778,14 @@ class nxPackageTestCases(unittest2.TestCase):
         Remove test resources.
         """
         time.sleep(4)
-        if os.system('which dpkg ') == 0 :
-            os.system('dpkg -r ' + self.pkg + ' &> /dev/null')
+        if os.system('which dpkg') == 0 :
+            os.system('dpkg -r ' + self.pkg + ' 2> /dev/null')
             if os.path.exists('/usr/bin/dummy.sh'):
-                os.system('dpkg -r dummy &> /dev/null')
+                os.system('dpkg -r dummy 2> /dev/null')
         else :
-            os.system('rpm -e ' + self.pkg + ' &> /dev/null')
+            os.system('rpm -e ' + self.pkg + ' 2> /dev/null')
             if os.path.exists('/usr/bin/dummy.sh'):
-                os.system('rpm -e dummy &> /dev/null')
+                os.system('rpm -e dummy 2> /dev/null')
         time.sleep(3)
 
     def CheckInventory(self, Name, Inventory):
@@ -811,7 +795,6 @@ class nxPackageTestCases(unittest2.TestCase):
             if Name != None and len(Name) and not fnmatch.fnmatch(i['Name'].value,Name):
                 print('Name:' + Name + ' != ' + i['Name'].value)
                 return False
-            print('Inventory Matched: ' + repr(i))
         return True
 
     def make_MI(self, retval, Ensure, PackageManager, Name, FilePath, PackageGroup, Arguments,
@@ -925,7 +908,7 @@ class nxPackageTestCases(unittest2.TestCase):
         self.assertTrue(nxPackage.Set_Marshall('Present','',self.pkg,'',False,'',0)==
                         [0],"nxPackage.Set_Marshall('Present','','" + self.pkg + "','',False,'',0) should return ==[0]")
         r=nxPackage.Get_Marshall('Present','',self.pkg,'',False,'',0)
-        print('GET:'+repr(r))
+
 
         self.assertTrue(check_values(r,self.make_MI(0,'present', None,self.pkg,'',False,'',0, None, None, None, None, None, None, None )) == True
                         ,"nxPackage.Get_Marshall('Present','','" + self.pkg + "','',False,'',0)[0] should return == 0")
@@ -933,7 +916,7 @@ class nxPackageTestCases(unittest2.TestCase):
     def testTestEnableNameDefaultProviderBadReturnCodeError(self):
         self.assertTrue(nxPackage.Set_Marshall('Present','',self.pkg,'',False,'',0)==
                         [0],"nxPackage.Set_Marshall('Present','','" + self.pkg + "','',False,'',0) should return ==[0]")
-        print('TEST:'+repr(nxPackage.Test_Marshall('Present','',self.pkg,'',False,'',6)))
+
 
         self.assertTrue(nxPackage.Test_Marshall('Present','',self.pkg,'',False,'',6)==
                         [-1],"nxPackage.Test_Marshall('Present','','" + self.pkg + "','',False,'',True,6) should return == [-1]")
@@ -942,19 +925,19 @@ class nxPackageTestCases(unittest2.TestCase):
         self.assertTrue(nxPackage.Set_Marshall('Present','',self.pkg,'',False,'',0)==
                         [0],"nxPackage.Set_Marshall('Present','','" + self.pkg + "','',False,'',0) should return ==[0]")
         r=nxPackage.Get_Marshall('Present','',self.pkg,'',False,'',6)
-        print('GET:'+repr(r))
+
         self.assertTrue(check_values(r,self.make_MI(0,'present', None,self.pkg,'',False,'',6, None, None, None, None, None, None, None )) == True
                         ,"nxPackage.Get_Marshall('Present','','" + self.pkg + "','',False,'',True,6)[0] should return == 0")
 
     def testTestEnableNameDefaultProvider(self):
         self.assertTrue(nxPackage.Set_Marshall('Present','',self.pkg,'',False,'',0)==
                         [0],"nxPackage.Set_Marshall('Present','','" + self.pkg + "','',False,'',0) should return ==[0]")
-        print('TEST:'+repr(nxPackage.Test_Marshall('Present','',self.pkg,'',False,'',0)))
+
 
         self.assertTrue(nxPackage.Test_Marshall('Present','',self.pkg,'',False,'',0)==
                         [0],"nxPackage.Test_Marshall('Present','','" + self.pkg + "','',False,'',0) should return == [0]")
 
-    @unittest2.skipUnless(os.system('which yum ') ==
+    @unittest2.skipUnless(os.system('which yum') ==
                           0,'groupmode is not implemented.')
     def testSetEnableGroupDefaultProvider(self):
         self.assertTrue(nxPackage.Set_Marshall('Present','','Remote Desktop Clients','',True,'',0)==
@@ -979,7 +962,7 @@ class nxPackageTestCases(unittest2.TestCase):
                         [0],"nxPackage.Set_Marshall('Absent','','" + self.pkg + "','',False,'',0) should return ==[0]")
         time.sleep(4)
         r=nxPackage.Get_Marshall('Absent','',self.pkg,'',False,'',0)
-        print('GET:'+repr(r))
+
         self.assertTrue(check_values(r,self.make_MI(0,'absent', None,self.pkg,'',False,'',0, None, None, None, None, None, None, None )) == True
                         ,"nxPackage.Get_Marshall('Absent','','" + self.pkg + "','',False,'',0)[0] should return == 0")
 
@@ -990,12 +973,12 @@ class nxPackageTestCases(unittest2.TestCase):
         self.assertTrue(nxPackage.Set_Marshall('Absent','',self.pkg,'',False,'',0)==
                         [0],"nxPackage.Set_Marshall('Absent','','" + self.pkg + "','',False,'',0) should return ==[0]")
         time.sleep(4)
-        print('TEST:'+repr(nxPackage.Test_Marshall('Absent','',self.pkg,'',False,'',0)))
+
 
         self.assertTrue(nxPackage.Test_Marshall('Absent','',self.pkg,'',False,'',0)==
                         [0],"nxPackage.Test_Marshall('Absent','','" + self.pkg + "','',False,'',0) should return == [0]")
 
-    @unittest2.skipUnless(os.system('which yum ') ==
+    @unittest2.skipUnless(os.system('which yum') ==
                           0,'groupmode is not implemented.')
     def testSetDisableGroupDefaultProvider(self):
         self.assertTrue(nxPackage.Set_Marshall('Present','','Remote Desktop Clients','',True,'',0)==
@@ -1014,13 +997,11 @@ class nxPackageTestCases(unittest2.TestCase):
 
     def testGetEnableBadNameDefaultProvider(self):
         r=nxPackage.Get_Marshall('Present','','nanoo','',False,'',0)
-        print('GET:'+repr(r))
+
         self.assertTrue(check_values(r,self.make_MI(0,'present', None,'nanoo','',False,'',0, None, None, None, None, None, None, None )) == True
                         ,"nxPackage.Get_Marshall('Present','','nanoo','',False,'',0)[-1] should return == 0")
 
     def testTestEnableBadNameDefaultProvider(self):
-        print('TEST:'+repr(nxPackage.Test_Marshall('Present','','nanoo','',False,'',0)))
-
         self.assertTrue(nxPackage.Test_Marshall('Present','','nanoo','',False,'',0)==
                         [-1],"nxPackage.Test_Marshall('Present','','nanoo','',False,'',0) should return == [-1]")
 
@@ -1034,13 +1015,11 @@ class nxPackageTestCases(unittest2.TestCase):
 
     def testGetDisableBadNameDefaultProvider(self):
         r=nxPackage.Get_Marshall('Absent','','nanoo','',False,'',0)
-        print('GET:'+repr(r))
+
         self.assertTrue(check_values(r,self.make_MI(0,'absent', None,'nanoo','',False,'',0, None, None, None, None, None, None, None )) == True
                         ,"nxPackage.Get_Marshall('Absent','','nanoo','',False,'',0)[0] should return == 0")
 
     def testTestDisableBadNameDefaultProvider(self):
-        print('TEST:'+repr(nxPackage.Test_Marshall('Absent','','nanoo','',False,'',0)))
-
         self.assertTrue(nxPackage.Test_Marshall('Absent','','nanoo','',False,'',0)==
                         [0],"nxPackage.Test_Marshall('Absent','','nanoo','',False,'',0) should return == [0]")
 
@@ -1051,7 +1030,7 @@ class nxPackageTestCases(unittest2.TestCase):
     def testInventoryMarshall(self):
         r=nxPackage.Inventory_Marshall('','','*','',False,'',0)
         self.assertTrue(r[0] == 0,"Inventory_Marshall('','','*','',False,'',0)  should return == [0]")
-        print(repr(r[1]))
+
 
     def testInventoryMarshallFilterName(self):
         self.assertTrue(nxPackage.Set_Marshall('Present','',self.pkg,'',False,'',0)==
@@ -1079,7 +1058,7 @@ class nxPackageTestCases(unittest2.TestCase):
         r=nxPackageBroken.Inventory_Marshall('','','*','',False,'',0)
         os.system('rm /tmp/nxPackageBroken.py')
         self.assertTrue(len(r[1]['__Inventory'].value) == 0,"nxPackageBroken.Inventory_Marshall('','','*','',False,'',0)  should return empty MI_INSTANCEA.")
-        print(repr(r[1]))
+
 
 
 class nxFileTestCases(unittest2.TestCase):
@@ -1090,17 +1069,17 @@ class nxFileTestCases(unittest2.TestCase):
         """
         Setup test resources
         """
-        os.system('rm -rf /tmp/*pp*')
-        os.system('rm -rf /tmp/Python-2.4.6.tgz')
-        nxFile.SetShowMof(True)
+        os.system('rm -rf /tmp/*pp* 2> /dev/null')
+        os.system('rm -rf /tmp/Python-2.4.6.tgz 2> /dev/null')
+        nxFile.SetShowMof(False)
         print(self.id() + '\n')
         
     def tearDown(self):
         """
         Remove test resources.
         """
-        os.system('rm -rf /tmp/*pp*')
-        os.system('rm -rf /tmp/Python-2.4.6.tgz')
+        os.system('rm -rf /tmp/*pp* 2> /dev/null')
+        os.system('rm -rf /tmp/Python-2.4.6.tgz 2> /dev/null')
 
     def make_MI(self,retval,DestinationPath, SourcePath, Ensure, Type, Force, Contents, Checksum, Recurse, Links, Owner, Group, Mode, ModifiedDate):
         d=dict();
@@ -1922,7 +1901,7 @@ class nxServiceTestCases(unittest2.TestCase):
                 os.chmod('/usr/sbin/dummy_service.py',0o744)
             except:
                 print(repr(sys.exc_info()))
-            os.system('systemctl --system daemon-reload &> /dev/null')
+            os.system('systemctl --system daemon-reload 2> /dev/null')
         elif nxService.UpstartExists():
             self.controller='upstart'
             try:
@@ -1953,22 +1932,22 @@ class nxServiceTestCases(unittest2.TestCase):
         """
         dist=platform.dist()[0].lower()
         if nxService.SystemdExists():
-            os.system('systemctl disable dummy_service &> /dev/null')
+            os.system('systemctl disable dummy_service 2> /dev/null')
             if 'ubuntu' in dist or 'debian' in dist  or 'cent' in dist:
                 os.system('rm /usr/sbin/dummy_service.py /lib/systemd/system/dummy_service.' + \
-                          'service /etc/systemd/system/multi-user.target.wants/dummy_service.service &> /dev/null')
+                          'service /etc/systemd/system/multi-user.target.wants/dummy_service.service 2> /dev/null')
             else:
-                os.system('rm /usr/sbin/dummy_service.py /etc/rc.d/dummy_service &> /dev/null')
-            os.system('systemctl --system daemon-reload &> /dev/null')
+                os.system('rm /usr/sbin/dummy_service.py /etc/rc.d/dummy_service 2> /dev/null')
+            os.system('systemctl --system daemon-reload 2> /dev/null')
         elif nxService.UpstartExists():
-            os.system('update-rc.d -f dummy_service remove &> /dev/null')
-            os.system('rm /usr/sbin/dummy_service.py /etc/init/dummy_service.conf /etc/init.d/dummy_service /etc/default/dummy_service &> /dev/null')
+            os.system('update-rc.d -f dummy_service remove 2> /dev/null')
+            os.system('rm /usr/sbin/dummy_service.py /etc/init/dummy_service.conf /etc/init.d/dummy_service /etc/default/dummy_service 2> /dev/null')
         elif nxService.InitExists():
-            os.system('chkconfig --del dummy_service &> /dev/null')
-            os.system('rm /usr/sbin/dummy_service.py /etc/init.d/dummy_service &> /dev/null')
+            os.system('chkconfig --del dummy_service 2> /dev/null')
+            os.system('rm /usr/sbin/dummy_service.py /etc/init.d/dummy_service 2> /dev/null')
             
         time.sleep(1)
-        os.system("ps -ef | grep -v grep | grep dummy_service | awk '{print $2}' | xargs -L1 kill &> /dev/null")
+        os.system("ps -ef | grep -v grep | grep dummy_service | awk '{print $2}' | xargs -L1 kill 2> /dev/null")
 
     def CheckInventory(self, Name, Controller, Enabled, State, Inventory):
         if len(Inventory['__Inventory'].value) < 1:
@@ -1983,7 +1962,6 @@ class nxServiceTestCases(unittest2.TestCase):
             if State != None and len(State) and not fnmatch.fnmatch(i['State'].value,State):
                 print('State:' + State + ' != ' + i['State'].value)
                 return False
-            print('Inventory Matched: ' + repr(i))
         return True
 
     def make_MI(self,retval, Name, Controller, Enabled, State, Path, Description, Runlevels):
@@ -2045,7 +2023,7 @@ class nxServiceTestCases(unittest2.TestCase):
         self.assertTrue(nxService.Set_Marshall("dummy_service", controller, True, "running")==
                         [0],'nxService.Set_Marshall("dummy_service", "'+controller+'", True, "running") should return ==[0]')
         r=nxService.Get_Marshall("dummy_service", controller, True, "running")
-        print(repr(r[1]))
+
         self.assertTrue(check_values(r,self.make_MI(0,"dummy_service", controller, True, "running",None,None,None)) == True
                         ,'nxService.Get_Marshall("dummy_service", "'+controller+'", True, "running") should return ==[0]')
 
@@ -2056,7 +2034,7 @@ class nxServiceTestCases(unittest2.TestCase):
         self.assertTrue(nxService.Set_Marshall("dummy_service", controller, False, "stopped")==
                         [0],'nxService.Set_Marshall("dummy_service", "'+controller+'", False, "stopped") should return ==[0]')
         r=nxService.Get_Marshall("dummy_service", controller, False, "stopped")
-        print('GET:'+repr(r))
+
         self.assertTrue(check_values(r,self.make_MI(0,"dummy_service", controller, False, "stopped", None, None, None)) == True
                         ,'nxService.Get_Marshall("dummy_service", "'+controller+'", False, "stopped") should return ==[0,"dummy_service", controller, False, "stopped"]')
 
@@ -2065,7 +2043,7 @@ class nxServiceTestCases(unittest2.TestCase):
         self.assertTrue(nxService.Set_Marshall("yummyservice", controller, True, "running")==
                         [-1],'nxService.Set_Marshall("yummyservice", "'+controller+'", True, "running") should return ==[-1]')
         r=nxService.Get_Marshall("yummyservice", controller, True, "running")
-        print('GET:'+repr(r))
+
         self.assertTrue(check_values(r,self.make_MI(0,"yummyservice", controller, True, "running", None, None, None)) == False
                         ,'nxService.Get_Marshall("yummyservice", "'+controller+'", True, "running")[0:5] should return ==[-1,"yummyservice", controller, True, "running"]')
 
@@ -2074,14 +2052,14 @@ class nxServiceTestCases(unittest2.TestCase):
         self.assertTrue(nxService.Set_Marshall("yummyservice", controller, False, "stopped")==
                         [-1],'nxService.Set_Marshall("yummyservice", "'+controller+'", False, "stopped") should return ==[-1]')
         r=nxService.Get_Marshall("yummyservice", controller, False, "stopped")
-        print('GET:'+repr(r))
+
         self.assertTrue(check_values(r,self.make_MI(0,"yummyservice", controller, False, "stopped", None, None, None)) == False
                         ,'nxService.Get_Marshall("yummyservice", "'+controller+'", False, "stopped")[0:5] should return ==[-1,"yummyservice", controller, False, "stopped"]')
 
     def testInventoryMarshall(self):
         r=nxService.Inventory_Marshall('*', self.controller, None,'')
         self.assertTrue(r[0] == 0,"Inventory_Marshall('*', " + self.controller + ", None,'')  should return == 0")
-        print(repr(r[1]))
+
 
     def testInventoryMarshallCmdlineError(self):
         os.system('cp  ./Scripts/nxService.py /tmp/nxServiceBroken.py')
@@ -2093,19 +2071,19 @@ class nxServiceTestCases(unittest2.TestCase):
         r=nxServiceBroken.Inventory_Marshall('*', self.controller, None,'')
         os.system('rm /tmp/nxServiceBroken.py')
         self.assertTrue(r[0] == -1,"nxServiceBroken.Inventory_Marshall('*', " + self.controller + ", None,'')  should return == -1")
-        print(repr(r[1]))
+
 
     def testInventoryMarshallControllerWildcard(self):
         r=nxService.Inventory_Marshall('*', '*', None,'')
         self.assertTrue(r[0] == 0,"Inventory_Marshall('*', '*', None,'')  should return == 0")
-        print(repr(r[1]))
+
 
     def testInventoryMarshallControllerError(self):
         controllers = ['systemd', 'upstart', 'init']
         controllers.remove(self.controller)
         r=nxService.Inventory_Marshall('*', controllers[0], None,'')
         self.assertTrue(r[0] == -1,"Inventory_Marshall('*', " + self.controller + ", None,'')  should return == -1")
-        print(repr(r[1]))
+
 
     def testInventoryMarshallDummyService(self):
         self.assertTrue(nxService.Set_Marshall("dummy_service", self.controller, True, "running")==
@@ -2187,7 +2165,7 @@ class nxSshAuthorizedKeysTestCases(unittest2.TestCase):
         Setup test resources
         """
         self.mykey='MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDLXp6PkCtbpV+P1gwFQWH6Ez0U83uEmS8IGnpeI8Fk8rY/vHOZzZZaxRCw+loyc342qCDIQheMOCNm5Fkevz06q757/oooiLR3yryYGKiKG1IZIiplmtsC95oKrzUSKk60wuI1mbgpMUP5LKi/Tvxes5PmkUtXfimz2qgkeUcPpQIDAQAB'
-        if os.system('grep jojoma /etc/passwd'):
+        if os.system('grep -q jojoma /etc/passwd'):
             nxUser.Set_Marshall("jojoma", "Present", "JO JO MA", "JOJOMA", 'badpass', False, False, "/home/jojoma", "mail" )    
         path='/home/jojoma/.ssh/authorized_keys'
         if not os.path.isfile(path):
@@ -2201,7 +2179,7 @@ class nxSshAuthorizedKeysTestCases(unittest2.TestCase):
         Remove test resources.
         """
         path='/home/jojoma/.ssh/authorized_keys'
-        os.system('rm -rf ' + path)
+        os.system('rm -rf ' + path + ' 2> /dev/null')
 
     def make_MI(self,retval, KeyComment, Ensure, UserName, Key):
         d=dict();
@@ -2285,7 +2263,7 @@ class nxEnvironmentTestCases(unittest2.TestCase):
         """
         Setup test resources
         """
-        os.system('rm /tmp/environment /tmp/DSCEnvironment.sh')
+        os.system('rm /tmp/environment /tmp/DSCEnvironment.sh 2> /dev/null')
         path='/etc/environment'
         if os.path.isfile(path) :
             os.system('cp -p ' + path + ' /tmp/')
@@ -2300,11 +2278,6 @@ class nxEnvironmentTestCases(unittest2.TestCase):
         """
         Remove test resources.
         """
-        print("TEARDOWN")
-        os.system('echo "Contents of /etc/environment are: " 1>&2' )
-        os.system('cat /etc/environment 1>&2')
-        os.system('echo "Contents of /etc/profile.d/DSCEnvironment.sh are: " 1>&2')
-        os.system('cat /etc/profile.d/DSCEnvironment.sh 1>&2')
         path='/etc/environment'
         if os.path.isfile('/tmp/environment') :
             os.system('mv ' + ' /tmp/environment ' + path)
@@ -2374,7 +2347,7 @@ class nxEnvironmentTestCases(unittest2.TestCase):
         self.assertTrue(nxEnvironment.Set_Marshall('MYVAR','/tmp','Present',False) ==
                         [0],"assert nxEnvironment.Set_Marshall('MYVAR','/tmp','Present',False) should == [0]")
         r=nxEnvironment.Get_Marshall('MYVAR','/tmp','Present',False)
-        print('GET:'+repr(r))
+
         self.assertTrue(check_values(r,self.make_MI(0,'MYVAR','/tmp','present',False)) == True
                         ,"assert nxEnvironment.Get_Marshall('MYVAR','/tmp','Present',False)[0] should == [0]")
         
@@ -2417,13 +2390,13 @@ class nxEnvironmentTestCases(unittest2.TestCase):
         self.assertTrue(nxEnvironment.Set_Marshall('','/tmp','Present',True) ==
                         [0],"assert nxEnvironment.Set_Marshall('','/tmp','Present',True) should == [0]")
         r=nxEnvironment.Get_Marshall('','/tmp','Present',True)
-        print('GET:'+repr(r))
+
         self.assertTrue(check_values(r,self.make_MI(0,'','/tmp','present',True)) == True
                         ,"assert nxEnvironment.Get_Marshall('','/tmp','Present',True) should == [0]")
         
     def testGetPathPresentError(self):
         r=nxEnvironment.Get_Marshall('','/tp','Present',True)
-        print('GET:'+repr(r))
+
         self.assertTrue(check_values(r,self.make_MI(0,'','/tp','present',True)) == False
                         ,"assert nxEnvironment.Get_Marshall('','/tmp','Present',True)[0] should == [-1]")
 
@@ -2482,7 +2455,7 @@ def StartFirewall(firewall):
     t['ufw']='yes | ufw enable '
     t['SuSEfirewall2']='SuSEfirewall2 start'
     t['firewalld']='service firewalld start'
-    os.system(t[firewall])
+    os.system(t[firewall] + ' 2> /dev/null')
 
 def StopFirewall(firewall):
     if firewall == 'iptables':
@@ -2491,7 +2464,7 @@ def StopFirewall(firewall):
     t['ufw']='ufw disable'
     t['SuSEfirewall2']='SuSEfirewall2 stop'
     t['firewalld']='service firewalld stop'
-    os.system(t[firewall])
+    os.system(t[firewall] + ' 2> /dev/null')
 
 
 @unittest2.skipUnless(FirewallTypeIs() != 
@@ -2839,7 +2812,7 @@ class nxDNSServerAddressTestCases(unittest2.TestCase):
     def testGetDNSServerAddressPresent(self):
         d=ParseMOF('./Scripts/Tests/test_mofs/nxDNSServerAddress_add.mof')
         self.assertTrue(nxDNSServerAddress.Set_Marshall(**d) == [0],'Set('+repr(d)+') should return == [0]')
-        print("HERE "+repr(nxDNSServerAddress.Get_Marshall(**d)))
+
         self.assertTrue(check_values(nxDNSServerAddress.Get_Marshall(**d), \
         self.make_MI(0,**d))  ==  True, \
         'Get('+repr(d)+' should return [0,'+ repr(d) + ']')
@@ -2952,7 +2925,7 @@ class nxArchiveTestCases(unittest2.TestCase):
         self.assertTrue(nxArchive.Set_Marshall(**d) == [0],'Set('+repr(d)+') should return == [0]')
 
 
-@unittest2.skipUnless(os.system('ps -ef | grep -v grep | grep mysqld') ==
+@unittest2.skipUnless(os.system('ps -ef | grep -v grep | grep -q mysqld') ==
                       0,'Skipping nxMySqlUserTestCases.   mysqld is not running.')
 class nxMySqlUserTestCases(unittest2.TestCase):
     """
@@ -2963,7 +2936,7 @@ class nxMySqlUserTestCases(unittest2.TestCase):
         cmd = "DROP USER " + Name + ";"
         cmd='mysql -u root -e "' + cmd + ' FLUSH PRIVILEGES;"'
         os.environ['MYSQL_PWD'] = 'root'
-        os.system(cmd)
+        os.system(cmd + ' 2> /dev/null')
         os.environ['MYSQL_PWD'] = ''
 
     def setUp(self):
@@ -3034,7 +3007,7 @@ class nxMySqlUserTestCases(unittest2.TestCase):
         'Get('+repr(d)+' should return ==['+repr(d)+']')
 
 
-@unittest2.skipUnless(os.system('ps -ef | grep -v grep | grep mysqld') ==
+@unittest2.skipUnless(os.system('ps -ef | grep -v grep | grep -q mysqld') ==
                       0,'Skipping nxMySqlDatabaseTestCases.   mysqld is not running.')
 class nxMySqlDatabaseTestCases(unittest2.TestCase):
     """
@@ -3046,7 +3019,7 @@ class nxMySqlDatabaseTestCases(unittest2.TestCase):
         cmd = "DROP DATABASE " + Name + ";"
         cmd='mysql -u root -e "' + cmd + '"'
         os.environ['MYSQL_PWD'] = 'root'
-        os.system(cmd)
+        os.system(cmd + ' 2> /dev/null')
         os.environ['MYSQL_PWD'] = ''
 
     def setUp(self):
@@ -3101,7 +3074,7 @@ class nxMySqlDatabaseTestCases(unittest2.TestCase):
         'Get('+repr(d)+' should return ==['+repr(d)+']')
 
 
-@unittest2.skipUnless(os.system('ps -ef | grep -v grep | grep mysqld') ==
+@unittest2.skipUnless(os.system('ps -ef | grep -v grep | grep -q mysqld') ==
                       0,'Skipping nxMySqlGrantTestCases.   mysqld is not running.')
 class nxMySqlGrantTestCases(unittest2.TestCase):
     """
@@ -3115,7 +3088,7 @@ class nxMySqlGrantTestCases(unittest2.TestCase):
         cmd = "REVOKE "+ PermissionType + " ON " + DatabaseName + ".* FROM '" + UserName+"'@'" + Host  + "';"
         cmd='mysql -u root -e "' + cmd + ' FLUSH PRIVILEGES;"'
         os.environ['MYSQL_PWD'] = 'root'
-        os.system(cmd)
+        os.system(cmd + ' 2> /dev/null')
         os.environ['MYSQL_PWD'] = ''
 
     def setUp(self):
@@ -3201,7 +3174,7 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         """
         cls.create_files = False
         cls.linkfarm = '/tmp/linkfarm/'
-        os.system('rm -rf ' + cls.linkfarm)
+        os.system('rm -rf ' + cls.linkfarm + ' 2> /dev/null')
         os.makedirs(cls.linkfarm+'joe')
         os.makedirs(cls.linkfarm+'bob')
         open(cls.linkfarm+'joe/linkfarmjoefile1.txt','w+').write(\
@@ -3213,7 +3186,7 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         open(cls.linkfarm+'bob/linkfarmbobfile2.txt','w+').write(\
             'Contents of linkfarmbobfile2.txt\n')
         cls.basepath = '/tmp/FileInventory/'
-        os.system('rm -rf ' + cls.basepath)
+        os.system('rm -rf ' + cls.basepath + ' 2> /dev/null')
         os.makedirs(cls.basepath+'joedir0/joedir1/joedir2/')
         open(cls.basepath+'basedirfile1.txt','w+').write(\
             'Contents of basedirfile1.txt\n')
@@ -3278,7 +3251,8 @@ class nxFileInventoryTestCases(unittest2.TestCase):
 
     @classmethod    
     def tearDownClass(cls):
-        os.system('rm -rf ' + cls.basepath)
+        os.system('rm -rf ' + cls.basepath + ' 2> /dev/null')
+        os.system('rm -rf ' + cls.linkfarm + ' 2> /dev/null')
     
     def setUp(self):
         """
@@ -3318,7 +3292,6 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         return l
     
     def testFileInventoryInventory_MarshallDir(self):
-        print('Using path:' + self.basepath)
         d = {'Links': u'ignore', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3333,7 +3306,6 @@ class nxFileInventoryTestCases(unittest2.TestCase):
 
     
     def testFileInventoryInventory_MarshallFile(self):
-        print('Using path:' + self.basepath) 
         d = {'Links': u'ignore', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3345,11 +3317,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallFile')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#         for d in r[1]['__Inventory'].value:
+#             print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallSingleFile(self):
-        print('Using path:' + self.basepath + 'basedirfile1.txt') 
         d = {'Links': u'ignore', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3361,11 +3332,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallSingleFile')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallSingleFile_omsadminconf(self):
-        print('Using path:' + self.basepath + 'omsadmin.conf')
         d = {'Links': u'ignore', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3377,19 +3347,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallSingleFile')
         self.assertTrue(l == [], repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallTypeWild(self):
-        print('Using path:' + self.basepath) 
-        d = {'Links': u'ignore', 'MaxOutputSize': None, \
-             'Checksum': u'md5', 'Recurse': False, \
-             'MaxContentsReturnable': None, \
-             'DestinationPath': self.basepath, 'UseSudo': True, 'Type': u'*'}
-        r = nxFileInventory.Inventory_Marshall(**d)
-        self.assertTrue(r[0] == 0,'Inventory_Marshall('+repr(d)+')[0] should return == 0') 
-    def testFileInventoryInventory_MarshallTypeWild(self):
-        print('Using path:' + self.basepath) 
         d = {'Links': u'ignore', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3401,11 +3362,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallTypeWild')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallDirRecurse(self):
-        print('Using path:' + self.basepath) 
         d = {'Links': u'ignore', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3417,11 +3377,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallDirRecurse')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallFileRecurse(self):
-        print('Using path:' + self.basepath) 
         d = {'Links': u'ignore', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3433,11 +3392,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallFileRecurse')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallTypeWildRecurse(self):
-        print('Using path:' + self.basepath) 
         d = {'Links': u'ignore', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3449,11 +3407,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallTypeWildRecurse')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallWildDir(self):
-        print('Using path:' + self.basepath + '*dir*')
         d = {'Links': u'ignore', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3465,11 +3422,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildDir')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallWildFile(self):
-        print('Using path:' + self.basepath + '*/*file*')
         d = {'Links': u'ignore', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3481,11 +3437,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildFile')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallWildTypeWild(self):
-        print('Using path:' + self.basepath + '*/*')
         d = {'Links': u'ignore', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3497,11 +3452,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildTypeWild')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallWildDirRecurse(self):
-        print('Using path:' + self.basepath + '*/*dir*')
         d = {'Links': u'ignore', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3513,11 +3467,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildDirRecurse')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallWildFileRecurse(self):
-        print('Using path:' + self.basepath + '*/*file*')
         d = {'Links': u'ignore', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3529,11 +3482,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildFileRecurse')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallWildTypeWildRecurse(self):
-        print('Using path:' + self.basepath + '*/*')
         d = {'Links': u'ignore', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3545,11 +3497,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildTypeWildRecurse')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallDirFollowLink(self):
-        print('Using path:' + self.basepath) 
         d = {'Links': u'follow', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3561,11 +3512,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallDirFollowLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallFileFollowLink(self):
-        print('Using path:' + self.basepath) 
         d = {'Links': u'follow', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3577,11 +3527,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallFileFollowLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallTypeWildFollowLink(self):
-        print('Using path:' + self.basepath) 
         d = {'Links': u'follow', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3593,11 +3542,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallTypeWildFollowLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallDirRecurseFollowLink(self):
-        print('Using path:' + self.basepath) 
         d = {'Links': u'follow', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3609,11 +3557,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallDirRecurseFollowLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallFileRecurseFollowLink(self):
-        print('Using path:' + self.basepath) 
         d = {'Links': u'follow', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3625,11 +3572,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallFileRecurseFollowLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallTypeWildRecurseFollowLink(self):
-        print('Using path:' + self.basepath) 
         d = {'Links': u'follow', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3641,11 +3587,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallTypeWildRecurseFollowLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallWildDirFollowLink(self):
-        print('Using path:' + self.basepath + '*dir*')
         d = {'Links': u'follow', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3657,11 +3602,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildDirFollowLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallWildFileFollowLink(self):
-        print('Using path:' + self.basepath + '*/*file*')
         d = {'Links': u'follow', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3673,11 +3617,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildFileFollowLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallWildTypeWildFollowLink(self):
-        print('Using path:' + self.basepath + '*/*')
         d = {'Links': u'follow', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3689,11 +3632,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildTypeWildFollowLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallWildDirRecurseFollowLink(self):
-        print('Using path:' + self.basepath + '*/*dir*')
         d = {'Links': u'follow', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3705,11 +3647,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildDirRecurseFollowLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallWildFileRecurseFollowLink(self):
-        print('Using path:' + self.basepath + '*/*file*')
         d = {'Links': u'follow', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3721,11 +3662,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildFileRecurseFollowLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallWildTypeWildRecurseFollowLink(self):
-        print('Using path:' + self.basepath + '*/*')
         d = {'Links': u'follow', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3737,12 +3677,11 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildTypeWildRecurseFollowLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
 
     def testFileInventoryInventory_MarshallDirManageLink(self):
-        print('Using path:' + self.basepath) 
         d = {'Links': u'manage', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3754,11 +3693,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallDirManageLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallFileManageLink(self):
-        print('Using path:' + self.basepath) 
         d = {'Links': u'manage', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3770,11 +3708,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallFileManageLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallTypeWildManageLink(self):
-        print('Using path:' + self.basepath) 
         d = {'Links': u'manage', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3786,11 +3723,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallTypeWildManageLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallDirRecurseManageLink(self):
-        print('Using path:' + self.basepath) 
         d = {'Links': u'manage', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3802,11 +3738,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallDirRecurseManageLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallFileRecurseManageLink(self):
-        print('Using path:' + self.basepath) 
         d = {'Links': u'manage', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3818,11 +3753,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallFileRecurseManageLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallTypeWildRecurseManageLink(self):
-        print('Using path:' + self.basepath) 
         d = {'Links': u'manage', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3834,11 +3768,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallTypeWildRecurseManageLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallWildDirManageLink(self):
-        print('Using path:' + self.basepath + '*dir*')
         d = {'Links': u'manage', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3850,11 +3783,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildDirManageLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallWildFileManageLink(self):
-        print('Using path:' + self.basepath + '*/*file*')
         d = {'Links': u'manage', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3866,11 +3798,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildFileManageLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallWildTypeWildManageLink(self):
-        print('Using path:' + self.basepath + '*/*')
         d = {'Links': u'manage', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': False, \
              'MaxContentsReturnable': None, \
@@ -3882,11 +3813,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildTypeWildManageLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallWildDirRecurseManageLink(self):
-        print('Using path:' + self.basepath + '*/*dir*')
         d = {'Links': u'manage', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3898,11 +3828,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildDirRecurseManageLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallWildFileRecurseManageLink(self):
-        print('Using path:' + self.basepath + '*/*file*')
         d = {'Links': u'manage', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3914,11 +3843,10 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildFileRecurseManageLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
     def testFileInventoryInventory_MarshallWildTypeWildRecurseManageLink(self):
-        print('Using path:' + self.basepath + '*/*')
         d = {'Links': u'manage', 'MaxOutputSize': None, \
              'Checksum': u'md5', 'Recurse': True, \
              'MaxContentsReturnable': None, \
@@ -3930,8 +3858,8 @@ class nxFileInventoryTestCases(unittest2.TestCase):
         l = self.MakeList(r)
         g = self.DeserializeInventoryObject('testFileInventoryInventory_MarshallWildTypeWildRecurseManageLink')
         self.assertTrue(g == l, repr(g) + '\n should be == to \n' + repr(l))
-        for d in r[1]['__Inventory'].value:
-            print(d['DestinationPath'], d['Contents'])
+#        for d in r[1]['__Inventory'].value:
+#            print(d['DestinationPath'], d['Contents'])
 
 
 
@@ -3956,5 +3884,5 @@ if __name__ == '__main__':
     s17=unittest2.TestLoader().loadTestsFromTestCase(nxMySqlGrantTestCases)
     s18=unittest2.TestLoader().loadTestsFromTestCase(nxFileInventoryTestCases)
     alltests = unittest2.TestSuite([s1,s2,s3,s4,s5,s6,s7,s8,s9,s10,s11,s12,s13,s14,s15,s16,s17,s18])
-    if not unittest2.TextTestRunner(stream=sys.stdout,verbosity=3).run(alltests).wasSuccessful():
+    if not unittest2.TextTestRunner(stream=sys.stdout,verbosity=0).run(alltests).wasSuccessful():
         sys.exit(1)


### PR DESCRIPTION
Also fix bug in 2.4x nxPackage.

@Microsoft/powershell-dsc-devs 
@Microsoft/ostc-devs 

This adds the 2.4x and 3.x tests to .travis.yml.
Multiple travis-ci builds from my fork have passed.