### PR TITLE
Permissions Issue fix for Dsc Inventory files. 

### DIFF
--- a/LCM/scripts/PerformInventory.py
+++ b/LCM/scripts/PerformInventory.py
@@ -67,7 +67,7 @@ if optionsValid == False:
 
 omi_bindir = "<CONFIG_BINDIR>"
 omi_sysconfdir = "<CONFIG_SYSCONFDIR>"
-dsc_sysconfdir = omi_sysconfdir + "<CONFIG_SYSCONFDIR_DSC>"
+dsc_sysconfdir = omi_sysconfdir + "/<CONFIG_SYSCONFDIR_DSC>"
 dsc_reportdir = dsc_sysconfdir + "/InventoryReports"
 omicli_path = omi_bindir + "/omicli"
 temp_report_path = dsc_sysconfdir + "/configuration/Inventory.xml.temp"

--- a/LCM/scripts/PerformInventory.py
+++ b/LCM/scripts/PerformInventory.py
@@ -101,9 +101,6 @@ if len(dsc_sysconfdir) < 10:
 # Acquire inventory file lock
 filehandle = os.open(dsc_sysconfdir + "/inventory_lock", os.O_WRONLY | os.O_CREAT , 0o644)
 inventory_lock = os.fdopen(filehandle, 'w')
-
-
-# inventory_lock = open(dsc_sysconfdir + "/inventory_lock", "w+", 0o600)
 fcntl.flock(inventory_lock, fcntl.LOCK_EX)
 
 os.system("rm -f " + dsc_reportdir + "/*")


### PR DESCRIPTION
This is to fix the permission issue for these files generated by DSC Inventory. They were set as world writeable.  Now updated to be 'rw-r-r'.
Inventory.xml.temp
inventory_lock
CompletePackageInventory.xml

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/powershell-dsc-for-linux/278)
<!-- Reviewable:end -->
