### PR TITLE
Rename PSDesiredStateConfiguration to match the actual modulename

### DIFF
--- a/LCM/Base_Inventory.mof
+++ b/LCM/Base_Inventory.mof
@@ -6,7 +6,7 @@ instance of MSFT_nxPackageResource
 {
                 Name = "*";
                 ResourceId = "[MSFT_nxPackageResource]Inventory";
-                ModuleName = "PSDesiredStateConfiguration";
+                ModuleName = "nx";
                 ModuleVersion = "1.0";
 
 
@@ -17,7 +17,7 @@ instance of MSFT_nxServiceResource
                 Name = "*";
                 Controller = "*";
                 ResourceId = "[MSFT_nxServiceResource]Inventory";
-                ModuleName = "PSDesiredStateConfiguration";
+                ModuleName = "nx";
                 ModuleVersion = "1.0";
 
 

--- a/Providers/Extras/Configuration_MOFs/nxFile_1.mof
+++ b/Providers/Extras/Configuration_MOFs/nxFile_1.mof
@@ -8,7 +8,7 @@ instance of MSFT_nxFileResource
 	Group = "root";
 	Mode = "644";
 	ResourceId = "[MSFT_nxFileResource]File1";
-	ModuleName = "PSDesiredStateConfiguration";
+	ModuleName = "nx";
 	ModuleVersion = "1.0";
 	
 	
@@ -20,7 +20,7 @@ instance of MSFT_nxFileResource
 	Ensure = "Present";
 	Type = "Directory";
 	ResourceId = "[MSFT_nxFileResource]Dir1";
-	ModuleName = "PSDesiredStateConfiguration";
+	ModuleName = "nx";
 	ModuleVersion = "1.0";
 	
 	
@@ -37,7 +37,7 @@ instance of MSFT_nxFileResource
 	Mode = "744";
 	Recurse = True;
 	ResourceId = "[MSFT_nxFileResource]Dir2";
-	ModuleName = "PSDesiredStateConfiguration";
+	ModuleName = "nx";
 	ModuleVersion = "1.0";
 	
 	

--- a/Providers/Extras/Configuration_MOFs/nxGroup_1.mof
+++ b/Providers/Extras/Configuration_MOFs/nxGroup_1.mof
@@ -5,7 +5,7 @@ instance of MSFT_nxGroupResource
 	MembersToInclude = { "root", "ftp",  "lp", "daemon", "apache", "johnkord" };
 	MembersToExclude = { "johnkord" };
 	ResourceId = "[MSFT_nxGroupResource]Test";
-	ModuleName = "PSDesiredStateConfiguration";
+	ModuleName = "nx";
 	ModuleVersion = "1.0";
 	
 	

--- a/Providers/Extras/Configuration_MOFs/nxScript_1.mof
+++ b/Providers/Extras/Configuration_MOFs/nxScript_1.mof
@@ -12,7 +12,7 @@ instance of MSFT_nxScriptResource
 	User = "johnkord";
 	Group = "johnkord";
 	ResourceId = "[MSFT_nxScriptResource]Script1";
-	ModuleName = "PSDesiredStateConfiguration";
+	ModuleName = "nx";
 	ModuleVersion = "1.0";
 	
 };

--- a/Providers/Extras/Configuration_MOFs/nxService_1.mof
+++ b/Providers/Extras/Configuration_MOFs/nxService_1.mof
@@ -6,7 +6,7 @@ instance of MSFT_nxServiceResource
 	State = "Stopped";
 	
 	ResourceId = "[MSFT_nxServiceResource]TestService";
-	ModuleName = "PSDesiredStateConfiguration";
+	ModuleName = "nx";
 	ModuleVersion = "1.0";
 
 };

--- a/Providers/Extras/Configuration_MOFs/nxUser_1.mof
+++ b/Providers/Extras/Configuration_MOFs/nxUser_1.mof
@@ -11,7 +11,7 @@ instance of MSFT_nxUserResource
 	FullName = "Dr. Test User";
 	
 	ResourceId = "[MSFT_nxUserResource]Test";
-	ModuleName = "PSDesiredStateConfiguration";
+	ModuleName = "nx";
 	ModuleVersion = "1.0";
 	
 	

--- a/Providers/Modules/Plugins/ChangeTracking/conf/change_tracking_inventory.mof
+++ b/Providers/Modules/Plugins/ChangeTracking/conf/change_tracking_inventory.mof
@@ -6,7 +6,7 @@ instance of MSFT_nxPackageResource
 {
                 Name = "*";
                 ResourceId = "[MSFT_nxPackageResource]Inventory";
-                ModuleName = "PSDesiredStateConfiguration";
+                ModuleName = "nx";
                 ModuleVersion = "1.0";
 
 

--- a/Providers/Modules/Plugins/ChangeTracking/conf/service_change_tracking_inventory.mof
+++ b/Providers/Modules/Plugins/ChangeTracking/conf/service_change_tracking_inventory.mof
@@ -7,7 +7,7 @@ instance of MSFT_nxServiceResource
                 Name = "*";
                 Controller = "*";
                 ResourceId = "[MSFT_nxServiceResource]Inventory";
-                ModuleName = "PSDesiredStateConfiguration";
+                ModuleName = "nx";
                 ModuleVersion = "1.0";
 
 

--- a/Providers/Modules/Plugins/PatchManagement/conf/patch_management_inventory.mof
+++ b/Providers/Modules/Plugins/PatchManagement/conf/patch_management_inventory.mof
@@ -6,7 +6,7 @@ instance of MSFT_nxAvailableUpdatesResource
 {
     Name = "*";
     ResourceId = "[MSFT_nxAvailableUpdates]Inventory";
-    ModuleName = "PSDesiredStateConfiguration";
+    ModuleName = "nx";
     ModuleVersion = "1.0";
 };
 

--- a/Providers/Scripts/2.4x-2.5x/Scripts/Tests/test_mofs/nxOMSGenerateInventoryMof_test.mof
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/Tests/test_mofs/nxOMSGenerateInventoryMof_test.mof
@@ -12,7 +12,7 @@ instance of MSFT_nxOMSGenerateInventoryMofInstance as $MSFT_nxOMSGenerateInvento
      "MaxContentsReturnable=0",
      "MaxOutputSize = 5000000",
      "ResourceId = \"[MSFT_nxFileInventoryResource]Inventory\"",
-     "ModuleName = \"PSDesiredStateConfiguration\"",
+     "ModuleName = \"nxFileInventory\"",
      "ModuleVersion = \"1.0\""
   };
 };

--- a/Providers/Scripts/2.6x-2.7x/Scripts/Tests/test_mofs/nxOMSGenerateInventoryMof_test.mof
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/Tests/test_mofs/nxOMSGenerateInventoryMof_test.mof
@@ -12,7 +12,7 @@ instance of MSFT_nxOMSGenerateInventoryMofInstance as $MSFT_nxOMSGenerateInvento
      "MaxContentsReturnable=0",
      "MaxOutputSize = 5000000",
      "ResourceId = \"[MSFT_nxFileInventoryResource]Inventory\"",
-     "ModuleName = \"PSDesiredStateConfiguration\"",
+     "ModuleName = \"nxFileInventory\"",
      "ModuleVersion = \"1.0\""
   };
 };

--- a/Providers/Scripts/3.x/Scripts/Tests/test_mofs/nxOMSGenerateInventoryMof_test.mof
+++ b/Providers/Scripts/3.x/Scripts/Tests/test_mofs/nxOMSGenerateInventoryMof_test.mof
@@ -12,7 +12,7 @@ instance of MSFT_nxOMSGenerateInventoryMofInstance as $MSFT_nxOMSGenerateInvento
      "MaxContentsReturnable=0",
      "MaxOutputSize = 5000000",
      "ResourceId = \"[MSFT_nxFileInventoryResource]Inventory\"",
-     "ModuleName = \"PSDesiredStateConfiguration\"",
+     "ModuleName = \"nxFileInventory\"",
      "ModuleVersion = \"1.0\""
   };
 };


### PR DESCRIPTION
This PR fixes the typo in the mof files that reference to DSC module PSDesiredStateConfiguration instead of nx and nxFileInventory.  Apparently, the module name is not used at the moment and by accident these mofs are parsed successfully, but eventually it will.
@gauravga , @Atchub 