### PR TITLE
update syslog resource and the version to 2.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,7 +309,7 @@ nxOMSPerfCounter:
 
 nxOMSSyslog:
 	rm -rf output/staging; \
-        VERSION="2.1"; \
+        VERSION="2.2"; \
         PROVIDERS="nxOMSSyslog"; \
         STAGINGDIR="output/staging/$@/DSCResources"; \
         cat Providers/Modules/$@.psd1 | sed "s@<MODULE_VERSION>@$${VERSION}@" > intermediate/Modules/$@.psd1; \

--- a/Providers/nxOMSSyslog/MSFT_nxOMSSyslogResource.h
+++ b/Providers/nxOMSSyslog/MSFT_nxOMSSyslogResource.h
@@ -12,7 +12,6 @@
 #include <MI.h>
 #include "OMI_BaseResource.h"
 #include "MSFT_nxOMSSyslogSource.h"
-#include "MSFT_nxOMSSyslogResource.h"
 
 /*
 **==============================================================================
@@ -20,7 +19,6 @@
 ** MSFT_nxOMSSyslogResource [MSFT_nxOMSSyslogResource]
 **
 ** Keys:
-**    SyslogSource
 **    WorkspaceID
 **
 **==============================================================================
@@ -31,7 +29,7 @@ typedef struct _MSFT_nxOMSSyslogResource /* extends OMI_BaseResource */
     MI_Instance __instance;
     /* OMI_BaseResource properties */
     /* MSFT_nxOMSSyslogResource properties */
-    /*KEY*/ MSFT_nxOMSSyslogSource_ConstArrayRef SyslogSource;
+    MSFT_nxOMSSyslogSource_ConstArrayRef SyslogSource;
     /*KEY*/ MI_ConstStringField WorkspaceID;
 }
 MSFT_nxOMSSyslogResource;

--- a/Providers/nxOMSSyslog/MSFT_nxOMSSyslogResource.schema.mof
+++ b/Providers/nxOMSSyslog/MSFT_nxOMSSyslogResource.schema.mof
@@ -8,7 +8,7 @@ class MSFT_nxOMSSyslogSource
 [ClassVersion("1.0.0")] 
 class MSFT_nxOMSSyslogResource : OMI_BaseResource
 {
-    [key, EmbeddedInstance("MSFT_nxOMSSyslogSource") : ToSubclass ] string SyslogSource[];
+    [write, EmbeddedInstance("MSFT_nxOMSSyslogSource") : ToSubclass ] string SyslogSource[];
     [key] string WorkspaceID;
 };
  

--- a/Providers/nxOMSSyslog/WMIAdapter.c
+++ b/Providers/nxOMSSyslog/WMIAdapter.c
@@ -30,8 +30,8 @@ MI_EXTERN_C MI_Module* MI_MAIN_CALL MI_Main(_In_ MI_Server* server);
 HINSTANCE g_hModule = NULL;
 
 // Unique provider ID
-// {6143B37E-197F-462D-825C-0E5B55C0A9C8}
-CLSID g_providerClassID = { 0x6143b37e, 0x197f, 0x462d, { 0x82, 0x5c, 0x0e, 0x5b, 0x55, 0xc0, 0xa9, 0xc8 } };
+// {D8A56EAD-5679-47E4-8F3F-803F43B0D227}
+CLSID g_providerClassID = { 0xd8a56ead, 0x5679, 0x47e4, { 0x8f, 0x3f, 0x80, 0x3f, 0x43, 0xb0, 0xd2, 0x27 } };
 
 // DllMain is needed to get the module handle for registration.
 EXTERN_C BOOL WINAPI DllMain(_In_ HINSTANCE hInstance,

--- a/Providers/nxOMSSyslog/schema.c
+++ b/Providers/nxOMSSyslog/schema.c
@@ -1054,14 +1054,14 @@ MI_CONST MI_ClassDecl MSFT_nxOMSSyslogSource_rtti =
 **==============================================================================
 */
 
-static MI_CONST MI_Boolean MSFT_nxOMSSyslogResource_SyslogSource_Key_qual_value = 1;
+static MI_CONST MI_Boolean MSFT_nxOMSSyslogResource_SyslogSource_Write_qual_value = 1;
 
-static MI_CONST MI_Qualifier MSFT_nxOMSSyslogResource_SyslogSource_Key_qual =
+static MI_CONST MI_Qualifier MSFT_nxOMSSyslogResource_SyslogSource_Write_qual =
 {
-    MI_T("Key"),
+    MI_T("Write"),
     MI_BOOLEAN,
-    MI_FLAG_DISABLEOVERRIDE|MI_FLAG_TOSUBCLASS,
-    &MSFT_nxOMSSyslogResource_SyslogSource_Key_qual_value
+    MI_FLAG_ENABLEOVERRIDE|MI_FLAG_TOSUBCLASS,
+    &MSFT_nxOMSSyslogResource_SyslogSource_Write_qual_value
 };
 
 static MI_CONST MI_Char* MSFT_nxOMSSyslogResource_SyslogSource_EmbeddedInstance_qual_value = MI_T("MSFT_nxOMSSyslogSource");
@@ -1076,14 +1076,14 @@ static MI_CONST MI_Qualifier MSFT_nxOMSSyslogResource_SyslogSource_EmbeddedInsta
 
 static MI_Qualifier MI_CONST* MI_CONST MSFT_nxOMSSyslogResource_SyslogSource_quals[] =
 {
-    &MSFT_nxOMSSyslogResource_SyslogSource_Key_qual,
+    &MSFT_nxOMSSyslogResource_SyslogSource_Write_qual,
     &MSFT_nxOMSSyslogResource_SyslogSource_EmbeddedInstance_qual,
 };
 
 /* property MSFT_nxOMSSyslogResource.SyslogSource */
 static MI_CONST MI_PropertyDecl MSFT_nxOMSSyslogResource_SyslogSource_prop =
 {
-    MI_FLAG_PROPERTY|MI_FLAG_KEY|MI_FLAG_READONLY, /* flags */
+    MI_FLAG_PROPERTY, /* flags */
     0x0073650C, /* code */
     MI_T("SyslogSource"), /* name */
     MSFT_nxOMSSyslogResource_SyslogSource_quals, /* qualifiers */

--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -57,7 +57,7 @@ SHLIB_EXT: 'so'
 /opt/microsoft/omsconfig/Scripts/OMS_MetaConfigHelper.py; intermediate/Scripts/OMS_MetaConfigHelper.py; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nx_1.0.zip; release/nx_1.0.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSPerfCounter_2.2.zip; release/nxOMSPerfCounter_2.2.zip; 755; ${{RUN_AS_USER}}; root
-/opt/microsoft/omsconfig/module_packages/nxOMSSyslog_2.1.zip; release/nxOMSSyslog_2.1.zip; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/omsconfig/module_packages/nxOMSSyslog_2.2.zip; release/nxOMSSyslog_2.2.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSKeyMgmt_1.0.zip; release/nxOMSKeyMgmt_1.0.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/${{SHORT_NAME}}/keys/dscgpgkey.asc; LCM/keys/dscgpgkey.asc; 644; ${{RUN_AS_USER}}; root
 /opt/microsoft/${{SHORT_NAME}}/keys/msgpgkey.asc; LCM/keys/msgpgkey.asc; 644; ${{RUN_AS_USER}}; root
@@ -246,7 +246,7 @@ chown -R ${{RUN_AS_USER}} /opt/microsoft/omsconfig/Scripts
 # Set up the modules
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nx_1.0.zip 0"
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSPerfCounter_2.2.zip 0"
-su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSSyslog_2.1.zip 0"
+su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSSyslog_2.2.zip 0"
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSKeyMgmt_1.0.zip 0"
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxFileInventory_1.1.zip 0"
 


### PR DESCRIPTION
Updated syslog resource to be able to pass empty or null in SyslogSource and changed this property to not be a key property. Only workspace id should be the key.
@amitsara 