### PR TITLE
Simplify python ctypes detection

### DIFF
--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -160,28 +160,13 @@ fi
 #endif
 
 %Preinstall_200
-tmpfile=`mktemp`
 echo "Checking for ctypes python module..."
-cat <<EOF > $tmpfile
-#!/usr/bin/python
-import ctypes
-EOF
-
-chmod u+x $tmpfile
-$tmpfile 1> /dev/null 2> /dev/null
-tmpfile_ctypes=$?
-rm $tmpfile
-
 python -c "import ctypes" 1> /dev/null 2> /dev/null
 cmdline_ctypes=$?
-if [ $cmdline_ctypes -eq 0 -a $tmpfile_ctypes -ne 0 ]; then
-    echo "Warning: The ctypes python module was found, but it appears that /tmp may be mounted as noexec. This may affect some DSC functionality."
-elsif [ $cmdline_ctypes -ne 0 -a $tmpfile_ctypes -ne 0 ]; then
+if [ $cmdline_ctypes -ne 0 ]; then    
     echo "Error: Python does not support ctypes on this system.  Please install the ctypes module for Python or upgrade to a newer version of python that comes with the ctypes module."
     echo "Please remove the omi package and try again after installing the ctypes module or upgrading Python.  You can check if the ctypes module is installed by starting python and running the command: 'import ctypes'"
     exit 1
-else
-    echo "The ctypes python module was found."
 fi
 
 %Postinstall_10


### PR DESCRIPTION
This PR is to simplifier python ctypes module detection to enable customers who have SELinux policy on in their environments and cover scenarios where sudo user does not have write or execute access to default /tmp location. 

Executing the python file in addition to running python command from commandline is not necessary in pre-install step. python scripts get installed under DSC paths, and when it comes to that , oms or omi user would already have correct write and execute permissions to given dsc folder.  Running import ctypes code sits only in dsc python scripts that call into ctypes APIs, so if there are systems where python and ctypes are installed, and running python commands from commandline succeeds, then that would also work from a python file, and even if it does not work (rare case, unbelievable that it could ever happen ), then the corresponding error would be thrown from a dsc script that has a call to ctypes API which should be sufficient. 

@KrisBash 