### PR TITLE
performance improvement for YUM update assessment

### DIFF
--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxAvailableUpdates.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxAvailableUpdates.py
@@ -18,6 +18,7 @@ nxDSCLog = imp.load_source('nxDSCLog', '../nxDSCLog.py')
 helperlib = imp.load_source('helperlib', '../helperlib.py')
 LG = nxDSCLog.DSCLog
 
+
 # [ClassVersion("1.0.0"),FriendlyName("nxAvailableUpdates"),SupportsInventory()]
 # class MSFT_nxAvailableUpdatesResource : OMI_BaseResource
 # {
@@ -26,12 +27,12 @@ LG = nxDSCLog.DSCLog
 #   [read] string Repository;
 #   [read] string Version;
 #   [read] string Architecture;
- 
+
 # };
 
 def Inventory_Marshall(Name):
     if Name is not None and len(Name) > 0:
-        Name = Name.encode('ascii','ignore')
+        Name = Name.encode('ascii', 'ignore')
     retval, pkgs = GetUpdates(Name)
     for p in pkgs:
         p['Name'] = protocol.MI_String(p['Name'])
@@ -39,16 +40,17 @@ def Inventory_Marshall(Name):
         p['Repository'] = protocol.MI_String(p['Repository'])
         p['Version'] = protocol.MI_String(p['Version'])
         p['Architecture'] = protocol.MI_String(p['Architecture'])
-    Inventory=protocol.MI_InstanceA(pkgs)
+    Inventory = protocol.MI_InstanceA(pkgs)
     retd = {}
     retd["__Inventory"] = Inventory
     return retval, retd
 
+
 def GetUpdates(Name):
-    d={}
+    d = {}
+    LG().Log('DEBUG', "Starting to check Available Updates")
     mgr = GetPackageManager()
     if mgr == None:
-        Print("ERROR: Unable to find one of 'apt', 'yum', or 'zypper'.")
         LG().Log('ERROR', "Unable to find one of 'apt', 'yum', or 'zypper'.")
         return -1, d
     if mgr == 'apt':
@@ -57,7 +59,9 @@ def GetUpdates(Name):
         d = GetYumUpdates(Name)
     elif mgr == 'zypper':
         d = GetZypperUpdates(Name)
+    LG().Log('DEBUG', "Completed checking Available Updates")
     return 0, d
+
 
 def GetAptUpdates(Name):
     # Format:
@@ -65,7 +69,7 @@ def GetAptUpdates(Name):
     # Inst sosreport [3.2-2ubuntu1] (3.2-2ubuntu1.1 Ubuntu:15.10/wily-updates [amd64])
 
     updates_list = []
-    d={}
+    d = {}
     # Refresh the repo
     if helperlib.CONFIG_SYSCONFDIR_DSC == "omsconfig":
         cmd = 'sudo /opt/microsoft/omsconfig/Scripts/OMSAptUpdates.sh'
@@ -73,12 +77,13 @@ def GetAptUpdates(Name):
         cmd = 'apt-get -q update'
     code, out = RunGetOutput(cmd, False, False)
     cmd = 'LANG=en_US.UTF8 apt-get -s dist-upgrade | grep "^Inst"'
+    LG().Log('DEBUG', "Retrieving update package list using cmd:" + cmd)
     code, out = RunGetOutput(cmd, False, False)
-    if len(out) < 2 :
+    if len(out) < 2:
         return updates_list
-    srch_txt=r'Inst[ ](.*?)[ ].*?[(](.*?)[ ](.*?)[ ]\[(.*?)\]'
-    srch=re.compile(srch_txt, re.M|re.S)
-    pkg_list=srch.findall(out)
+    srch_txt = r'Inst[ ](.*?)[ ].*?[(](.*?)[ ](.*?)[ ]\[(.*?)\]'
+    srch = re.compile(srch_txt, re.M | re.S)
+    pkg_list = srch.findall(out)
     for pkg in pkg_list:
         d['BuildDate'] = ''
         d['Name'] = pkg[0]
@@ -88,8 +93,9 @@ def GetAptUpdates(Name):
         d['Version'] = pkg[1]
         d['Repository'] = pkg[2]
         updates_list.append(copy.deepcopy(d))
+    LG().Log('DEBUG', "Number of packages being written to the XML: " + str(len(updates_list)))
     return updates_list
-         
+
 
 def GetYumUpdates(Name):
     # Format:
@@ -105,16 +111,15 @@ def GetYumUpdates(Name):
     # Epoch and Buildtime are not available for 'yum info available'.
     # If 'repoquery is installed Epoch and Buildtime will be used.
     # Epoch is added to the front of the 'Version', and sanitized afterward.
-    
+
     updates_list = []
-    d={}
     # No need to refresh the repo - 'check-update' will do this.
 
     if os.path.exists('/usr/bin/repoquery'):
-        srch_str=r'Name.*?: (.*?)\n.*?Arch.*?: (.*?)\n.*?Version.*?: (.*?)\n.*?Release.*?: (.*?)\n.*?Repo.*?: (.*?)\n.*?Buildtime.*?: (.*?)\n'
+        srch_str = r'Name.*?: (.*?)\n.*?Arch.*?: (.*?)\n.*?Version.*?: (.*?)\n.*?Release.*?: (.*?)\n.*?Repo.*?: (.*?)\n.*?Buildtime.*?: (.*?)\n'
     else:
-        srch_str=r'Name.*?: (.*?)\n.*?Arch.*?: (.*?)\n.*?Version.*?: (.*?)\n.*?Release.*?: (.*?)\n.*?Repo.*?: (.*?)\n'
-        
+        srch_str = r'Name.*?: (.*?)\n.*?Arch.*?: (.*?)\n.*?Version.*?: (.*?)\n.*?Release.*?: (.*?)\n.*?Repo.*?: (.*?)\n'
+
     if helperlib.CONFIG_SYSCONFDIR_DSC == "omsconfig":
         yum_list = 'sudo /opt/microsoft/omsconfig/Scripts/OMSYumUpdates.sh '
         yum_info = yum_list
@@ -124,43 +129,88 @@ def GetYumUpdates(Name):
             yum_info = 'repoquery --queryformat "Name : %{NAME}\nArch : %{ARCH}\nVersion :  %{EPOCH}:%{VERSION}\nRelease : %{RELEASE}\nRepo : %{REPO}\nBuildtime : %{BUILDTIME}" '
         else:
             yum_info = 'yum info available '
-    cmd = "LANG=en_US.UTF8 " + yum_list + "| awk '{print $1}'"
-    code, pkg_list = RunGetOutput(cmd, False, False)
-    if len(pkg_list) < 2 :
-        LG().Log('INFO', "Nothing to send info on. No packages")
-        return updates_list
-    # Remove the chatter.  Yum puts a blank line before the list.
-    if pkg_list.find('\n\n') > -1:
-        pkg_list = pkg_list[pkg_list.find('\n\n')+2:]
-    LG().Log('DEBUG', "Number of packages: " + str(len(pkg_list.splitlines())))
-    srch = re.compile(srch_str, re.M | re.S)
-    for pkg in pkg_list.splitlines():
-        if len(pkg) < 2 :
-            LG().Log('VERBOSE', "Avoiding very small entries.")
-            continue
-        cmd = "LANG=en_US.UTF8 " + yum_info + pkg
+    cmd = "LANG=en_US.UTF8 " + yum_list
+    start_time = time.time()
+    LG().Log('DEBUG', "Retrieving update package list using cmd: " + cmd)
+    retcode, pkg_list = RunGetOutput(cmd, False, False)
+    LG().Log('DEBUG', "Cmd execution time: " + str((time.time() - start_time) / 60))
+    #LG().Log('DEBUG', "Cmd output for update list : " + pkg_list)    
+
+    # Sample output from OMSYumUpdates.sh
+    #   ca-certificates.noarch
+    #   glibc.x86_64
+    #   glibc-common.x86_64
+    #   glibc-devel.x86_64
+    #   glibc-headers.x86_64
+    if validate_yum_pkg_list_output(pkg_list, retcode):
+        # Remove the chatter.  Yum puts a blank line before the list.
+        if pkg_list.find('\n\n') > -1:
+            pkg_list = pkg_list[pkg_list.find('\n\n') + 2:]
+        LG().Log('DEBUG', "Number of packages to be updated: " + str(len(pkg_list.splitlines())))
+        srch = re.compile(srch_str, re.M | re.S)
+
+        param_list = ""
+        for pkg in pkg_list.splitlines():
+            param_list = param_list + " " + pkg
+
+        cmd = "LANG=en_US.UTF8 " + yum_info + param_list
+        LG().Log('DEBUG', "Retrieving individual package information from Yum using cmd: " + cmd)
+        start_time = time.time()
         code, out = RunGetOutput(cmd, False, False)
+        LG().Log('DEBUG', "Cmd execution time: " + str((time.time() - start_time) / 60))
+        #LG().Log('DEBUG', "Cmd output is : " + out)
+        updates_list = []
         if len(out) < 1 or ':' not in out:
-            LG().Log('DEBUG', "Checking the output in 'out': " + out)
-            continue
-        m = srch.search(out)
-        if m == None:
-            continue
-        d['Name'] = m.group(1)
-        if len(Name) and not fnmatch.fnmatch(d['Name'], Name):
-            continue
-        d['Architecture'] = m.group(2)
-        d['Version'] =  m.group(3) + '-' + m.group(4)
-        if ':' not in d['Version']: # Add a '0:' for epoch.
-            d['Version'] = '0:' + d['Version']
-        d['Version'] = d['Version'].replace('(none)','0') # Handle the Epoch '(none)'. 
-        d['Repository'] = m.group(5)
-        d['BuildDate'] = ''
-        if len(m.groups()) == 6: # Buildtime
-            d['BuildDate'] = time.asctime(time.gmtime(int(m.group(6))))
-        updates_list.append(copy.deepcopy(d))
+            LG().Log('DEBUG', "Failed retrieving individual package info. Output is too small : " + out)
+            return updates_list
+        yum_pkg_info_list = srch.finditer(out)
+        updates_list = get_yum_updates_list(yum_pkg_info_list, Name)
     LG().Log('DEBUG', "Number of packages being written to the XML: " + str(len(updates_list)))
     return updates_list
+
+
+def get_yum_updates_list(yum_pkg_info_list, Name):
+    d = {}
+    updates_list = []
+    for yum_pkg_info in yum_pkg_info_list:
+        d['Name'] = yum_pkg_info.group(1)
+        if len(Name) and not fnmatch.fnmatch(d['Name'], Name):
+            continue
+        d['Architecture'] = yum_pkg_info.group(2)
+        d['Version'] = yum_pkg_info.group(3) + '-' + yum_pkg_info.group(4)
+        if ':' not in d['Version']:  # Add a '0:' for epoch.
+            d['Version'] = '0:' + d['Version']
+        d['Version'] = d['Version'].replace('(none)', '0')  # Handle the Epoch '(none)'.
+        d['Repository'] = yum_pkg_info.group(5)
+        d['BuildDate'] = ''
+        if len(yum_pkg_info.groups()) == 6:  # Buildtime
+            d['BuildDate'] = time.asctime(time.gmtime(int(yum_pkg_info.group(6))))
+        updates_list.append(copy.deepcopy(d))
+    return updates_list
+
+
+def validate_yum_pkg_list_output(pkg_list, retcode):
+    repo_urls_unreachable_error = "Could not contact any CDS load balancers"
+    repo_urls_unconfigured_error = "Cannot find a valid baseurl for repo"
+    yum_packageupdates_available_exitcode = 100
+    yum_no_applicable_packages_exitcode = 0
+
+    if retcode == yum_packageupdates_available_exitcode:
+        if len(pkg_list) < 2:
+            LG().Log('INFO', "Nothing to send info on. No packages")
+        else:
+            return True
+    elif retcode == yum_no_applicable_packages_exitcode:
+        LG().Log('DEBUG', "No packages are available for update")
+    else:
+        LG().Log('DEBUG', "Error return code when retrieving update package list: " + str(retcode))
+        LG().Log('DEBUG', "Output when retrieving update package list: " + str(pkg_list))
+        if repo_urls_unreachable_error in str(pkg_list):
+            LG().Log('DEBUG', "Unable to contact YUM repos" + str(pkg_list))
+        if repo_urls_unconfigured_error in str(pkg_list):
+            LG().Log('DEBUG', "YUM Repo urls are not configured" + str(pkg_list))
+    return False
+
 
 def GetZypperUpdates(Name):
     # Format:
@@ -170,7 +220,7 @@ def GetZypperUpdates(Name):
     # SLES11-SP3-Updates | slessp3-WALinuxAgent-12085 | 1       | recommended | needed
 
     updates_list = []
-    d={}
+    d = {}
     pkg_list = ''
     # For omsagent the repo is refreshed in OMSZypperUpdates.sh.
     if helperlib.CONFIG_SYSCONFDIR_DSC == "omsconfig":
@@ -179,14 +229,16 @@ def GetZypperUpdates(Name):
         zypper = 'zypper -q lu'
         # Refresh the repo.
         cmd = 'zypper -qn refresh'
+        LG().Log('DEBUG', "Executing cmd: " + cmd)
         code, out = RunGetOutput(cmd, False, False)
     cmd = 'LANG=en_US.UTF8 ' + zypper + ' | grep "|" | grep -vE "Status|Current Version"'
+    LG().Log('DEBUG', "Retrieving update package list using cmd:" + cmd)
     code, out = RunGetOutput(cmd, False, False)
     pkg_list = out
     if len(pkg_list) < 2:
         return updates_list
     for pkg in pkg_list.splitlines():
-        pkg=pkg.split('|')
+        pkg = pkg.split('|')
         d['BuildDate'] = ''
         d['Name'] = pkg[2].strip()
         if len(Name) and not fnmatch.fnmatch(d['Name'], Name):
@@ -195,8 +247,10 @@ def GetZypperUpdates(Name):
         d['Version'] = "0:" + pkg[4].strip()
         d['Repository'] = pkg[1].strip()
         updates_list.append(copy.deepcopy(d))
+    LG().Log('DEBUG', "Number of packages being written to the XML: " + str(len(updates_list)))
     return updates_list
-        
+
+
 def RunGetOutput(cmd, no_output, chk_err=True):
     """
     Wrapper for subprocess.check_output.
@@ -204,6 +258,7 @@ def RunGetOutput(cmd, no_output, chk_err=True):
     trapping expected exceptions.
     Reports exceptions to Error if chk_err parameter is True
     """
+
     def check_output(no_output, *popenargs, **kwargs):
         """
         Backport from subprocess module from python 2.7
@@ -218,6 +273,7 @@ def RunGetOutput(cmd, no_output, chk_err=True):
         process = subprocess.Popen(stdout=out_file, *popenargs, **kwargs)
         output, unused_err = process.communicate()
         retcode = process.poll()
+        #LG().Log('DEBUG', "return code is  " + str(retcode))
         if retcode:
             cmd = kwargs.get("args")
             if cmd is None:
@@ -244,17 +300,21 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             no_output, cmd, stderr=subprocess.STDOUT, shell=True)
     except subprocess.CalledProcessError, e:
         if chk_err:
-            Print("CalledProcessError.  Error Code is " + str(e.returncode), file=sys.stdout)
-            Print("CalledProcessError.  Command string was " + e.cmd, file=sys.stdout)
-            Print("CalledProcessError.  Command result was " + (e.output[:-1]).decode('utf8','ignore').encode("ascii", "ignore"), file=sys.stdout)
+            LG().Log('DEBUG', "CalledProcessError.  Error Code is " + str(e.returncode), file=sys.stdout)
+            LG().Log('DEBUG', "CalledProcessError.  Command string was " + e.cmd, file=sys.stdout)
+            LG().Log('DEBUG',
+                     "CalledProcessError.  Command result was " + (e.output[:-1]).decode('utf8', 'ignore').encode(
+                         "ascii",
+                         "ignore"),
+                     file=sys.stdout)
         if no_output:
             return e.returncode, None
         else:
-            return e.returncode, e.output.decode('utf8','ignore').encode('ascii', 'ignore')
+            return e.returncode, e.output.decode('utf8', 'ignore').encode('ascii', 'ignore')
     if no_output:
         return 0, None
     else:
-        return 0, output.decode('utf8','ignore').encode('ascii', 'ignore')
+        return 0, output.decode('utf8', 'ignore').encode('ascii', 'ignore')
 
 
 def GetPackageManager():
@@ -268,7 +328,3 @@ def GetPackageManager():
                 ret = 'apt'
             break
     return ret
-
-def Print(s, file=sys.stdout):
-    file.write(s + '\n')
-

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxAvailableUpdates.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxAvailableUpdates.py
@@ -3,7 +3,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # See license.txt for license information.
 # ===================================
-from __future__ import print_function
 
 import subprocess
 import sys
@@ -19,6 +18,7 @@ nxDSCLog = imp.load_source('nxDSCLog', '../nxDSCLog.py')
 helperlib = imp.load_source('helperlib', '../helperlib.py')
 LG = nxDSCLog.DSCLog
 
+
 # [ClassVersion("1.0.0"),FriendlyName("nxAvailableUpdates"),SupportsInventory()]
 # class MSFT_nxAvailableUpdatesResource : OMI_BaseResource
 # {
@@ -27,12 +27,12 @@ LG = nxDSCLog.DSCLog
 #   [read] string Repository;
 #   [read] string Version;
 #   [read] string Architecture;
- 
+
 # };
 
 def Inventory_Marshall(Name):
     if Name is not None and len(Name) > 0:
-        Name = Name.encode('ascii','ignore')
+        Name = Name.encode('ascii', 'ignore')
     retval, pkgs = GetUpdates(Name)
     for p in pkgs:
         p['Name'] = protocol.MI_String(p['Name'])
@@ -40,16 +40,17 @@ def Inventory_Marshall(Name):
         p['Repository'] = protocol.MI_String(p['Repository'])
         p['Version'] = protocol.MI_String(p['Version'])
         p['Architecture'] = protocol.MI_String(p['Architecture'])
-    Inventory=protocol.MI_InstanceA(pkgs)
+    Inventory = protocol.MI_InstanceA(pkgs)
     retd = {}
     retd["__Inventory"] = Inventory
     return retval, retd
 
+
 def GetUpdates(Name):
-    d={}
+    d = {}
+    LG().Log('DEBUG', "Starting to check Available Updates")
     mgr = GetPackageManager()
     if mgr == None:
-        print("ERROR: Unable to find one of 'apt', 'yum', or 'zypper'.")
         LG().Log('ERROR', "Unable to find one of 'apt', 'yum', or 'zypper'.")
         return -1, d
     if mgr == 'apt':
@@ -58,7 +59,9 @@ def GetUpdates(Name):
         d = GetYumUpdates(Name)
     elif mgr == 'zypper':
         d = GetZypperUpdates(Name)
+    LG().Log('DEBUG', "Completed checking Available Updates")
     return 0, d
+
 
 def GetAptUpdates(Name):
     # Format:
@@ -66,7 +69,7 @@ def GetAptUpdates(Name):
     # Inst sosreport [3.2-2ubuntu1] (3.2-2ubuntu1.1 Ubuntu:15.10/wily-updates [amd64])
 
     updates_list = []
-    d={}
+    d = {}
     # Refresh the repo
     if helperlib.CONFIG_SYSCONFDIR_DSC == "omsconfig":
         cmd = 'sudo /opt/microsoft/omsconfig/Scripts/OMSAptUpdates.sh'
@@ -74,12 +77,13 @@ def GetAptUpdates(Name):
         cmd = 'apt-get -q update'
     code, out = RunGetOutput(cmd, False, False)
     cmd = 'LANG=en_US.UTF8 apt-get -s dist-upgrade | grep "^Inst"'
+    LG().Log('DEBUG', "Retrieving update package list using cmd:" + cmd)
     code, out = RunGetOutput(cmd, False, False)
-    if len(out) < 2 :
+    if len(out) < 2:
         return updates_list
-    srch_txt=r'Inst[ ](.*?)[ ].*?[(](.*?)[ ](.*?)[ ]\[(.*?)\]'
-    srch=re.compile(srch_txt, re.M|re.S)
-    pkg_list=srch.findall(out)
+    srch_txt = r'Inst[ ](.*?)[ ].*?[(](.*?)[ ](.*?)[ ]\[(.*?)\]'
+    srch = re.compile(srch_txt, re.M | re.S)
+    pkg_list = srch.findall(out)
     for pkg in pkg_list:
         d['BuildDate'] = ''
         d['Name'] = pkg[0]
@@ -89,8 +93,9 @@ def GetAptUpdates(Name):
         d['Version'] = pkg[1]
         d['Repository'] = pkg[2]
         updates_list.append(copy.deepcopy(d))
+    LG().Log('DEBUG', "Number of packages being written to the XML: " + str(len(updates_list)))
     return updates_list
-         
+
 
 def GetYumUpdates(Name):
     # Format:
@@ -106,16 +111,15 @@ def GetYumUpdates(Name):
     # Epoch and Buildtime are not available for 'yum info available'.
     # If 'repoquery is installed Epoch and Buildtime will be used.
     # Epoch is added to the front of the 'Version', and sanitized afterward.
-    
+
     updates_list = []
-    d={}
     # No need to refresh the repo - 'check-update' will do this.
 
     if os.path.exists('/usr/bin/repoquery'):
-        srch_str=r'Name.*?: (.*?)\n.*?Arch.*?: (.*?)\n.*?Version.*?: (.*?)\n.*?Release.*?: (.*?)\n.*?Repo.*?: (.*?)\n.*?Buildtime.*?: (.*?)\n'
+        srch_str = r'Name.*?: (.*?)\n.*?Arch.*?: (.*?)\n.*?Version.*?: (.*?)\n.*?Release.*?: (.*?)\n.*?Repo.*?: (.*?)\n.*?Buildtime.*?: (.*?)\n'
     else:
-        srch_str=r'Name.*?: (.*?)\n.*?Arch.*?: (.*?)\n.*?Version.*?: (.*?)\n.*?Release.*?: (.*?)\n.*?Repo.*?: (.*?)\n'
-        
+        srch_str = r'Name.*?: (.*?)\n.*?Arch.*?: (.*?)\n.*?Version.*?: (.*?)\n.*?Release.*?: (.*?)\n.*?Repo.*?: (.*?)\n'
+
     if helperlib.CONFIG_SYSCONFDIR_DSC == "omsconfig":
         yum_list = 'sudo /opt/microsoft/omsconfig/Scripts/OMSYumUpdates.sh '
         yum_info = yum_list
@@ -125,43 +129,88 @@ def GetYumUpdates(Name):
             yum_info = 'repoquery --queryformat "Name : %{NAME}\nArch : %{ARCH}\nVersion :  %{EPOCH}:%{VERSION}\nRelease : %{RELEASE}\nRepo : %{REPO}\nBuildtime : %{BUILDTIME}" '
         else:
             yum_info = 'yum info available '
-    cmd = "LANG=en_US.UTF8 " + yum_list + "| awk '{print $1}'"
-    code, pkg_list = RunGetOutput(cmd, False, False)
-    if len(pkg_list) < 2 :
-        LG().Log('INFO', "Nothing to send info on. No packages")
-        return updates_list
-    # Remove the chatter.  Yum puts a blank line before the list.
-    if pkg_list.find('\n\n') > -1:
-        pkg_list = pkg_list[pkg_list.find('\n\n')+2:]
-    LG().Log('DEBUG', "Number of packages: " + str(len(pkg_list.splitlines())))
-    srch = re.compile(srch_str, re.M | re.S)
-    for pkg in pkg_list.splitlines():
-        if len(pkg) < 2 :
-            LG().Log('VERBOSE', "Avoiding very small entries.")
-            continue
-        cmd = "LANG=en_US.UTF8 " + yum_info + pkg
+    cmd = "LANG=en_US.UTF8 " + yum_list
+    start_time = time.time()
+    LG().Log('DEBUG', "Retrieving update package list using cmd: " + cmd)
+    retcode, pkg_list = RunGetOutput(cmd, False, False)
+    LG().Log('DEBUG', "Cmd execution time: " + str((time.time() - start_time) / 60))
+    #LG().Log('DEBUG', "Cmd output for update list : " + pkg_list)    
+
+    # Sample output from OMSYumUpdates.sh
+    #   ca-certificates.noarch
+    #   glibc.x86_64
+    #   glibc-common.x86_64
+    #   glibc-devel.x86_64
+    #   glibc-headers.x86_64
+    if validate_yum_pkg_list_output(pkg_list, retcode):
+        # Remove the chatter.  Yum puts a blank line before the list.
+        if pkg_list.find('\n\n') > -1:
+            pkg_list = pkg_list[pkg_list.find('\n\n') + 2:]
+        LG().Log('DEBUG', "Number of packages to be updated: " + str(len(pkg_list.splitlines())))
+        srch = re.compile(srch_str, re.M | re.S)
+
+        param_list = ""
+        for pkg in pkg_list.splitlines():
+            param_list = param_list + " " + pkg
+
+        cmd = "LANG=en_US.UTF8 " + yum_info + param_list
+        LG().Log('DEBUG', "Retrieving individual package information from Yum using cmd: " + cmd)
+        start_time = time.time()
         code, out = RunGetOutput(cmd, False, False)
+        LG().Log('DEBUG', "Cmd execution time: " + str((time.time() - start_time) / 60))
+        #LG().Log('DEBUG', "Cmd output is : " + out)
+        updates_list = []
         if len(out) < 1 or ':' not in out:
-            LG().Log('DEBUG', "Checking the output in 'out': " + out)
-            continue
-        m = srch.search(out)
-        if m == None:
-            continue
-        d['Name'] = m.group(1)
-        if len(Name) and not fnmatch.fnmatch(d['Name'], Name):
-            continue
-        d['Architecture'] = m.group(2)
-        d['Version'] =  m.group(3) + '-' + m.group(4)
-        if ':' not in d['Version']: # Add a '0:' for epoch.
-            d['Version'] = '0:' + d['Version']
-        d['Version'] = d['Version'].replace('(none)','0') # Handle the Epoch '(none)'. 
-        d['Repository'] = m.group(5)
-        d['BuildDate'] = ''
-        if len(m.groups()) == 6: # Buildtime
-            d['BuildDate'] = time.asctime(time.gmtime(int(m.group(6))))
-        updates_list.append(copy.deepcopy(d))
+            LG().Log('DEBUG', "Failed retrieving individual package info. Output is too small : " + out)
+            return updates_list
+        yum_pkg_info_list = srch.finditer(out)
+        updates_list = get_yum_updates_list(yum_pkg_info_list, Name)
     LG().Log('DEBUG', "Number of packages being written to the XML: " + str(len(updates_list)))
     return updates_list
+
+
+def get_yum_updates_list(yum_pkg_info_list, Name):
+    d = {}
+    updates_list = []
+    for yum_pkg_info in yum_pkg_info_list:
+        d['Name'] = yum_pkg_info.group(1)
+        if len(Name) and not fnmatch.fnmatch(d['Name'], Name):
+            continue
+        d['Architecture'] = yum_pkg_info.group(2)
+        d['Version'] = yum_pkg_info.group(3) + '-' + yum_pkg_info.group(4)
+        if ':' not in d['Version']:  # Add a '0:' for epoch.
+            d['Version'] = '0:' + d['Version']
+        d['Version'] = d['Version'].replace('(none)', '0')  # Handle the Epoch '(none)'.
+        d['Repository'] = yum_pkg_info.group(5)
+        d['BuildDate'] = ''
+        if len(yum_pkg_info.groups()) == 6:  # Buildtime
+            d['BuildDate'] = time.asctime(time.gmtime(int(yum_pkg_info.group(6))))
+        updates_list.append(copy.deepcopy(d))
+    return updates_list
+
+
+def validate_yum_pkg_list_output(pkg_list, retcode):
+    repo_urls_unreachable_error = "Could not contact any CDS load balancers"
+    repo_urls_unconfigured_error = "Cannot find a valid baseurl for repo"
+    yum_packageupdates_available_exitcode = 100
+    yum_no_applicable_packages_exitcode = 0
+
+    if retcode == yum_packageupdates_available_exitcode:
+        if len(pkg_list) < 2:
+            LG().Log('INFO', "Nothing to send info on. No packages")
+        else:
+            return True
+    elif retcode == yum_no_applicable_packages_exitcode:
+        LG().Log('DEBUG', "No packages are available for update")
+    else:
+        LG().Log('DEBUG', "Error return code when retrieving update package list: " + str(retcode))
+        LG().Log('DEBUG', "Output when retrieving update package list: " + str(pkg_list))
+        if repo_urls_unreachable_error in str(pkg_list):
+            LG().Log('DEBUG', "Unable to contact YUM repos" + str(pkg_list))
+        if repo_urls_unconfigured_error in str(pkg_list):
+            LG().Log('DEBUG', "YUM Repo urls are not configured" + str(pkg_list))
+    return False
+
 
 def GetZypperUpdates(Name):
     # Format:
@@ -171,7 +220,7 @@ def GetZypperUpdates(Name):
     # SLES11-SP3-Updates | slessp3-WALinuxAgent-12085 | 1       | recommended | needed
 
     updates_list = []
-    d={}
+    d = {}
     pkg_list = ''
     # For omsagent the repo is refreshed in OMSZypperUpdates.sh.
     if helperlib.CONFIG_SYSCONFDIR_DSC == "omsconfig":
@@ -180,14 +229,16 @@ def GetZypperUpdates(Name):
         zypper = 'zypper -q lu'
         # Refresh the repo.
         cmd = 'zypper -qn refresh'
+        LG().Log('DEBUG', "Executing cmd: " + cmd)
         code, out = RunGetOutput(cmd, False, False)
     cmd = 'LANG=en_US.UTF8 ' + zypper + ' | grep "|" | grep -vE "Status|Current Version"'
+    LG().Log('DEBUG', "Retrieving update package list using cmd:" + cmd)
     code, out = RunGetOutput(cmd, False, False)
     pkg_list = out
     if len(pkg_list) < 2:
         return updates_list
     for pkg in pkg_list.splitlines():
-        pkg=pkg.split('|')
+        pkg = pkg.split('|')
         d['BuildDate'] = ''
         d['Name'] = pkg[2].strip()
         if len(Name) and not fnmatch.fnmatch(d['Name'], Name):
@@ -196,8 +247,10 @@ def GetZypperUpdates(Name):
         d['Version'] = "0:" + pkg[4].strip()
         d['Repository'] = pkg[1].strip()
         updates_list.append(copy.deepcopy(d))
+    LG().Log('DEBUG', "Number of packages being written to the XML: " + str(len(updates_list)))
     return updates_list
-        
+
+
 def RunGetOutput(cmd, no_output, chk_err=True):
     """
     Wrapper for subprocess.check_output.
@@ -205,6 +258,7 @@ def RunGetOutput(cmd, no_output, chk_err=True):
     trapping expected exceptions.
     Reports exceptions to Error if chk_err parameter is True
     """
+
     def check_output(no_output, *popenargs, **kwargs):
         """
         Backport from subprocess module from python 2.7
@@ -219,6 +273,7 @@ def RunGetOutput(cmd, no_output, chk_err=True):
         process = subprocess.Popen(stdout=out_file, *popenargs, **kwargs)
         output, unused_err = process.communicate()
         retcode = process.poll()
+        #LG().Log('DEBUG', "return code is  " + str(retcode))
         if retcode:
             cmd = kwargs.get("args")
             if cmd is None:
@@ -245,17 +300,21 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             no_output, cmd, stderr=subprocess.STDOUT, shell=True)
     except subprocess.CalledProcessError, e:
         if chk_err:
-            print("CalledProcessError.  Error Code is " + str(e.returncode), file=sys.stdout)
-            print("CalledProcessError.  Command string was " + e.cmd, file=sys.stdout)
-            print("CalledProcessError.  Command result was " + (e.output[:-1]).decode('utf8','ignore').encode("ascii", "ignore"), file=sys.stdout)
+            LG().Log('DEBUG', "CalledProcessError.  Error Code is " + str(e.returncode), file=sys.stdout)
+            LG().Log('DEBUG', "CalledProcessError.  Command string was " + e.cmd, file=sys.stdout)
+            LG().Log('DEBUG',
+                     "CalledProcessError.  Command result was " + (e.output[:-1]).decode('utf8', 'ignore').encode(
+                         "ascii",
+                         "ignore"),
+                     file=sys.stdout)
         if no_output:
             return e.returncode, None
         else:
-            return e.returncode, e.output.decode('utf8','ignore').encode('ascii', 'ignore')
+            return e.returncode, e.output.decode('utf8', 'ignore').encode('ascii', 'ignore')
     if no_output:
         return 0, None
     else:
-        return 0, output.decode('utf8','ignore').encode('ascii', 'ignore')
+        return 0, output.decode('utf8', 'ignore').encode('ascii', 'ignore')
 
 
 def GetPackageManager():

--- a/Providers/Scripts/3.x/Scripts/nxAvailableUpdates.py
+++ b/Providers/Scripts/3.x/Scripts/nxAvailableUpdates.py
@@ -18,6 +18,7 @@ nxDSCLog = imp.load_source('nxDSCLog', '../nxDSCLog.py')
 helperlib = imp.load_source('helperlib', '../helperlib.py')
 LG = nxDSCLog.DSCLog
 
+
 # [ClassVersion("1.0.0"),FriendlyName("nxAvailableUpdates"),SupportsInventory()]
 # class MSFT_nxAvailableUpdatesResource : OMI_BaseResource
 # {
@@ -26,7 +27,7 @@ LG = nxDSCLog.DSCLog
 #   [read] string Repository;
 #   [read] string Version;
 #   [read] string Architecture;
- 
+
 # };
 
 def Inventory_Marshall(Name):
@@ -37,16 +38,17 @@ def Inventory_Marshall(Name):
         p['Repository'] = protocol.MI_String(p['Repository'])
         p['Version'] = protocol.MI_String(p['Version'])
         p['Architecture'] = protocol.MI_String(p['Architecture'])
-    Inventory=protocol.MI_InstanceA(pkgs)
+    Inventory = protocol.MI_InstanceA(pkgs)
     retd = {}
     retd["__Inventory"] = Inventory
     return retval, retd
 
+
 def GetUpdates(Name):
-    d={}
+    d = {}
+    LG().Log('DEBUG', "Starting to check Available Updates")
     mgr = GetPackageManager()
     if mgr == None:
-        print("ERROR: Unable to find one of 'apt', 'yum', or 'zypper'.")
         LG().Log('ERROR', "Unable to find one of 'apt', 'yum', or 'zypper'.")
         return -1, d
     if mgr == 'apt':
@@ -55,7 +57,9 @@ def GetUpdates(Name):
         d = GetYumUpdates(Name)
     elif mgr == 'zypper':
         d = GetZypperUpdates(Name)
+    LG().Log('DEBUG', "Completed checking Available Updates")
     return 0, d
+
 
 def GetAptUpdates(Name):
     # Format:
@@ -63,7 +67,7 @@ def GetAptUpdates(Name):
     # Inst sosreport [3.2-2ubuntu1] (3.2-2ubuntu1.1 Ubuntu:15.10/wily-updates [amd64])
 
     updates_list = []
-    d={}
+    d = {}
     # Refresh the repo
     if helperlib.CONFIG_SYSCONFDIR_DSC == "omsconfig":
         cmd = 'sudo /opt/microsoft/omsconfig/Scripts/OMSAptUpdates.sh'
@@ -71,12 +75,13 @@ def GetAptUpdates(Name):
         cmd = 'apt-get -q update'
     code, out = RunGetOutput(cmd, False, False)
     cmd = 'LANG=en_US.UTF8 apt-get -s dist-upgrade | grep "^Inst"'
+    LG().Log('DEBUG', "Retrieving update package list using cmd:" + cmd)
     code, out = RunGetOutput(cmd, False, False)
-    if len(out) < 2 :
+    if len(out) < 2:
         return updates_list
-    srch_txt=r'Inst[ ](.*?)[ ].*?[(](.*?)[ ](.*?)[ ]\[(.*?)\]'
-    srch=re.compile(srch_txt, re.M|re.S)
-    pkg_list=srch.findall(out)
+    srch_txt = r'Inst[ ](.*?)[ ].*?[(](.*?)[ ](.*?)[ ]\[(.*?)\]'
+    srch = re.compile(srch_txt, re.M | re.S)
+    pkg_list = srch.findall(out)
     for pkg in pkg_list:
         d['BuildDate'] = ''
         d['Name'] = pkg[0]
@@ -86,8 +91,9 @@ def GetAptUpdates(Name):
         d['Version'] = pkg[1]
         d['Repository'] = pkg[2]
         updates_list.append(copy.deepcopy(d))
+    LG().Log('DEBUG', "Number of packages being written to the XML: " + str(len(updates_list)))
     return updates_list
-         
+
 
 def GetYumUpdates(Name):
     # Format:
@@ -103,16 +109,15 @@ def GetYumUpdates(Name):
     # Epoch and Buildtime are not available for 'yum info available'.
     # If 'repoquery is installed Epoch and Buildtime will be used.
     # Epoch is added to the front of the 'Version', and sanitized afterward.
-    
+
     updates_list = []
-    d={}
     # No need to refresh the repo - 'check-update' will do this.
 
     if os.path.exists('/usr/bin/repoquery'):
-        srch_str=r'Name.*?: (.*?)\n.*?Arch.*?: (.*?)\n.*?Version.*?: (.*?)\n.*?Release.*?: (.*?)\n.*?Repo.*?: (.*?)\n.*?Buildtime.*?: (.*?)\n'
+        srch_str = r'Name.*?: (.*?)\n.*?Arch.*?: (.*?)\n.*?Version.*?: (.*?)\n.*?Release.*?: (.*?)\n.*?Repo.*?: (.*?)\n.*?Buildtime.*?: (.*?)\n'
     else:
-        srch_str=r'Name.*?: (.*?)\n.*?Arch.*?: (.*?)\n.*?Version.*?: (.*?)\n.*?Release.*?: (.*?)\n.*?Repo.*?: (.*?)\n'
-        
+        srch_str = r'Name.*?: (.*?)\n.*?Arch.*?: (.*?)\n.*?Version.*?: (.*?)\n.*?Release.*?: (.*?)\n.*?Repo.*?: (.*?)\n'
+
     if helperlib.CONFIG_SYSCONFDIR_DSC == "omsconfig":
         yum_list = 'sudo /opt/microsoft/omsconfig/Scripts/OMSYumUpdates.sh '
         yum_info = yum_list
@@ -122,43 +127,88 @@ def GetYumUpdates(Name):
             yum_info = 'repoquery --queryformat "Name : %{NAME}\nArch : %{ARCH}\nVersion :  %{EPOCH}:%{VERSION}\nRelease : %{RELEASE}\nRepo : %{REPO}\nBuildtime : %{BUILDTIME}" '
         else:
             yum_info = 'yum info available '
-    cmd = "LANG=en_US.UTF8 " + yum_list + "| awk '{print $1}'"
-    code, pkg_list = RunGetOutput(cmd, False, False)
-    if len(pkg_list) < 2 :
-        LG().Log('INFO', "Nothing to send info on. No packages")
-        return updates_list
-    # Remove the chatter.  Yum puts a blank line before the list.
-    if pkg_list.find('\n\n') > -1:
-        pkg_list = pkg_list[pkg_list.find('\n\n')+2:]
-    LG().Log('DEBUG', "Number of packages: " + str(len(pkg_list.splitlines())))
-    srch = re.compile(srch_str, re.M | re.S)
-    for pkg in pkg_list.splitlines():
-        if len(pkg) < 2 :
-            LG().Log('VERBOSE', "Avoiding very small entries.")
-            continue
-        cmd = "LANG=en_US.UTF8 " + yum_info + pkg
+    cmd = "LANG=en_US.UTF8 " + yum_list
+    start_time = time.time()
+    LG().Log('DEBUG', "Retrieving update package list using cmd: " + cmd)
+    retcode, pkg_list = RunGetOutput(cmd, False, False)
+    LG().Log('DEBUG', "Cmd execution time: " + str((time.time() - start_time) / 60))
+    #LG().Log('DEBUG', "Cmd output for update list : " + pkg_list)    
+
+    # Sample output from OMSYumUpdates.sh
+    #   ca-certificates.noarch
+    #   glibc.x86_64
+    #   glibc-common.x86_64
+    #   glibc-devel.x86_64
+    #   glibc-headers.x86_64
+    if validate_yum_pkg_list_output(pkg_list, retcode):
+        # Remove the chatter.  Yum puts a blank line before the list.
+        if pkg_list.find('\n\n') > -1:
+            pkg_list = pkg_list[pkg_list.find('\n\n') + 2:]
+        LG().Log('DEBUG', "Number of packages to be updated: " + str(len(pkg_list.splitlines())))
+        srch = re.compile(srch_str, re.M | re.S)
+
+        param_list = ""
+        for pkg in pkg_list.splitlines():
+            param_list = param_list + " " + pkg
+
+        cmd = "LANG=en_US.UTF8 " + yum_info + param_list
+        LG().Log('DEBUG', "Retrieving individual package information from Yum using cmd: " + cmd)
+        start_time = time.time()
         code, out = RunGetOutput(cmd, False, False)
+        LG().Log('DEBUG', "Cmd execution time: " + str((time.time() - start_time) / 60))
+        #LG().Log('DEBUG', "Cmd output is : " + out)
+        updates_list = []
         if len(out) < 1 or ':' not in out:
-            LG().Log('DEBUG', "Checking the output in 'out': " + out)
-            continue
-        m = srch.search(out)
-        if m == None:
-            continue
-        d['Name'] = m.group(1)
-        if len(Name) and not fnmatch.fnmatch(d['Name'], Name):
-            continue
-        d['Architecture'] = m.group(2)
-        d['Version'] =  m.group(3) + '-' + m.group(4)
-        if ':' not in d['Version']: # Add a '0:' for epoch.
-            d['Version'] = '0:' + d['Version']
-        d['Version'] = d['Version'].replace('(none)','0') # Handle the Epoch '(none)'. 
-        d['Repository'] = m.group(5)
-        d['BuildDate'] = ''
-        if len(m.groups()) == 6: # Buildtime
-            d['BuildDate'] = time.asctime(time.gmtime(int(m.group(6))))
-        updates_list.append(copy.deepcopy(d))
+            LG().Log('DEBUG', "Failed retrieving individual package info. Output is too small : " + out)
+            return updates_list
+        yum_pkg_info_list = srch.finditer(out)
+        updates_list = get_yum_updates_list(yum_pkg_info_list, Name)
     LG().Log('DEBUG', "Number of packages being written to the XML: " + str(len(updates_list)))
     return updates_list
+
+
+def get_yum_updates_list(yum_pkg_info_list, Name):
+    d = {}
+    updates_list = []
+    for yum_pkg_info in yum_pkg_info_list:
+        d['Name'] = yum_pkg_info.group(1)
+        if len(Name) and not fnmatch.fnmatch(d['Name'], Name):
+            continue
+        d['Architecture'] = yum_pkg_info.group(2)
+        d['Version'] = yum_pkg_info.group(3) + '-' + yum_pkg_info.group(4)
+        if ':' not in d['Version']:  # Add a '0:' for epoch.
+            d['Version'] = '0:' + d['Version']
+        d['Version'] = d['Version'].replace('(none)', '0')  # Handle the Epoch '(none)'.
+        d['Repository'] = yum_pkg_info.group(5)
+        d['BuildDate'] = ''
+        if len(yum_pkg_info.groups()) == 6:  # Buildtime
+            d['BuildDate'] = time.asctime(time.gmtime(int(yum_pkg_info.group(6))))
+        updates_list.append(copy.deepcopy(d))
+    return updates_list
+
+
+def validate_yum_pkg_list_output(pkg_list, retcode):
+    repo_urls_unreachable_error = "Could not contact any CDS load balancers"
+    repo_urls_unconfigured_error = "Cannot find a valid baseurl for repo"
+    yum_packageupdates_available_exitcode = 100
+    yum_no_applicable_packages_exitcode = 0
+
+    if retcode == yum_packageupdates_available_exitcode:
+        if len(pkg_list) < 2:
+            LG().Log('INFO', "Nothing to send info on. No packages")
+        else:
+            return True
+    elif retcode == yum_no_applicable_packages_exitcode:
+        LG().Log('DEBUG', "No packages are available for update")
+    else:
+        LG().Log('DEBUG', "Error return code when retrieving update package list: " + str(retcode))
+        LG().Log('DEBUG', "Output when retrieving update package list: " + str(pkg_list))
+        if repo_urls_unreachable_error in str(pkg_list):
+            LG().Log('DEBUG', "Unable to contact YUM repos" + str(pkg_list))
+        if repo_urls_unconfigured_error in str(pkg_list):
+            LG().Log('DEBUG', "YUM Repo urls are not configured" + str(pkg_list))
+    return False
+
 
 def GetZypperUpdates(Name):
     # Format:
@@ -168,7 +218,7 @@ def GetZypperUpdates(Name):
     # SLES11-SP3-Updates | slessp3-WALinuxAgent-12085 | 1       | recommended | needed
 
     updates_list = []
-    d={}
+    d = {}
     pkg_list = ''
     # For omsagent the repo is refreshed in OMSZypperUpdates.sh.
     if helperlib.CONFIG_SYSCONFDIR_DSC == "omsconfig":
@@ -177,14 +227,16 @@ def GetZypperUpdates(Name):
         zypper = 'zypper -q lu'
         # Refresh the repo.
         cmd = 'zypper -qn refresh'
+        LG().Log('DEBUG', "Executing cmd: " + cmd)
         code, out = RunGetOutput(cmd, False, False)
     cmd = 'LANG=en_US.UTF8 ' + zypper + ' | grep "|" | grep -vE "Status|Current Version"'
+    LG().Log('DEBUG', "Retrieving update package list using cmd:" + cmd)
     code, out = RunGetOutput(cmd, False, False)
     pkg_list = out
     if len(pkg_list) < 2:
         return updates_list
     for pkg in pkg_list.splitlines():
-        pkg=pkg.split('|')
+        pkg = pkg.split('|')
         d['BuildDate'] = ''
         d['Name'] = pkg[2].strip()
         if len(Name) and not fnmatch.fnmatch(d['Name'], Name):
@@ -193,7 +245,10 @@ def GetZypperUpdates(Name):
         d['Version'] = "0:" + pkg[4].strip()
         d['Repository'] = pkg[1].strip()
         updates_list.append(copy.deepcopy(d))
+    LG().Log('DEBUG', "Number of packages being written to the XML: " + str(len(updates_list)))
     return updates_list
+
+
         
 def RunGetOutput(cmd, no_output, chk_err=True):
     """

--- a/Providers/Scripts/OMSYumUpdates.sh
+++ b/Providers/Scripts/OMSYumUpdates.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
 if [ "$1" = "" ]; then
-    yum check-update
+    yum check-update |  awk '{print $1}' 
+    exit ${PIPESTATUS[0]}   
 else
     if [ -e "/usr/bin/repoquery" ]; then
-	repoquery --queryformat "Name : %{NAME}\nArch : %{ARCH}\nVersion :  %{EPOCH}:%{VERSION}\nRelease : %{RELEASE}\nRepo : %{REPO}\nBuildtime : %{BUILDTIME}" $1
+	    repoquery --queryformat "Name : %{NAME}\nArch : %{ARCH}\nVersion :  %{EPOCH}:%{VERSION}\nRelease : %{RELEASE}\nRepo : %{REPO}\nBuildtime : %{BUILDTIME}" $*
     else
-	yum info available $1
+	    yum info available $*
     fi
 fi


### PR DESCRIPTION
1) improves the performance of YUM Update assessment by querying the repo only once for package updates instead of  per package.
2) error handling when the repos are not reachable, any other unknown errors
3) modified the yum return codes to validate output -ensuring there are no hangs by text processing these error messages
4) adds logging for all distros


tests:
1)verified that the performace improved by 40% just with 5 updates.. as its not directly proportional between repo queries and number of packages, the performance gain increases as the packages count increases
2) tested for error handling 
3) tested for return codes from yum- 
