### PR TITLE
npm: do not return error when sock conn fails in SET

### DIFF
--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSAgentNPMConfig.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSAgentNPMConfig.py
@@ -354,7 +354,7 @@ def SetConfigUpdate(ConfigID, Contents):
         if retval == 0:
             LOG_ACTION.log(LogType.Info, 'Updated agent config file for workspace ' + ConfigID)
             if ConfigID == GetWorkspaceRunningNPM():
-                retval = NotifyServer(Commands.Config)
+                NotifyServer(Commands.Config)
         elif retval != 0:
             LOG_ACTION.log(LogType.Error, 'Updating agent config file failed for workspace ' + ConfigID)
     return retval
@@ -478,13 +478,11 @@ def PurgeSolution(ConfigID):
         retval = False
 
     # notify ruby plugin to purge agent
-    if NotifyServer(Commands.Purge) != 0:
-        retval = False;
+    NotifyServer(Commands.Purge)
 
     return retval
 
 def NotifyServer(command):
-    retval = 0
     serverAddress = os.path.join(PATH_NPM_STATE, FNAME_UDS_SERVER)
     # Create a UDS socket
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -502,11 +500,14 @@ def NotifyServer(command):
         sock.sendall(message)
     except Exception, msg:
         LG().Log(LogType.Error, str(msg))
-        retval = -1
+        # restart omsagent if command was config update and sock conn failed
+        if (command == Commands.Config):
+            currentWsRunningNPM = GetWorkspaceRunningNPM()
+            if (currentWsRunningNPM != None):
+                OMS_ACTION.restart_oms_agent(currentWsRunningNPM)
     finally:
         LG().Log(LogType.Info, 'closing socket')
         sock.close()
-    return retval
 
 def WriteFile(path, contents):
     retval = 0

--- a/Providers/Scripts/3.x/Scripts/nxOMSAgentNPMConfig.py
+++ b/Providers/Scripts/3.x/Scripts/nxOMSAgentNPMConfig.py
@@ -355,7 +355,7 @@ def SetConfigUpdate(ConfigID, Contents):
         if retval == 0:
             LOG_ACTION.log(LogType.Info, 'Updated agent config file for workspace ' + ConfigID)
             if ConfigID == GetWorkspaceRunningNPM():
-                retval = NotifyServer(Commands.Config)
+                NotifyServer(Commands.Config)
         elif retval != 0:
             LOG_ACTION.log(LogType.Error, 'Updating agent config file failed for workspace ' + ConfigID)
     return retval
@@ -479,13 +479,11 @@ def PurgeSolution(ConfigID):
         retval = False
 
     # notify ruby plugin to purge agent
-    if NotifyServer(Commands.Purge) != 0:
-        retval = False;
+    NotifyServer(Commands.Purge)
 
     return retval
 
 def NotifyServer(command):
-    retval = 0
     serverAddress = os.path.join(PATH_NPM_STATE, FNAME_UDS_SERVER)
     # Create a UDS socket
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -503,11 +501,14 @@ def NotifyServer(command):
         sock.sendall(message)
     except Exception as msg:
         LG().Log(LogType.Error, str(msg))
-        retval = -1
+        # restart omsagent if command was config update and sock conn failed
+        if (command == Commands.Config):
+            currentWsRunningNPM = GetWorkspaceRunningNPM()
+            if (currentWsRunningNPM != None):
+                OMS_ACTION.restart_oms_agent(currentWsRunningNPM)
     finally:
         LG().Log(LogType.Info, 'closing socket')
         sock.close()
-    return retval
 
 def WriteFile(path, contents):
     retval = 0


### PR DESCRIPTION
Failing set call actually prevents SET to be invoked for other
modules. Hence using retries in npm rather than propagating SET
failure.