### PR TITLE
Fix StartDscConfiguration.py script on older Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: c
 dist: trusty   # Travis build machine is Ubuntu Trusty 14.04 x64
 sudo: required # A sudo enabled, full VM is used for building instead of a docker container
 
+branches:
+  only:
+    - master
+
 addons:
   apt:
     packages:
@@ -23,7 +27,7 @@ addons:
 script:
   - # Fetch the Build-PowerShell-DSC-for-Linux repository for dependencies to build from
   - git config --global 'url.https://github.com/.insteadOf' 'git@github.com:'
-  - git clone --recursive 'https://github.com/kwirkykat/Build-PowerShell-DSC-for-Linux.git' ../bld-dsc
+  - git clone --recursive 'https://github.com/Microsoft/Build-PowerShell-DSC-for-Linux.git' ../bld-dsc
   -
   - # Master branch for all submodules
   - cd ../bld-dsc

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: c
 dist: trusty   # Travis build machine is Ubuntu Trusty 14.04 x64
 sudo: required # A sudo enabled, full VM is used for building instead of a docker container
 
-branches:
-  only:
-    - master
-
 addons:
   apt:
     packages:
@@ -27,7 +23,7 @@ addons:
 script:
   - # Fetch the Build-PowerShell-DSC-for-Linux repository for dependencies to build from
   - git config --global 'url.https://github.com/.insteadOf' 'git@github.com:'
-  - git clone --recursive 'https://github.com/Microsoft/Build-PowerShell-DSC-for-Linux.git' ../bld-dsc
+  - git clone --recursive 'https://github.com/kwirkykat/Build-PowerShell-DSC-for-Linux.git' ../bld-dsc
   -
   - # Master branch for all submodules
   - cd ../bld-dsc

--- a/LCM/scripts/StartDscConfiguration.py
+++ b/LCM/scripts/StartDscConfiguration.py
@@ -68,13 +68,13 @@ def main(argv):
 
         for parameter in parameters.keys():
             parameterInfo = parameters[parameter]
-            parser.add_argument('-' + parameterInfo['shortForm'], '--' + parameter, help = parameterInfo['helpText'], action = parameterInfo['action'])
+            parser.add_option('-' + parameterInfo['shortForm'], '--' + parameter, help = parameterInfo['helpText'], action = parameterInfo['action'])
 
         (parsedArguments, extraArguments) = parser.parse_args(argv)
 
         for parameter in parameters.keys():
             if parameters[parameter]['required']:
-                if not parsedArguments[parameter]:
+                if not getattr(parsedArguments, parameter):
                     print 'StartDscConfiguration.py: error: argument -' + parameters[parameter]['shortForm'] + '/--' + parameter + ' is required.'
                     exit(1)
 


### PR DESCRIPTION
This should fix the error that was occurring when using StartDscConfiguration.py with older OSes that had older versions of Python and were missing the argparse package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/powershell-dsc-for-linux/341)
<!-- Reviewable:end -->
