### PR TITLE
Roll back the nx module version change

### DIFF
--- a/LCM/scripts/omi_preexec.sh
+++ b/LCM/scripts/omi_preexec.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 if [ ! -f /etc/opt/omi/conf/dsc/configuration/schema/MSFT_nxFileResource/MSFT_nxFileResource.schema.mof -o ! -f /opt/microsoft/dsc/Scripts/2.6x-2.7x/Scripts/nxFile.py -o ! -f /opt/omi/lib/libMSFT_nxFileResource.so ]; then
-    /opt/microsoft/dsc/Scripts/InstallModule.py /opt/microsoft/dsc/module_packages/nx_1.1.zip 0
+    /opt/microsoft/dsc/Scripts/InstallModule.py /opt/microsoft/dsc/module_packages/nx_1.0.zip 0
 fi
 exit 0

--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ providers:
 ifeq ($(BUILD_OMS),BUILD_OMS)
 nx:
 	rm -rf output/staging; \
-	VERSION="1.1"; \
+	VERSION="1.0"; \
 	PROVIDERS="nxService nxPackage nxUser nxGroup nxAvailableUpdates"; \
 	STAGINGDIR="output/staging/$@/DSCResources"; \
 	cat Providers/Modules/$@.psd1 | sed "s@<MODULE_VERSION>@$${VERSION}@" > intermediate/Modules/$@.psd1; \

--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -55,7 +55,7 @@ SHLIB_EXT: 'so'
 /opt/microsoft/omsconfig/Scripts/NPMAgentBinaryCap.sh; intermediate/Scripts/NPMAgentBinaryCap.sh; 755; root; root
 /opt/microsoft/omsconfig/Scripts/OMSAuditdPlugin.sh; intermediate/Scripts/OMSAuditdPlugin.sh; 755; root; root
 /opt/microsoft/omsconfig/Scripts/OMS_MetaConfigHelper.py; intermediate/Scripts/OMS_MetaConfigHelper.py; 755; ${{RUN_AS_USER}}; root
-/opt/microsoft/omsconfig/module_packages/nx_1.1.zip; release/nx_1.1.zip; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/omsconfig/module_packages/nx_1.0.zip; release/nx_1.0.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSPerfCounter_2.1.zip; release/nxOMSPerfCounter_2.1.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSSyslog_2.0.zip; release/nxOMSSyslog_2.0.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSKeyMgmt_1.0.zip; release/nxOMSKeyMgmt_1.0.zip; 755; ${{RUN_AS_USER}}; root
@@ -253,7 +253,7 @@ chown -R ${{RUN_AS_USER}} /opt/microsoft/omsagent/plugin
 chown -R ${{RUN_AS_USER}} /opt/microsoft/omsconfig/Scripts
 
 # Set up the modules
-su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nx_1.1.zip 0"
+su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nx_1.0.zip 0"
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSPerfCounter_2.1.zip 0"
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSSyslog_2.0.zip 0"
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSKeyMgmt_1.0.zip 0"


### PR DESCRIPTION
nx module is not a DSC resource publshed to cloud. also 1.0 module is being mentioned in the patch_management_inventory.mof, so for nx module to be increased we need to release nxomsplugin and upload the module. 
to mitigate the current issue, we are rolling back the version change and asking customer to upgrade the agent.

so rolling back the version changes

Pbuild is running 
