### PR TITLE
Bump nxOMSPerfCounter to 2.2: ensure omi_mapping_path is specified

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,7 +288,7 @@ nxMySQL:
 
 nxOMSPerfCounter:
 	rm -rf output/staging; \
-        VERSION="2.1"; \
+        VERSION="2.2"; \
         PROVIDERS="nxOMSPerfCounter"; \
         STAGINGDIR="output/staging/$@/DSCResources"; \
         cat Providers/Modules/$@.psd1 | sed "s@<MODULE_VERSION>@$${VERSION}@" > intermediate/Modules/$@.psd1; \

--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSPerfCounter.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSPerfCounter.py
@@ -17,33 +17,43 @@ LG = nxDSCLog.DSCLog
 conf_path = '/etc/opt/microsoft/omsagent/conf/omsagent.conf'
 omi_map_path = '/etc/opt/microsoft/omsagent/conf/omsagent.d/omi_mapping.json'
 omi_map = None
-multi_homed = None
+workspace_specific = None
 non_mh_heartbeat_cmd = '/opt/microsoft/omsagent/bin/omsadmin.sh -b'
 oms_restart_cmd = 'sudo /opt/microsoft/omsagent/bin/service_control restart'
 
 def init_paths(WorkspaceID):
+    """
+    Initialize path values depending on workspace ID
+    """
     global conf_path
     global omi_map_path
-    global multi_homed
+    global workspace_specific
 
     omsagent_dir = '/etc/opt/microsoft/omsagent/'
-    mh_conf_dir = omsagent_dir + WorkspaceID + '/conf'
+    wspc_conf_dir = omsagent_dir + WorkspaceID + '/conf'
 
-    multi_homed = os.path.isdir(mh_conf_dir)
+    workspace_specific = os.path.isdir(wspc_conf_dir)
 
-    if multi_homed:
-        LG().Log('INFO', 'OMSAgent is multi-homed and resource is updating workspace ' + WorkspaceID)
-        conf_path = mh_conf_dir + '/omsagent.conf'
-        omi_map_path = mh_conf_dir + '/omsagent.d/omi_mapping.json'
+    if workspace_specific:
+        LG().Log('INFO', 'Configuration is in a workspace-specific path; ' \
+                         'resource is updating workspace ' + WorkspaceID)
+        conf_path = wspc_conf_dir + '/omsagent.conf'
+        omi_map_path = wspc_conf_dir + '/omsagent.d/omi_mapping.json'
 
 
 def init_omi_map():
+    """
+    Initialize OMI value mapping
+    """
     global omi_map
     txt = codecs.open(omi_map_path, 'r', 'utf8').read()
     omi_map = eval(txt)
 
 
 def init_vars(WorkspaceID, HeartbeatIntervalSeconds, PerfCounterObject):
+    """
+    Initialize global values
+    """
     init_paths(WorkspaceID)
     init_omi_map()
 
@@ -128,6 +138,7 @@ def Test(HeartbeatIntervalSeconds, PerfCounterObject):
         HeartbeatIntervalSeconds, PerfCounterObject)
     if NewHeartbeatIntervalSeconds != HeartbeatIntervalSeconds:
         return [-1]
+
     PerfCounterObject.sort()
     for perf in PerfCounterObject:
         perf['PerformanceCounter'].sort()
@@ -136,7 +147,11 @@ def Test(HeartbeatIntervalSeconds, PerfCounterObject):
     for perf in NewPerfs:
         perf['PerformanceCounter'].sort()
     if PerfCounterObject != NewPerfs:
-            return [-1]
+        return [-1]
+
+    # Check if the omi_mapping_path has been specified yet
+    if not CheckForOMIMappingPathInConf():
+        return [-1]
     return [0]
 
 
@@ -160,14 +175,14 @@ def TranslatePerfs(object_name, perfs):
 
 
 def ReadOMSAgentConf(HeartbeatIntervalSeconds, PerfCounterObject):
-    txt = ''
-    try:
-        txt = codecs.open(conf_path, 'r', 'utf8').read().encode(
-            'ascii', 'ignore')
-        LG().Log('INFO', 'Read omsagent configuration ' + conf_path + '.')
-    except:
-        LG().Log(
-            'ERROR', 'Unable to read omsagent configuration ' + conf_path + '.')
+    """
+    Read OMSAgent conf file and extract the current settings for
+    HeartbeatIntervalSeconds and perf objects
+    """
+    txt = get_conf_path_text()
+    if not txt:
+        return None, []
+
     heartbeat_srch_str = r'<source>.*?tag heartbeat.*?run_interval ([0-9]+[a-z])\n</source>\n'
     heartbeat_srch = re.compile(heartbeat_srch_str, re.M | re.S)
     m = heartbeat_srch.search(txt)
@@ -178,10 +193,9 @@ def ReadOMSAgentConf(HeartbeatIntervalSeconds, PerfCounterObject):
     else:
         interval = None
     new_heartbeat = interval
-    perf_src_srch_str = r'\n<source>\n  type oms_omi.*?object_name "(.*?)".*?instance_regex "(.*?)".*?counter_name_regex "(.*?)".*?interval ([0-9]+[a-z]).*?</source>\n'
-    perf_src_srch = re.compile(perf_src_srch_str, re.M | re.S)
+
     new_perfobj = []
-    sources = perf_src_srch.findall(txt)
+    sources = search_for_perf_sections(txt)
     inst = ''
     interval = 0
     for source in sources:
@@ -200,22 +214,22 @@ def ReadOMSAgentConf(HeartbeatIntervalSeconds, PerfCounterObject):
 
 
 def UpdateOMSAgentConf(WorkspaceID, HeartbeatIntervalSeconds, PerfCounterObject):
-    if os.path.exists(conf_path):
-        txt = codecs.open(conf_path, 'r', 'utf8').read().encode(
-            'ascii', 'ignore')
-        LG().Log('INFO', 'Read omsagent configuration ' + conf_path + '.')
-    else:
-        LG().Log(
-            'INFO', 'No omsagent configuration file present.  Will create new  configuration file at ' + conf_path + '.')
-        txt = ''
+    """
+    Write the new values given by parameters to the OMSAgent conf file
+    """
+    txt = get_conf_path_text()
+    if not txt:
+        LG().Log('INFO', 'Will create new configuration file at ' + conf_path + '.')
+
     heartbeat_srch_str = r'<source>.*?tag heartbeat.*?</source>\n'
     heartbeat_srch = re.compile(heartbeat_srch_str, re.M | re.S)
     heartbeat_cmd = non_mh_heartbeat_cmd
-    if multi_homed:
+    if workspace_specific:
         heartbeat_cmd = 'echo'
     heartbeat_src = '<source>\n  type exec\n  tag heartbeat.output\n  command ' + heartbeat_cmd + ' > /dev/null\n  format tsv\n  keys severity,message\n  run_interval ' + \
         str(HeartbeatIntervalSeconds) + 's\n</source>\n'
     txt = heartbeat_srch.sub(heartbeat_src, txt)
+
     d = {}
     perf_src_srch_str = r'\n<source>\n  type oms_omi.*?</source>\n'
     perf_src_srch = re.compile(perf_src_srch_str, re.M | re.S)
@@ -228,15 +242,18 @@ def UpdateOMSAgentConf(WorkspaceID, HeartbeatIntervalSeconds, PerfCounterObject)
             names = '(' + reduce(lambda x, y: x + '|' + y, d[k]) + ')'
             instances = re.sub(r'([><]|&gt|&lt)', '', perf['InstanceName'])
             instances = re.sub(r'([*])', '.*', instances)
+            # omi_map_path will be set to the appropriate value whether or not we are multi-homed
             new_source += '\n<source>\n  type oms_omi\n  object_name "' + k + '"\n  instance_regex "' + instances + \
                 '"\n  counter_name_regex "' + names + '"\n  interval ' + \
-                str(perf['IntervalSeconds']) + 's\n</source>\n'
+                str(perf['IntervalSeconds']) + 's\n  omi_mapping_path ' + omi_map_path + '\n</source>\n'
+
     m = heartbeat_srch.search(txt)
     if m is not None:
         i = m.end(0) + 1
         txt = txt[:i] + new_source + txt[i:]
     else:
         txt = new_source         
+
     try:
         codecs.open(conf_path, 'w', 'utf8').write(txt)
         LG().Log(
@@ -248,7 +265,7 @@ def UpdateOMSAgentConf(WorkspaceID, HeartbeatIntervalSeconds, PerfCounterObject)
 
     global oms_restart_cmd
     process_to_restart = 'omsagent'
-    if multi_homed:
+    if workspace_specific:
         oms_restart_cmd += ' ' + WorkspaceID
         process_to_restart += '-' + WorkspaceID
     if os.system(oms_restart_cmd) == 0:
@@ -259,18 +276,49 @@ def UpdateOMSAgentConf(WorkspaceID, HeartbeatIntervalSeconds, PerfCounterObject)
     return True
 
 
-def rm_unicode(obj):
-    if isinstance(obj, dict):
-        d = {}
-        for k, v in obj.iteritems():
-            d[rm_unicode(k)] = rm_unicode(v)
-        return d
-    elif isinstance(obj, list):
-        return [rm_unicode(i) for i in obj]
-    elif isinstance(obj, unicode):
-        return obj.encode('ascii', 'ignore')
+def CheckForOMIMappingPathInConf():
+    """
+    Return true if the omi_mapping_path has been specified in all perf
+    sections in conf_path
+    """
+    conf_path_txt = get_conf_path_text()
+    sources = search_for_perf_sections(conf_path_txt)
+    for source in sources:
+        try:
+            if 'omi_mapping_path' not in source[4]:
+                return False
+        except:
+            return False
+    return True
+
+
+def get_conf_path_text():
+    """
+    Get current text in the conf_path file
+    """
+    txt = ''
+    if os.path.exists(conf_path):
+        try:
+            txt = codecs.open(conf_path, 'r', 'utf8').read().encode('ascii',
+                                                                    'ignore')
+            LG().Log('INFO', 'Read omsagent configuration ' + conf_path + '.')
+        except:
+            LG().Log('ERROR', 'Unable to read omsagent configuration ' + conf_path + '.')
     else:
-        return obj
+        LG().Log('ERROR', 'No omsagent configuration file present.')
+    return txt
+
+
+def search_for_perf_sections(txt):
+    """
+    Returns all matches in txt for performance counter configuration
+    sections
+    """
+    perf_src_srch_str = r'\n<source>\n  type oms_omi.*?object_name "(.*?)".*?instance_regex "(.*?)".*?counter_name_regex "(.*?)".*?interval ([0-9]+[a-z])(.*?)</source>\n'
+    # Since this search uses re.S, newlines and omi_mapping_path will be
+    # matched
+    perf_src_srch = re.compile(perf_src_srch_str, re.M | re.S)
+    return perf_src_srch.findall(txt)
 
 
 def prune_perfs(PerfCounterObject):

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSPerfCounter.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSPerfCounter.py
@@ -8,6 +8,7 @@ import imp
 import re
 import codecs
 import json
+
 protocol = imp.load_source('protocol', '../protocol.py')
 nxDSCLog = imp.load_source('nxDSCLog', '../nxDSCLog.py')
 
@@ -17,33 +18,43 @@ LG = nxDSCLog.DSCLog
 conf_path = '/etc/opt/microsoft/omsagent/conf/omsagent.conf'
 omi_map_path = '/etc/opt/microsoft/omsagent/conf/omsagent.d/omi_mapping.json'
 omi_map = None
-multi_homed = None
+workspace_specific = None
 non_mh_heartbeat_cmd = '/opt/microsoft/omsagent/bin/omsadmin.sh -b'
 oms_restart_cmd = 'sudo /opt/microsoft/omsagent/bin/service_control restart'
 
 def init_paths(WorkspaceID):
+    """
+    Initialize path values depending on workspace ID
+    """
     global conf_path
     global omi_map_path
-    global multi_homed
+    global workspace_specific
 
     omsagent_dir = '/etc/opt/microsoft/omsagent/'
-    mh_conf_dir = omsagent_dir + WorkspaceID + '/conf'
+    wspc_conf_dir = omsagent_dir + WorkspaceID + '/conf'
 
-    multi_homed = os.path.isdir(mh_conf_dir)
+    workspace_specific = os.path.isdir(wspc_conf_dir)
 
-    if multi_homed:
-        LG().Log('INFO', 'OMSAgent is multi-homed and resource is updating workspace ' + WorkspaceID)
-        conf_path = mh_conf_dir + '/omsagent.conf'
-        omi_map_path = mh_conf_dir + '/omsagent.d/omi_mapping.json'
+    if workspace_specific:
+        LG().Log('INFO', 'Configuration is in a workspace-specific path; ' \
+                         'resource is updating workspace ' + WorkspaceID)
+        conf_path = wspc_conf_dir + '/omsagent.conf'
+        omi_map_path = wspc_conf_dir + '/omsagent.d/omi_mapping.json'
 
 
 def init_omi_map():
+    """
+    Initialize OMI value mapping
+    """
     global omi_map
     txt = codecs.open(omi_map_path, 'r', 'utf8').read()
     omi_map = eval(txt)
 
 
 def init_vars(WorkspaceID, HeartbeatIntervalSeconds, PerfCounterObject):
+    """
+    Initialize global values
+    """
     init_paths(WorkspaceID)
     init_omi_map()
 
@@ -125,6 +136,7 @@ def Test(HeartbeatIntervalSeconds, PerfCounterObject):
         HeartbeatIntervalSeconds, PerfCounterObject)
     if NewHeartbeatIntervalSeconds != HeartbeatIntervalSeconds:
         return [-1]
+
     PerfCounterObject.sort()
     for perf in PerfCounterObject:
         perf['PerformanceCounter'].sort()
@@ -133,7 +145,11 @@ def Test(HeartbeatIntervalSeconds, PerfCounterObject):
     for perf in NewPerfs:
         perf['PerformanceCounter'].sort()
     if PerfCounterObject != NewPerfs:
-            return [-1]
+        return [-1]
+
+    # Check if the omi_mapping_path has been specified yet
+    if not CheckForOMIMappingPathInConf():
+        return [-1]
     return [0]
 
 
@@ -157,14 +173,14 @@ def TranslatePerfs(object_name, perfs):
 
 
 def ReadOMSAgentConf(HeartbeatIntervalSeconds, PerfCounterObject):
-    txt = ''
-    try:
-        txt = codecs.open(conf_path, 'r', 'utf8').read().encode(
-            'ascii', 'ignore')
-        LG().Log('INFO', 'Read omsagent configuration ' + conf_path + '.')
-    except:
-        LG().Log(
-            'ERROR', 'Unable to read omsagent configuration ' + conf_path + '.')
+    """
+    Read OMSAgent conf file and extract the current settings for
+    HeartbeatIntervalSeconds and perf objects
+    """
+    txt = get_conf_path_text()
+    if not txt:
+        return None, []
+
     heartbeat_srch_str = r'<source>.*?tag heartbeat.*?run_interval ([0-9]+[a-z])\n</source>\n'
     heartbeat_srch = re.compile(heartbeat_srch_str, re.M | re.S)
     m = heartbeat_srch.search(txt)
@@ -175,10 +191,9 @@ def ReadOMSAgentConf(HeartbeatIntervalSeconds, PerfCounterObject):
     else:
         interval = None
     new_heartbeat = interval
-    perf_src_srch_str = r'\n<source>\n  type oms_omi.*?object_name "(.*?)".*?instance_regex "(.*?)".*?counter_name_regex "(.*?)".*?interval ([0-9]+[a-z]).*?</source>\n'
-    perf_src_srch = re.compile(perf_src_srch_str, re.M | re.S)
+
     new_perfobj = []
-    sources = perf_src_srch.findall(txt)
+    sources = search_for_perf_sections(txt)
     inst = ''
     interval = 0
     for source in sources:
@@ -197,22 +212,22 @@ def ReadOMSAgentConf(HeartbeatIntervalSeconds, PerfCounterObject):
 
 
 def UpdateOMSAgentConf(WorkspaceID, HeartbeatIntervalSeconds, PerfCounterObject):
-    if os.path.exists(conf_path):
-        txt = codecs.open(conf_path, 'r', 'utf8').read().encode(
-            'ascii', 'ignore')
-        LG().Log('INFO', 'Read omsagent configuration ' + conf_path + '.')
-    else:
-        LG().Log(
-            'INFO', 'No omsagent configuration file present.  Will create new  configuration file at ' + conf_path + '.')
-        txt = ''
+    """
+    Write the new values given by parameters to the OMSAgent conf file
+    """
+    txt = get_conf_path_text()
+    if not txt:
+        LG().Log('INFO', 'Will create new configuration file at ' + conf_path + '.')
+
     heartbeat_srch_str = r'<source>.*?tag heartbeat.*?</source>\n'
     heartbeat_srch = re.compile(heartbeat_srch_str, re.M | re.S)
     heartbeat_cmd = non_mh_heartbeat_cmd
-    if multi_homed:
+    if workspace_specific:
         heartbeat_cmd = 'echo'
     heartbeat_src = '<source>\n  type exec\n  tag heartbeat.output\n  command ' + heartbeat_cmd + ' > /dev/null\n  format tsv\n  keys severity,message\n  run_interval ' + \
         str(HeartbeatIntervalSeconds) + 's\n</source>\n'
     txt = heartbeat_srch.sub(heartbeat_src, txt)
+
     d = {}
     perf_src_srch_str = r'\n<source>\n  type oms_omi.*?</source>\n'
     perf_src_srch = re.compile(perf_src_srch_str, re.M | re.S)
@@ -225,15 +240,18 @@ def UpdateOMSAgentConf(WorkspaceID, HeartbeatIntervalSeconds, PerfCounterObject)
             names = '(' + reduce(lambda x, y: x + '|' + y, d[k]) + ')'
             instances = re.sub(r'([><]|&gt|&lt)', '', perf['InstanceName'])
             instances = re.sub(r'([*])', '.*', instances)
+            # omi_map_path will be set to the appropriate value whether or not we are multi-homed
             new_source += '\n<source>\n  type oms_omi\n  object_name "' + k + '"\n  instance_regex "' + instances + \
                 '"\n  counter_name_regex "' + names + '"\n  interval ' + \
-                str(perf['IntervalSeconds']) + 's\n</source>\n'
+                str(perf['IntervalSeconds']) + 's\n  omi_mapping_path ' + omi_map_path + '\n</source>\n'
+
     m = heartbeat_srch.search(txt)
     if m is not None:
         i = m.end(0) + 1
         txt = txt[:i] + new_source + txt[i:]
     else:
         txt = new_source         
+
     try:
         codecs.open(conf_path, 'w', 'utf8').write(txt)
         LG().Log(
@@ -245,7 +263,7 @@ def UpdateOMSAgentConf(WorkspaceID, HeartbeatIntervalSeconds, PerfCounterObject)
 
     global oms_restart_cmd
     process_to_restart = 'omsagent'
-    if multi_homed:
+    if workspace_specific:
         oms_restart_cmd += ' ' + WorkspaceID
         process_to_restart += '-' + WorkspaceID
     if os.system(oms_restart_cmd) == 0:
@@ -256,18 +274,49 @@ def UpdateOMSAgentConf(WorkspaceID, HeartbeatIntervalSeconds, PerfCounterObject)
     return True
 
 
-def rm_unicode(obj):
-    if isinstance(obj, dict):
-        d = {}
-        for k, v in obj.iteritems():
-            d[rm_unicode(k)] = rm_unicode(v)
-        return d
-    elif isinstance(obj, list):
-        return [rm_unicode(i) for i in obj]
-    elif isinstance(obj, unicode):
-        return obj.encode('ascii', 'ignore')
+def CheckForOMIMappingPathInConf():
+    """
+    Return true if the omi_mapping_path has been specified in all perf
+    sections in conf_path
+    """
+    conf_path_txt = get_conf_path_text()
+    sources = search_for_perf_sections(conf_path_txt)
+    for source in sources:
+        try:
+            if 'omi_mapping_path' not in source[4]:
+                return False
+        except:
+            return False
+    return True
+
+
+def get_conf_path_text():
+    """
+    Get current text in the conf_path file
+    """
+    txt = ''
+    if os.path.exists(conf_path):
+        try:
+            txt = codecs.open(conf_path, 'r', 'utf8').read().encode('ascii',
+                                                                    'ignore')
+            LG().Log('INFO', 'Read omsagent configuration ' + conf_path + '.')
+        except:
+            LG().Log('ERROR', 'Unable to read omsagent configuration ' + conf_path + '.')
     else:
-        return obj
+        LG().Log('ERROR', 'No omsagent configuration file present.')
+    return txt
+
+
+def search_for_perf_sections(txt):
+    """
+    Returns all matches in txt for performance counter configuration
+    sections
+    """
+    perf_src_srch_str = r'\n<source>\n  type oms_omi.*?object_name "(.*?)".*?instance_regex "(.*?)".*?counter_name_regex "(.*?)".*?interval ([0-9]+[a-z])(.*?)</source>\n'
+    # Since this search uses re.S, newlines and omi_mapping_path will be
+    # matched
+    perf_src_srch = re.compile(perf_src_srch_str, re.M | re.S)
+    return perf_src_srch.findall(txt)
 
 
 def prune_perfs(PerfCounterObject):

--- a/Providers/Scripts/3.x/Scripts/nxOMSPerfCounter.py
+++ b/Providers/Scripts/3.x/Scripts/nxOMSPerfCounter.py
@@ -9,6 +9,7 @@ import re
 import codecs
 import json
 from functools import reduce
+
 protocol = imp.load_source('protocol', '../protocol.py')
 nxDSCLog = imp.load_source('nxDSCLog', '../nxDSCLog.py')
 
@@ -18,33 +19,43 @@ LG = nxDSCLog.DSCLog
 conf_path = '/etc/opt/microsoft/omsagent/conf/omsagent.conf'
 omi_map_path = '/etc/opt/microsoft/omsagent/conf/omsagent.d/omi_mapping.json'
 omi_map = None
-multi_homed = None
+workspace_specific = None
 non_mh_heartbeat_cmd = '/opt/microsoft/omsagent/bin/omsadmin.sh -b'
 oms_restart_cmd = 'sudo /opt/microsoft/omsagent/bin/service_control restart'
 
 def init_paths(WorkspaceID):
+    """
+    Initialize path values depending on workspace ID
+    """
     global conf_path
     global omi_map_path
-    global multi_homed
+    global workspace_specific
 
     omsagent_dir = '/etc/opt/microsoft/omsagent/'
-    mh_conf_dir = omsagent_dir + WorkspaceID + '/conf'
+    wspc_conf_dir = omsagent_dir + WorkspaceID + '/conf'
 
-    multi_homed = os.path.isdir(mh_conf_dir)
+    workspace_specific = os.path.isdir(wspc_conf_dir)
 
-    if multi_homed:
-        LG().Log('INFO', 'OMSAgent is multi-homed and resource is updating workspace ' + WorkspaceID)
-        conf_path = mh_conf_dir + '/omsagent.conf'
-        omi_map_path = mh_conf_dir + '/omsagent.d/omi_mapping.json'
+    if workspace_specific:
+        LG().Log('INFO', 'Configuration is in a workspace-specific path; ' \
+                         'resource is updating workspace ' + WorkspaceID)
+        conf_path = wspc_conf_dir + '/omsagent.conf'
+        omi_map_path = wspc_conf_dir + '/omsagent.d/omi_mapping.json'
 
 
 def init_omi_map():
+    """
+    Initialize OMI value mapping
+    """
     global omi_map
     txt = codecs.open(omi_map_path, 'r', 'utf8').read()
     omi_map = eval(txt)
 
 
 def init_vars(WorkspaceID, HeartbeatIntervalSeconds, PerfCounterObject):
+    """
+    Initialize global values
+    """
     init_paths(WorkspaceID)
     init_omi_map()
 
@@ -122,13 +133,18 @@ def Test(HeartbeatIntervalSeconds, PerfCounterObject):
         HeartbeatIntervalSeconds, PerfCounterObject)
     if NewHeartbeatIntervalSeconds != HeartbeatIntervalSeconds:
         return [-1]
+
     for perf in PerfCounterObject:
         perf['PerformanceCounter'].sort()
         perf['AllInstances'] = True
     for perf in NewPerfs:
         perf['PerformanceCounter'].sort()
     if PerfCounterObject != NewPerfs:
-            return [-1]
+        return [-1]
+
+    # Check if the omi_mapping_path has been specified yet
+    if not CheckForOMIMappingPathInConf():
+        return [-1]
     return [0]
 
 
@@ -152,13 +168,14 @@ def TranslatePerfs(object_name, perfs):
 
 
 def ReadOMSAgentConf(HeartbeatIntervalSeconds, PerfCounterObject):
-    txt = ''
-    try:
-        txt = codecs.open(conf_path, 'r', 'utf8').read()
-        LG().Log('INFO', 'Read omsagent configuration ' + conf_path + '.')
-    except:
-        LG().Log(
-            'ERROR', 'Unable to read omsagent configuration ' + conf_path + '.')
+    """
+    Read OMSAgent conf file and extract the current settings for
+    HeartbeatIntervalSeconds and perf objects
+    """
+    txt = get_conf_path_text()
+    if not txt:
+        return None, []
+
     heartbeat_srch_str = r'<source>.*?tag heartbeat.*?run_interval ([0-9]+[a-z])\n</source>\n'
     heartbeat_srch = re.compile(heartbeat_srch_str, re.M | re.S)
     m = heartbeat_srch.search(txt)
@@ -169,10 +186,9 @@ def ReadOMSAgentConf(HeartbeatIntervalSeconds, PerfCounterObject):
     else:
         interval = None
     new_heartbeat = interval
-    perf_src_srch_str = r'\n<source>\n  type oms_omi.*?object_name "(.*?)".*?instance_regex "(.*?)".*?counter_name_regex "(.*?)".*?interval ([0-9]+[a-z]).*?</source>\n'
-    perf_src_srch = re.compile(perf_src_srch_str, re.M | re.S)
+
     new_perfobj = []
-    sources = perf_src_srch.findall(txt)
+    sources = search_for_perf_sections(txt)
     inst = ''
     interval = 0
     for source in sources:
@@ -191,21 +207,22 @@ def ReadOMSAgentConf(HeartbeatIntervalSeconds, PerfCounterObject):
 
 
 def UpdateOMSAgentConf(WorkspaceID, HeartbeatIntervalSeconds, PerfCounterObject):
-    if os.path.exists(conf_path):
-        txt = codecs.open(conf_path, 'r', 'utf8').read()
-        LG().Log('INFO', 'Read omsagent configuration ' + conf_path + '.')
-    else:
-        LG().Log(
-            'INFO', 'No omsagent configuration file present.  Will create new  configuration file at ' + conf_path + '.')
-        txt = ''
+    """
+    Write the new values given by parameters to the OMSAgent conf file
+    """
+    txt = get_conf_path_text()
+    if not txt:
+        LG().Log('INFO', 'Will create new configuration file at ' + conf_path + '.')
+
     heartbeat_srch_str = r'<source>.*?tag heartbeat.*?</source>\n'
     heartbeat_srch = re.compile(heartbeat_srch_str, re.M | re.S)
     heartbeat_cmd = non_mh_heartbeat_cmd
-    if multi_homed:
+    if workspace_specific:
         heartbeat_cmd = 'echo'
     heartbeat_src = '<source>\n  type exec\n  tag heartbeat.output\n  command ' + heartbeat_cmd + ' > /dev/null\n  format tsv\n  keys severity,message\n  run_interval ' + \
         str(HeartbeatIntervalSeconds) + 's\n</source>\n'
     txt = heartbeat_srch.sub(heartbeat_src, txt)
+
     d = {}
     perf_src_srch_str = r'\n<source>\n  type oms_omi.*?</source>\n'
     perf_src_srch = re.compile(perf_src_srch_str, re.M | re.S)
@@ -218,15 +235,18 @@ def UpdateOMSAgentConf(WorkspaceID, HeartbeatIntervalSeconds, PerfCounterObject)
             names = '(' + reduce(lambda x, y: x + '|' + y, d[k]) + ')'
             instances = re.sub(r'([><]|&gt|&lt)', '', perf['InstanceName'])
             instances = re.sub(r'([*])', '.*', instances)
+            # omi_map_path will be set to the appropriate value whether or not we are multi-homed
             new_source += '\n<source>\n  type oms_omi\n  object_name "' + k + '"\n  instance_regex "' + instances + \
                 '"\n  counter_name_regex "' + names + '"\n  interval ' + \
-                str(perf['IntervalSeconds']) + 's\n</source>\n'
+                str(perf['IntervalSeconds']) + 's\n  omi_mapping_path ' + omi_map_path + '\n</source>\n'
+
     m = heartbeat_srch.search(txt)
     if m is not None:
         i = m.end(0) + 1
         txt = txt[:i] + new_source + txt[i:]
     else:
         txt = new_source         
+
     try:
         codecs.open(conf_path, 'w', 'utf8').write(txt)
         LG().Log(
@@ -238,7 +258,7 @@ def UpdateOMSAgentConf(WorkspaceID, HeartbeatIntervalSeconds, PerfCounterObject)
 
     global oms_restart_cmd
     process_to_restart = 'omsagent'
-    if multi_homed:
+    if workspace_specific:
         oms_restart_cmd += ' ' + WorkspaceID
         process_to_restart += '-' + WorkspaceID
     if os.system(oms_restart_cmd) == 0:
@@ -249,18 +269,48 @@ def UpdateOMSAgentConf(WorkspaceID, HeartbeatIntervalSeconds, PerfCounterObject)
     return True
 
 
-def rm_unicode(obj):
-    if isinstance(obj, dict):
-        d = {}
-        for k, v in obj.iteritems():
-            d[rm_unicode(k)] = rm_unicode(v)
-        return d
-    elif isinstance(obj, list):
-        return [rm_unicode(i) for i in obj]
-    elif isinstance(obj, unicode):
-        return obj.encode('ascii', 'ignore')
+def CheckForOMIMappingPathInConf():
+    """
+    Return true if the omi_mapping_path has been specified in all perf
+    sections in conf_path
+    """
+    conf_path_txt = get_conf_path_text()
+    sources = search_for_perf_sections(conf_path_txt)
+    for source in sources:
+        try:
+            if 'omi_mapping_path' not in source[4]:
+                return False
+        except:
+            return False
+    return True
+
+
+def get_conf_path_text():
+    """
+    Get current text in the conf_path file
+    """
+    txt = ''
+    if os.path.exists(conf_path):
+        try:
+            txt = codecs.open(conf_path, 'r', 'utf8').read()
+            LG().Log('INFO', 'Read omsagent configuration ' + conf_path + '.')
+        except:
+            LG().Log('ERROR', 'Unable to read omsagent configuration ' + conf_path + '.')
     else:
-        return obj
+        LG().Log('ERROR', 'No omsagent configuration file present.')
+    return txt
+
+
+def search_for_perf_sections(txt):
+    """
+    Returns all matches in txt for performance counter configuration
+    sections
+    """
+    perf_src_srch_str = r'\n<source>\n  type oms_omi.*?object_name "(.*?)".*?instance_regex "(.*?)".*?counter_name_regex "(.*?)".*?interval ([0-9]+[a-z])(.*?)</source>\n'
+    # Since this search uses re.S, newlines and omi_mapping_path will be
+    # matched
+    perf_src_srch = re.compile(perf_src_srch_str, re.M | re.S)
+    return perf_src_srch.findall(txt)
 
 
 def prune_perfs(PerfCounterObject):

--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -56,7 +56,7 @@ SHLIB_EXT: 'so'
 /opt/microsoft/omsconfig/Scripts/OMSAuditdPlugin.sh; intermediate/Scripts/OMSAuditdPlugin.sh; 755; root; root
 /opt/microsoft/omsconfig/Scripts/OMS_MetaConfigHelper.py; intermediate/Scripts/OMS_MetaConfigHelper.py; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nx_1.0.zip; release/nx_1.0.zip; 755; ${{RUN_AS_USER}}; root
-/opt/microsoft/omsconfig/module_packages/nxOMSPerfCounter_2.1.zip; release/nxOMSPerfCounter_2.1.zip; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/omsconfig/module_packages/nxOMSPerfCounter_2.2.zip; release/nxOMSPerfCounter_2.2.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSSyslog_2.0.zip; release/nxOMSSyslog_2.0.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSKeyMgmt_1.0.zip; release/nxOMSKeyMgmt_1.0.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/${{SHORT_NAME}}/keys/dscgpgkey.asc; LCM/keys/dscgpgkey.asc; 644; ${{RUN_AS_USER}}; root
@@ -251,7 +251,7 @@ chown -R ${{RUN_AS_USER}} /opt/microsoft/omsconfig/Scripts
 
 # Set up the modules
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nx_1.0.zip 0"
-su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSPerfCounter_2.1.zip 0"
+su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSPerfCounter_2.2.zip 0"
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSSyslog_2.0.zip 0"
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSKeyMgmt_1.0.zip 0"
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxFileInventory_1.1.zip 0"


### PR DESCRIPTION
@Microsoft/omsagent-devs 

To fully support multi-homing, the omi_mapping_path parameter must be specified for the in_oms_omi.rb plugin.

Jenkins build passed, including unit tests and system tests. The resource has been verified locally.