### PR TITLE
Improve ctypes detection in Base_DSC.data

### DIFF
--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -161,7 +161,7 @@ fi
 
 %Preinstall_200
 tmpfile=`mktemp`
-printf "Checking for ctypes python module..."
+echo "Checking for ctypes python module..."
 cat <<EOF > $tmpfile
 #!/usr/bin/python
 import ctypes
@@ -169,14 +169,19 @@ EOF
 
 chmod u+x $tmpfile
 $tmpfile 1> /dev/null 2> /dev/null
-if [ $? -ne 0 ]; then
+tmpfile_ctypes=$?
+rm $tmpfile
+
+python -c "import ctypes" 1> /dev/null 2> /dev/null
+cmdline_ctypes=$?
+if [ $cmdline_ctypes -eq 0 -a $tmpfile_ctypes -ne 0 ]; then
+    echo "Warning: The ctypes python module was found, but it appears that /tmp may be mounted as noexec. This may affect some DSC functionality."
+elsif [ $cmdline_ctypes -ne 0 -a $tmpfile_ctypes -ne 0 ]; then
     echo "Error: Python does not support ctypes on this system.  Please install the ctypes module for Python or upgrade to a newer version of python that comes with the ctypes module."
     echo "Please remove the omi package and try again after installing the ctypes module or upgrading Python.  You can check if the ctypes module is installed by starting python and running the command: 'import ctypes'"
-	rm $tmpfile
     exit 1
 else
-    echo "ok!"
-	rm $tmpfile
+    echo "The ctypes python module was found."
 fi
 
 %Postinstall_10


### PR DESCRIPTION
@Microsoft/omsagent-devs 

OMSAgent release 1.3.4-127 included a [second ctypes check](https://github.com/Microsoft/OMS-Agent-for-Linux/commit/e93aa8926e2f93912dfe0cc09a8ae3e05e42b8e0#diff-71c19f94b3d458dfb8dc59477cd72403R387) in the omsagent shell bundle; however, DSC checks for ctypes separately.

To unblock several customers, this second check has also been added to the DSC code, in this PR. More refactoring should be considered later to host the ctypes check in only the DSC package.