### PR TITLE
Fix 2.6 and 3.x files for nxOMSSyslog 2.1 bump

### DIFF
--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSSyslog.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSSyslog.py
@@ -178,10 +178,9 @@ def ReadSyslogConf(SyslogSource, WorkspaceID):
     Read syslog conf file in rsyslog format for specified workspace and
     return the relevant facilities and severities
     """
+    # Check for the current conf even if it should be set to collect nothing
     out = []
     txt = ''
-    if len(SyslogSource) is 0:
-        return out
 
     # Read text from syslog conf file
     src_conf_path = GetSyslogConfPath()
@@ -194,7 +193,7 @@ def ReadSyslogConf(SyslogSource, WorkspaceID):
 
     # Find all lines sending to this workspace's port
     port = ExtractPortFromFluentDConf(WorkspaceID)
-    facility_search = r'^[^#](.*?)@.*?' + port + '$'
+    facility_search = r'^([^#].*?)@.*?' + port + '$'
     facility_re = re.compile(facility_search, re.M)
     for line in facility_re.findall(txt):
         l = line.replace('=', '')
@@ -280,6 +279,8 @@ def ReadSyslogNGConf(SyslogSource, WorkspaceID):
     """
     out = []
     txt = ''
+
+    # Read text from syslog conf file
     try:
         txt = codecs.open(syslog_ng_conf_path, 'r', 'utf8').read()
         LG().Log('INFO', 'Successfully read ' + syslog_ng_conf_path + '.')

--- a/Providers/Scripts/3.x/Scripts/nxOMSSyslog.py
+++ b/Providers/Scripts/3.x/Scripts/nxOMSSyslog.py
@@ -174,10 +174,9 @@ def ReadSyslogConf(SyslogSource, WorkspaceID):
     Read syslog conf file in rsyslog format for specified workspace and
     return the relevant facilities and severities
     """
+    # Check for the current conf even if it should be set to collect nothing
     out = []
     txt = ''
-    if len(SyslogSource) is 0:
-        return out
 
     # Read text from syslog conf file
     src_conf_path = GetSyslogConfPath()
@@ -190,7 +189,7 @@ def ReadSyslogConf(SyslogSource, WorkspaceID):
 
     # Find all lines sending to this workspace's port
     port = ExtractPortFromFluentDConf(WorkspaceID)
-    facility_search = r'^[^#](.*?)@.*?' + port + '$'
+    facility_search = r'^([^#].*?)@.*?' + port + '$'
     facility_re = re.compile(facility_search, re.M)
     for line in facility_re.findall(txt):
         l = line.replace('=', '')
@@ -276,6 +275,8 @@ def ReadSyslogNGConf(SyslogSource, WorkspaceID):
     """
     out = []
     txt = ''
+
+    # Read text from syslog conf file
     try:
         txt = codecs.open(syslog_ng_conf_path, 'r', 'utf8').read()
         LG().Log('INFO', 'Successfully read ' + syslog_ng_conf_path + '.')


### PR DESCRIPTION
@Microsoft/omsagent-devs 

The 2.6 and 3.x python version files were left out of https://github.com/Microsoft/PowerShell-DSC-for-Linux/pull/321 ; this PR propagates the changes to the remaining two versions