### PR TITLE
Bump nxOMSPerfCounter to 2.1: omsagent restart bug fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,7 +288,7 @@ nxMySQL:
 
 nxOMSPerfCounter:
 	rm -rf output/staging; \
-        VERSION="2.0"; \
+        VERSION="2.1"; \
         PROVIDERS="nxOMSPerfCounter"; \
         STAGINGDIR="output/staging/$@/DSCResources"; \
         cat Providers/Modules/$@.psd1 | sed "s@<MODULE_VERSION>@$${VERSION}@" > intermediate/Modules/$@.psd1; \

--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSPerfCounter.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSPerfCounter.py
@@ -249,9 +249,9 @@ def UpdateOMSAgentConf(WorkspaceID, HeartbeatIntervalSeconds, PerfCounterObject)
     global oms_restart_cmd
     process_to_restart = 'omsagent'
     if multi_homed:
-        restart_cmd += ' ' + WorkspaceID
+        oms_restart_cmd += ' ' + WorkspaceID
         process_to_restart += '-' + WorkspaceID
-    if os.system(restart_cmd) == 0:
+    if os.system(oms_restart_cmd) == 0:
         LG().Log('INFO', 'Successfully restarted ' + process_to_restart + '.')
     else:
         LG().Log('ERROR', 'Error restarting ' + process_to_restart + '.')

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSPerfCounter.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSPerfCounter.py
@@ -246,9 +246,9 @@ def UpdateOMSAgentConf(WorkspaceID, HeartbeatIntervalSeconds, PerfCounterObject)
     global oms_restart_cmd
     process_to_restart = 'omsagent'
     if multi_homed:
-        restart_cmd += ' ' + WorkspaceID
+        oms_restart_cmd += ' ' + WorkspaceID
         process_to_restart += '-' + WorkspaceID
-    if os.system(restart_cmd) == 0:
+    if os.system(oms_restart_cmd) == 0:
         LG().Log('INFO', 'Successfully restarted ' + process_to_restart + '.')
     else:
         LG().Log('ERROR', 'Error restarting ' + process_to_restart + '.')

--- a/Providers/Scripts/3.x/Scripts/nxOMSPerfCounter.py
+++ b/Providers/Scripts/3.x/Scripts/nxOMSPerfCounter.py
@@ -239,9 +239,9 @@ def UpdateOMSAgentConf(WorkspaceID, HeartbeatIntervalSeconds, PerfCounterObject)
     global oms_restart_cmd
     process_to_restart = 'omsagent'
     if multi_homed:
-        restart_cmd += ' ' + WorkspaceID
+        oms_restart_cmd += ' ' + WorkspaceID
         process_to_restart += '-' + WorkspaceID
-    if os.system(restart_cmd) == 0:
+    if os.system(oms_restart_cmd) == 0:
         LG().Log('INFO', 'Successfully restarted ' + process_to_restart + '.')
     else:
         LG().Log('ERROR', 'Error restarting ' + process_to_restart + '.')

--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -56,7 +56,7 @@ SHLIB_EXT: 'so'
 /opt/microsoft/omsconfig/Scripts/OMSAuditdPlugin.sh; intermediate/Scripts/OMSAuditdPlugin.sh; 755; root; root
 /opt/microsoft/omsconfig/Scripts/OMS_MetaConfigHelper.py; intermediate/Scripts/OMS_MetaConfigHelper.py; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nx_1.1.zip; release/nx_1.1.zip; 755; ${{RUN_AS_USER}}; root
-/opt/microsoft/omsconfig/module_packages/nxOMSPerfCounter_2.0.zip; release/nxOMSPerfCounter_2.0.zip; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/omsconfig/module_packages/nxOMSPerfCounter_2.1.zip; release/nxOMSPerfCounter_2.1.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSSyslog_2.0.zip; release/nxOMSSyslog_2.0.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSKeyMgmt_1.0.zip; release/nxOMSKeyMgmt_1.0.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSCustomLog_1.0.zip; release/nxOMSCustomLog_1.0.zip; 755; ${{RUN_AS_USER}}; root
@@ -254,7 +254,7 @@ chown -R ${{RUN_AS_USER}} /opt/microsoft/omsconfig/Scripts
 
 # Set up the modules
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nx_1.1.zip 0"
-su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSPerfCounter_2.0.zip 0"
+su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSPerfCounter_2.1.zip 0"
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSSyslog_2.0.zip 0"
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSKeyMgmt_1.0.zip 0"
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSCustomLog_1.0.zip 0"


### PR DESCRIPTION
@Microsoft/omsagent-devs 
Corrected a bug causing the resource to generate an error in omsconfig.log and not correctly restart the omsagent process after changing its configuration
Tested locally, pBuild running now