### PR TITLE
Fix #312: OMSAgent installation via OMSAgent Extension removes DSC files

### DIFF
--- a/LCM/scripts/InstallModule.py
+++ b/LCM/scripts/InstallModule.py
@@ -180,7 +180,7 @@ for resource in resourcelist:
         sys.exit(1)
 
     os.rename(libdirPath, modulePath + "/DSCResources/" + resource + "/lib")
-    retval = subprocess.call(["cp " +  modulePath + "/DSCResources/" + resource + "/lib/*.* "  + omi_libdir + "/"], shell=True)
+    retval = subprocess.call(["cp --remove-destination " +  modulePath + "/DSCResources/" + resource + "/lib/*.* "  + omi_libdir + "/"], shell=True)
     if retval != 0:
         os.rename(modulePath + "/DSCResources/" + resource + "/lib", libdirPath)
         print("Error: Failed to install module " + moduleName + " on resource " + resource)

--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -234,12 +234,6 @@ chmod -R a+rx $CONFIG_SYSCONFDIR/${{SHORT_NAME}}/configuration/schema
 chmod -R a+rx $CONFIG_SYSCONFDIR/${{SHORT_NAME}}/configuration/baseregistration
 chmod -R a+rx $CONFIG_SYSCONFDIR/${{SHORT_NAME}}/configuration/registration
 
-for f in /opt/omi/lib/libMSFT_*; do
-    if [ -L $f ]; then
-        rm $f
-    fi
-done
-
 #if BUILD_OMS == 1
 chown -R ${{RUN_AS_USER}} /opt/microsoft/omsconfig/modules
 chown -R ${{RUN_AS_USER}} $OMI_REGISTER_DIR/root-oms


### PR DESCRIPTION
Use '--remove-destination' parameter with copy command in InstallModule.py

We won't blindly remove symlinks from **/opt/omi/lib**. Instead, when installing new resources, we remove symlink/actual files if they already exist.