### PR TITLE
removed libcurl reference from log to be consistent with omsagent

### DIFF
--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -125,7 +125,7 @@ PREREQ_ERROR=0
 
 LIBCURL_SO=`ldconfig -p | grep "libcurl" | awk -F ">" '{print $2}' | awk -F " " '{print $1; exit 0}'`
 if [ -z "$LIBCURL_SO" ]; then
-   echo "Error: Unable to find libcurl in ldconfig.  Please install curl."
+   echo "Error: Please install curl."
    PREREQ_ERROR=1
 fi
 


### PR DESCRIPTION
curl installs libcurl3 or whichever version is in the latest curl, having an explicit version reference for the dependent package in the logs gives an impression that agent has two dependencies. 
@Microsoft/omsagent-devs 