### PR TITLE
syslog-ng source fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,7 +309,7 @@ nxOMSPerfCounter:
 
 nxOMSSyslog:
 	rm -rf output/staging; \
-        VERSION="1.0"; \
+        VERSION="1.1"; \
         PROVIDERS="nxOMSSyslog"; \
         STAGINGDIR="output/staging/$@/DSCResources"; \
         cat Providers/Modules/$@.psd1 | sed "s@<MODULE_VERSION>@$${VERSION}@" > intermediate/Modules/$@.psd1; \

--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSSyslog.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSSyslog.py
@@ -236,6 +236,12 @@ def UpdateSyslogNGConf(SyslogSource):
     facility_re = re.compile(facility_search, re.M | re.S)
     txt = facility_re.sub('', txt)
     txt += '\n\n#OMS_Destination\ndestination d_oms { udp("127.0.0.1" port(25224)); };\n'
+    source_search = r'^source (.*?src).*$'
+    source_re = re.compile(source_search, re.M)
+    source_result = source_re.search(txt)
+    source_expr = 'src'
+    if source_result:
+        source_expr = source_result.group(1)
     for d in SyslogSource:
         if 'Severities' not in d.keys() or d['Severities'] is None or len(d['Severities']) is 0:
             facility_txt = ''
@@ -246,7 +252,7 @@ def UpdateSyslogNGConf(SyslogSource):
                 d['Facility'] + \
                 '_oms { level(' + sevs + ') and facility(' + d[
                     'Facility'] + '); };\n'
-            facility_txt += 'log { source(src); filter(f_' + d[
+            facility_txt += 'log { source(' + source_expr + '); filter(f_' + d[
                 'Facility'] + '_oms); destination(d_oms); };\n'
             txt += facility_txt
     try:

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSSyslog.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSSyslog.py
@@ -236,6 +236,12 @@ def UpdateSyslogNGConf(SyslogSource):
     facility_re = re.compile(facility_search, re.M | re.S)
     txt = facility_re.sub('', txt)
     txt += '\n\n#OMS_Destination\ndestination d_oms { udp("127.0.0.1" port(25224)); };\n'
+    source_search = r'^source (.*?src).*$'
+    source_re = re.compile(source_search, re.M)
+    source_result = source_re.search(txt)
+    source_expr = 'src'
+    if source_result:
+        source_expr = source_result.group(1)
     for d in SyslogSource:
         if 'Severities' not in d.keys() or d['Severities'] is None or len(d['Severities']) is 0:
             facility_txt = ''
@@ -246,7 +252,7 @@ def UpdateSyslogNGConf(SyslogSource):
                 d['Facility'] + \
                 '_oms { level(' + sevs + ') and facility(' + d[
                     'Facility'] + '); };\n'
-            facility_txt += 'log { source(src); filter(f_' + d[
+            facility_txt += 'log { source(' + source_expr + '); filter(f_' + d[
                 'Facility'] + '_oms); destination(d_oms); };\n'
             txt += facility_txt
     try:

--- a/Providers/Scripts/3.x/Scripts/nxOMSSyslog.py
+++ b/Providers/Scripts/3.x/Scripts/nxOMSSyslog.py
@@ -233,6 +233,12 @@ def UpdateSyslogNGConf(SyslogSource):
     facility_re = re.compile(facility_search, re.M | re.S)
     txt = facility_re.sub('', txt)
     txt += '\n\n#OMS_Destination\ndestination d_oms { udp("127.0.0.1" port(25224)); };\n'
+    source_search = r'^source (.*?src).*$'
+    source_re = re.compile(source_search, re.M)
+    source_result = source_re.search(txt)
+    source_expr = 'src'
+    if source_result:
+        source_expr = source_result.group(1)
     for d in SyslogSource:
         if 'Severities' not in d.keys() or d['Severities'] is None or len(d['Severities']) is 0:
             facility_txt = ''
@@ -243,7 +249,7 @@ def UpdateSyslogNGConf(SyslogSource):
                 d['Facility'] + \
                 '_oms { level(' + sevs + ') and facility(' + d[
                     'Facility'] + '); };\n'
-            facility_txt += 'log { source(src); filter(f_' + d[
+            facility_txt += 'log { source(' + source_expr + '); filter(f_' + d[
                 'Facility'] + '_oms); destination(d_oms); };\n'
             txt += facility_txt
     try:

--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -57,7 +57,7 @@ SHLIB_EXT: 'so'
 /opt/microsoft/omsconfig/Scripts/OMS_MetaConfigHelper.py; intermediate/Scripts/OMS_MetaConfigHelper.py; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nx_1.0.zip; release/nx_1.0.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSPerfCounter_1.1.zip; release/nxOMSPerfCounter_1.1.zip; 755; ${{RUN_AS_USER}}; root
-/opt/microsoft/omsconfig/module_packages/nxOMSSyslog_1.0.zip; release/nxOMSSyslog_1.0.zip; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/omsconfig/module_packages/nxOMSSyslog_1.1.zip; release/nxOMSSyslog_1.1.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSKeyMgmt_1.0.zip; release/nxOMSKeyMgmt_1.0.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSCustomLog_1.0.zip; release/nxOMSCustomLog_1.0.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSSudoCustomLog_1.0.zip; release/nxOMSSudoCustomLog_1.0.zip; 755; ${{RUN_AS_USER}}; root
@@ -263,7 +263,7 @@ chown -R ${{RUN_AS_USER}} /opt/microsoft/omsconfig/Scripts
 # Set up the modules
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nx_1.0.zip 0"
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSPerfCounter_1.1.zip 0"
-su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSSyslog_1.0.zip 0"
+su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSSyslog_1.1.zip 0"
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSKeyMgmt_1.0.zip 0"
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSCustomLog_1.0.zip 0"
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSSudoCustomLog_1.0.zip 0"


### PR DESCRIPTION
This PR resolves the issue with syslong-ng.conf being generated with records containing non existing source "src", when on some distros such as Ubuntu 14, 16, /etc/syslog-ng/syslog-ng.conf has source defined as "s_src". In result, since syslong-ng service restart fails , oms linux agent would not be able to send syslog data when rsyslog does not present or syslog-ng is used.
@KrisBash 