### PR TITLE
Move AGENT_GUID to non-workspace-specific location to allow for single-machine agent ID

### DIFF
--- a/LCM/scripts/OMS_MetaConfigHelper.py
+++ b/LCM/scripts/OMS_MetaConfigHelper.py
@@ -4,6 +4,7 @@ import sys
 
 conf_path = "/etc/opt/microsoft/omsagent/conf/omsadmin.conf"
 metamof_path = "/etc/opt/omi/conf/omsconfig/generated_meta_config.mof"
+oms_agentid_path = "/etc/opt/microsoft/omsagent/agentid"
 agentid_path = "/etc/opt/omi/conf/omsconfig/agentid"
 omshelper_disable_path = "/etc/opt/omi/conf/omsconfig/omshelper_disable"
 
@@ -147,6 +148,12 @@ if disable_flag == True:
 if not os.path.isfile(omshelper_disable_path):
     # source the omsadmin conf file and get the key/value pairs
     keyvals = source_file(conf_path)
+    # If machine-wide agentid file is available, then read agent guid from there
+    if os.path.isfile(oms_agentid_path):
+        f = open(oms_agentid_path, "r")
+        contents = f.read().strip()
+        f.close()
+        keyvals["AGENT_GUID"] = contents
     
     # Looking for DSC_ENDPOINT and AGENT_GUID
 


### PR DESCRIPTION
Corresponding OMSAgent PR: https://github.com/Microsoft/OMS-Agent-for-Linux/pull/527

These two PRs must be merged at the same time.

@Microsoft/omsagent-devs 