### PR TITLE
Fix#319 : Python <defunct> processes building from omsagent

### DIFF
--- a/Providers/PythonProvider.hpp
+++ b/Providers/PythonProvider.hpp
@@ -75,6 +75,7 @@ private:
 
     int verifySocketState ();
     void handleSocketClosed ();
+    static void handleChildSignal(int sig);
 
     template<typename T>
     int send (T const& val);
@@ -144,6 +145,7 @@ private:
     static unsigned char const SET = 1;
     static unsigned char const GET = 2;
     static unsigned char const INVENTORY = 3;
+    static MI_Boolean CHILD_SIGNAL_REGISTERED;
 
     std::string const m_Name;
     int m_FD;


### PR DESCRIPTION
Normal scenario:
When any DSC operation is started, it loads native provider that creates a child process to execute python provider (get/set/test/inventory) method.
After DSC operation completes, native provider is unloaded. Provider unload signals the child process and child process gets closed.

Zombie process issue:
When DSC executes more than one provider, it creates multiple python processes to execute each kind of resource mentioned in DSC mof document.
DSC execute provider one by one in the sequence they are written in mof document. It is possible that one of the provider execution takes a lot of time when other providers execution is completed.
In that case completed python process appears as Zombie.

Fix:
	Register for child process completion signal and handle it from native provider so that child process can be closed.