### PR TITLE
Fixing inventory_lock permissions issue on upgrade 

### DIFF
--- a/LCM/scripts/PerformInventory.py
+++ b/LCM/scripts/PerformInventory.py
@@ -100,9 +100,15 @@ if len(dsc_sysconfdir) < 10:
     print("Error: Something has gone horribly wrong with the directory paths.")
     sys.exit(1)
 
+# If inventory lock files already exists update its permissions.  
+if os.path.isfile(inventorylock_path):
+    os.chmod(inventorylock_path , stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
+
+# open the inventory lock file, this also creates a file if it does not exist so we are using 644 permissions 
+filehandle = os.open(dsc_sysconfdir + "/inventory_lock", os.O_WRONLY | os.O_CREAT , 0o644)
+inventory_lock = os.fdopen(filehandle, 'w')
+
 # Acquire inventory file lock
-inventory_lock = open(inventorylock_path, "w+")
-os.chmod(inventorylock_path , stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
 fcntl.flock(inventory_lock, fcntl.LOCK_EX)
 
 os.system("rm -f " + dsc_reportdir + "/*")

--- a/LCM/scripts/PerformInventory.py
+++ b/LCM/scripts/PerformInventory.py
@@ -3,6 +3,7 @@ import fileinput
 import sys
 import subprocess
 import os
+import stat
 import fcntl
 import shutil
 from xml.dom.minidom import parse
@@ -72,6 +73,7 @@ dsc_reportdir = dsc_sysconfdir + "/InventoryReports"
 omicli_path = omi_bindir + "/omicli"
 temp_report_path = dsc_sysconfdir + "/configuration/Inventory.xml.temp"
 report_path = dsc_sysconfdir + "/configuration/Inventory.xml"
+inventorylock_path = dsc_sysconfdir + "/inventory_lock"
 
 if "outxml" in Variables:
     report_path = Variables["outxml"]
@@ -99,8 +101,8 @@ if len(dsc_sysconfdir) < 10:
     sys.exit(1)
 
 # Acquire inventory file lock
-filehandle = os.open(dsc_sysconfdir + "/inventory_lock", os.O_WRONLY | os.O_CREAT , 0o644)
-inventory_lock = os.fdopen(filehandle, 'w')
+inventory_lock = open(inventorylock_path, "w+")
+os.chmod(inventorylock_path , stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
 fcntl.flock(inventory_lock, fcntl.LOCK_EX)
 
 os.system("rm -f " + dsc_reportdir + "/*")
@@ -134,5 +136,6 @@ shutil.move(temp_report_path, report_path)
 
 # Release inventory file lock
 fcntl.flock(inventory_lock, fcntl.LOCK_UN)
+inventory_lock.close()
 
 sys.exit(retval)

--- a/LCM/scripts/PerformInventory.py
+++ b/LCM/scripts/PerformInventory.py
@@ -105,7 +105,7 @@ if os.path.isfile(inventorylock_path):
     os.chmod(inventorylock_path , stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
 
 # open the inventory lock file, this also creates a file if it does not exist so we are using 644 permissions 
-filehandle = os.open(dsc_sysconfdir + "/inventory_lock", os.O_WRONLY | os.O_CREAT , 0o644)
+filehandle = os.open(inventorylock_path, os.O_WRONLY | os.O_CREAT , 0o644)
 inventory_lock = os.fdopen(filehandle, 'w')
 
 # Acquire inventory file lock

--- a/LCM/scripts/PerformInventory.py
+++ b/LCM/scripts/PerformInventory.py
@@ -3,9 +3,9 @@ import fileinput
 import sys
 import subprocess
 import os
-import stat
 import fcntl
 import shutil
+import stat
 from xml.dom.minidom import parse
 
 def usage():


### PR DESCRIPTION
This to fix permission issues in inventorylock file when upgrade happens. I have updated it to use chmod now as it was not updating the permission on file used for locking mechanism. This was only happening when file already exists with ww permissions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/powershell-dsc-for-linux/282)
<!-- Reviewable:end -->
