### PR TITLE
Bump nxOMSSyslog to 2.1: Fix regex for correct ReadSyslogConf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,7 +309,7 @@ nxOMSPerfCounter:
 
 nxOMSSyslog:
 	rm -rf output/staging; \
-        VERSION="2.0"; \
+        VERSION="2.1"; \
         PROVIDERS="nxOMSSyslog"; \
         STAGINGDIR="output/staging/$@/DSCResources"; \
         cat Providers/Modules/$@.psd1 | sed "s@<MODULE_VERSION>@$${VERSION}@" > intermediate/Modules/$@.psd1; \

--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSSyslog.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSSyslog.py
@@ -178,10 +178,9 @@ def ReadSyslogConf(SyslogSource, WorkspaceID):
     Read syslog conf file in rsyslog format for specified workspace and
     return the relevant facilities and severities
     """
+    # Check for the current conf even if it should be set to collect nothing
     out = []
     txt = ''
-    if len(SyslogSource) is 0:
-        return out
 
     # Read text from syslog conf file
     src_conf_path = GetSyslogConfPath()
@@ -194,7 +193,7 @@ def ReadSyslogConf(SyslogSource, WorkspaceID):
 
     # Find all lines sending to this workspace's port
     port = ExtractPortFromFluentDConf(WorkspaceID)
-    facility_search = r'^[^#](.*?)@.*?' + port + '$'
+    facility_search = r'^([^#].*?)@.*?' + port + '$'
     facility_re = re.compile(facility_search, re.M)
     for line in facility_re.findall(txt):
         l = line.replace('=', '')
@@ -280,6 +279,8 @@ def ReadSyslogNGConf(SyslogSource, WorkspaceID):
     """
     out = []
     txt = ''
+
+    # Read text from syslog conf file
     try:
         txt = codecs.open(syslog_ng_conf_path, 'r', 'utf8').read()
         LG().Log('INFO', 'Successfully read ' + syslog_ng_conf_path + '.')

--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -57,7 +57,7 @@ SHLIB_EXT: 'so'
 /opt/microsoft/omsconfig/Scripts/OMS_MetaConfigHelper.py; intermediate/Scripts/OMS_MetaConfigHelper.py; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nx_1.0.zip; release/nx_1.0.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSPerfCounter_2.2.zip; release/nxOMSPerfCounter_2.2.zip; 755; ${{RUN_AS_USER}}; root
-/opt/microsoft/omsconfig/module_packages/nxOMSSyslog_2.0.zip; release/nxOMSSyslog_2.0.zip; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/omsconfig/module_packages/nxOMSSyslog_2.1.zip; release/nxOMSSyslog_2.1.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSKeyMgmt_1.0.zip; release/nxOMSKeyMgmt_1.0.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/${{SHORT_NAME}}/keys/dscgpgkey.asc; LCM/keys/dscgpgkey.asc; 644; ${{RUN_AS_USER}}; root
 /opt/microsoft/${{SHORT_NAME}}/keys/msgpgkey.asc; LCM/keys/msgpgkey.asc; 644; ${{RUN_AS_USER}}; root
@@ -252,7 +252,7 @@ chown -R ${{RUN_AS_USER}} /opt/microsoft/omsconfig/Scripts
 # Set up the modules
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nx_1.0.zip 0"
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSPerfCounter_2.2.zip 0"
-su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSSyslog_2.0.zip 0"
+su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSSyslog_2.1.zip 0"
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSKeyMgmt_1.0.zip 0"
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxFileInventory_1.1.zip 0"
 


### PR DESCRIPTION
@Microsoft/omsagent-devs @KrisBash 

Our regex was not matching the first character of each line in the rsyslog configuration file, which was causing Test to consistently fail because the existing config never matched the new config.