### PR TITLE
Fix#304 : Multiple instances of OMSConsistencyInvoker process.

### DIFF
--- a/LCM/dsc/engine/ConfigurationManager/LocalConfigurationManager.c
+++ b/LCM/dsc/engine/ConfigurationManager/LocalConfigurationManager.c
@@ -63,11 +63,84 @@ static LCMTaskNode * g_TaskHead = NULL;
 static pthread_mutex_t g_TaskQueueMutex;
 static int g_TaskQueueShutdown = 0;
 static int g_TaskQueueExists = 0;
+static MI_Char g_CurrentRunningMethodName[LCM_MAX_PATH] = {0};
+
+// This method is to verify if a task node can be added in the operation queue or not.
+// Task is not allowed to add in queue in following conditions.
+//     1. Incoming dsc task request is ‘PerformRequiredConfigurationChecks’
+//          and
+//            a. Consistency Check is already running.
+//            b. Consistency Check is already queued to run later.
+MI_Boolean TaskAllowedToAddInQueue(LCMTaskNode * node)
+{
+    LCMTaskNode* current;
+    MI_Boolean result = MI_TRUE;
+
+    if(node == NULL)
+    {
+        return result;
+    }
+
+    Context_Invoke_Basic *nodeArgs = (Context_Invoke_Basic *)node->params;
+    if(nodeArgs == NULL || nodeArgs->methodName == NULL)
+    {
+        return result;
+    }
+
+    pthread_mutex_lock(&g_TaskQueueMutex);
+
+    // if incoming request is consistency request.
+    if(Tcscasecmp(nodeArgs->methodName, MSFT_DSCLocalConfigManager_PerformRequiredConfigurationChecks) == 0)
+    {
+        // verify if consistency operation is already queued.
+        current = g_TaskHead;
+        while (current != NULL)
+        {
+            Context_Invoke_Basic *currentNodeArgs = current->params;
+            if(currentNodeArgs == NULL || currentNodeArgs->methodName == NULL)
+            {
+                current = current->next;
+                continue;
+            }
+
+            // Only one consistency operation can be queued.
+            if(Tcscasecmp(currentNodeArgs->methodName, MSFT_DSCLocalConfigManager_PerformRequiredConfigurationChecks) == 0)
+            {
+                DSC_EventWriteMessageDscOperationAlreadyQueued(currentNodeArgs->methodName);
+                result = MI_FALSE;
+                goto Cleanup;
+            }
+
+            current = current->next;
+        }
+
+        // verify if consistency operation is already running.
+        if(Tcscasecmp(g_CurrentRunningMethodName, MSFT_DSCLocalConfigManager_PerformRequiredConfigurationChecks) == 0)
+        {
+            DSC_EventWriteMessageDscOperationAlreadyRunning(nodeArgs->methodName);
+            result = MI_FALSE;
+            goto Cleanup;
+        }
+    }
+
+Cleanup:
+    pthread_mutex_unlock(&g_TaskQueueMutex);
+    return result;
+}
 
 void AddToTaskQueue(LCMTaskNode * node)
 {
     LCMTaskNode* current;
+    if(!TaskAllowedToAddInQueue(node))
+    {
+        Context_Invoke_Basic *args = (Context_Invoke_Basic *)node->params;
+        MI_Context_PostResult(args->context, MI_RESULT_OK);
+        DSC_free(node);
+        return;
+    }
+
     pthread_mutex_lock(&g_TaskQueueMutex);
+
     if (g_TaskHead == NULL)
     {
 	g_TaskHead = node;
@@ -102,28 +175,50 @@ void TaskQueueLoop()
     
     while (shouldShutdown == 0)
     {
-	pthread_mutex_lock(&g_TaskQueueMutex);
+    pthread_mutex_lock(&g_TaskQueueMutex);
 	if (g_TaskHead != NULL)
 	{
 	    Thread t;
-	    PAL_Uint32 ret;
+        PAL_Uint32 ret;
+        ptrdiff_t start,finish;
+        MI_Real64 duration;
+        MI_Char wcTime[DURATION_SIZE] = {0}; 
 
 	    currentTask = g_TaskHead;
 	    g_TaskHead = currentTask->next;
-	    pthread_mutex_unlock(&g_TaskQueueMutex);
+        
+        Context_Invoke_Basic *nodeArgs = (Context_Invoke_Basic *)currentTask->params;
+        if(nodeArgs != NULL && nodeArgs->methodName != NULL)
+        {
+            Tcslcpy(g_CurrentRunningMethodName, nodeArgs->methodName, LCM_MAX_PATH);
+        }
+        pthread_mutex_unlock(&g_TaskQueueMutex);
+        
+        DSC_EventWriteMessageStartingDscOperation(g_CurrentRunningMethodName);
+
+        // Capture timestamp when operation started.
+        start=CPU_GetTimeStamp();
 
 	    Thread_CreateJoinable(&t, currentTask->task, NULL, currentTask->params);
 	    Thread_Join(&t, &ret);
 	    Thread_Destroy(&t);
-	    DSC_free(currentTask);
-	}
+        DSC_free(currentTask);
+
+        // Operation is completed.
+        finish=CPU_GetTimeStamp();
+        duration = (MI_Real64)(finish- start) / TIME_PER_SECONND;
+        Stprintf(wcTime, DURATION_SIZE, MI_T("%0.4f"), duration);
+
+        DSC_EventWriteMessageDscOperationCompleted(g_CurrentRunningMethodName, wcTime);
+        g_CurrentRunningMethodName[0] = '\0';
+    }
 	else
 	{
 	    currentTask = NULL;
 	    pthread_mutex_unlock(&g_TaskQueueMutex);
 	}
 
-	usleep(10000);
+    usleep(10000);
 
 	pthread_mutex_lock(&g_TaskQueueMutex);
 	shouldShutdown = g_TaskQueueShutdown;

--- a/LCM/dsc/engine/ConfigurationManager/MSFT_DSCLocalConfigurationManager.c
+++ b/LCM/dsc/engine/ConfigurationManager/MSFT_DSCLocalConfigurationManager.c
@@ -29,9 +29,22 @@ void MI_CALL MSFT_DSCLocalConfigurationManager_Load(
     _In_opt_ MI_Module_Self* selfModule,
     _In_ MI_Context* context)
 {
+    MI_Result miResult;
+    MI_Instance *cimErrorDetails = NULL;
     MI_UNREFERENCED_PARAMETER(selfModule);
 
     *self = NULL;
+
+    //load will not be called by multiple threads
+    miResult = InitHandler(MI_T("MSFT_DSCLocalConfigurationManager_Load"), &cimErrorDetails);
+
+    if(miResult != MI_RESULT_OK)
+    {
+        MI_PostCimError(context, cimErrorDetails);
+        MI_Instance_Delete(cimErrorDetails);        
+        return;
+    }
+
     MI_Context_PostResult(context, MI_RESULT_OK);
 }
 

--- a/LCM/dsc/engine/EngineHelper/EventWrapper.h
+++ b/LCM/dsc/engine/EngineHelper/EventWrapper.h
@@ -339,6 +339,18 @@ void DSCFilePutLog(
 #define DSC_EventWriteDeleteFileFailed(AttemptNumber, FilePath, lastError, errorMessage) \
     ExpandEvent(DeleteFileFailed( g_ConfigurationDetails.jobGuidString, AttemptNumber, FilePath, lastError, errorMessage))
 
+#define DSC_EventWriteMessageDscOperationAlreadyQueued(dscOperationName) \
+    ExpandEvent(MessageDscOperationAlreadyQueued( g_ConfigurationDetails.jobGuidString, dscOperationName))
+
+#define DSC_EventWriteMessageDscOperationAlreadyRunning(dscOperationName) \
+    ExpandEvent(MessageDscOperationAlreadyRunning( g_ConfigurationDetails.jobGuidString, dscOperationName))
+    
+#define DSC_EventWriteMessageStartingDscOperation(dscOperationName) \
+    ExpandEvent(MessageStartingDscOperation( g_ConfigurationDetails.jobGuidString, dscOperationName))
+
+#define DSC_EventWriteMessageDscOperationCompleted(dscOperationName, totalExecutionTimeInSec) \
+    ExpandEvent(MessageDscOperationCompleted( g_ConfigurationDetails.jobGuidString, dscOperationName, totalExecutionTimeInSec))
+
 //Messages output in the operational channel
 #define DSC_EventWriteMessageScheduleTaskAfterReboot() \
     ExpandEvent(MessageScheduleTaskAfterReboot( g_ConfigurationDetails.jobGuidString))

--- a/LCM/dsc/engine/eventing/oidsc.h
+++ b/LCM/dsc/engine/eventing/oidsc.h
@@ -868,3 +868,27 @@ FILE_EVENT3(4327, WebDownloadManagerDoActionGetUrlVersion2_Impl, LOG_INFO, PAL_T
 #define WebDownloadManagerDoActionGetCallVersion2(a0, a1, a2) WebDownloadManagerDoActionGetCallVersion2_Impl(0, 0, tcs(a0), tcs(a1), tcs(a2))
 #endif
 FILE_EVENT3(4328, WebDownloadManagerDoActionGetCallVersion2_Impl, LOG_INFO, PAL_T("Job %s : \nWebDownloadManager for AgentId %s Do-DscAction command, GET call result: %s."), const TChar*, const TChar*, const TChar*)
+#if defined(CONFIG_ENABLE_DEBUG)
+#define MessageDscOperationAlreadyQueued(a0, a1) MessageDscOperationAlreadyQueued_Impl(__FILE__, __LINE__, tcs(a0), tcs(a1))
+#else
+#define MessageDscOperationAlreadyQueued(a0, a1) MessageDscOperationAlreadyQueued_Impl(0, 0, tcs(a0), tcs(a1))
+#endif
+FILE_EVENT2(4329, MessageDscOperationAlreadyQueued_Impl, LOG_WARNING, PAL_T("Job %s : DSC Operation %s is already queued, ignoring the request."), const TChar*, const TChar*)
+#if defined(CONFIG_ENABLE_DEBUG)
+#define MessageDscOperationAlreadyRunning(a0, a1) MessageDscOperationAlreadyRunning_Impl(__FILE__, __LINE__, tcs(a0), tcs(a1))
+#else
+#define MessageDscOperationAlreadyRunning(a0, a1) MessageDscOperationAlreadyRunning_Impl(0, 0, tcs(a0), tcs(a1))
+#endif
+FILE_EVENT2(4330, MessageDscOperationAlreadyRunning_Impl, LOG_WARNING, PAL_T("Job %s : DSC Operation %s is already running, ignoring the request."), const TChar*, const TChar*)
+#if defined(CONFIG_ENABLE_DEBUG)
+#define MessageStartingDscOperation(a0, a1) MessageStartingDscOperation_Impl(__FILE__, __LINE__, tcs(a0), tcs(a1))
+#else
+#define MessageStartingDscOperation(a0, a1) MessageStartingDscOperation_Impl(0, 0, tcs(a0), tcs(a1))
+#endif
+FILE_EVENT2(4331, MessageStartingDscOperation_Impl, LOG_WARNING, PAL_T("Job %s : Starting %s DSC operation."), const TChar*, const TChar*)
+#if defined(CONFIG_ENABLE_DEBUG)
+#define MessageDscOperationCompleted(a0, a1, a2) MessageDscOperationCompleted_Impl(__FILE__, __LINE__, tcs(a0), tcs(a1), tcs(a2))
+#else
+#define MessageDscOperationCompleted(a0, a1, a2) MessageDscOperationCompleted_Impl(0, 0, tcs(a0), tcs(a1), tcs(a2))
+#endif
+FILE_EVENT3(4332, MessageDscOperationCompleted_Impl, LOG_WARNING, PAL_T("Job %s : %s DSC operation completed in %s seconds."), const TChar*, const TChar*, const TChar*)


### PR DESCRIPTION

Issue:
        Recently, OMSAgent customer has reported this issue where they see 100s of OMSConsistencyInvoker processes running on the system. This is causing high load on server #304

        If consistency interval is very short and DSC operation takes more time than consistency run interval, DSC will start queuing consistency run request. Queueing Consistency run is not useful since all the operation performs same task again and again.

Solution:
        With this change, DSC engine will ignore new request for Consistency run if one is already running/queued.