### PR TITLE
Fix DSC build failure happening because of latest changes in omi.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,21 +170,21 @@ omi098:
 	rm -rf omi-1.0.8/output
 	ln -s output_openssl_0.9.8 omi-1.0.8/output
 	$(MAKE) -C omi-1.0.8
-	$(MAKE) -C omi-1.0.8/installbuilder SSL_VERSION=098 BUILD_RPM=$(BUILD_RPM) BUILD_DPKG=$(BUILD_DPKG)
+	$(MAKE) -C omi-1.0.8/installbuilder SSL_VERSION=098 BUILD_RPM=$(BUILD_RPM) BUILD_DPKG=$(BUILD_DPKG) SSL_BUILD=0.9.8
 
 omi100:
 	$(MAKE) configureomi100
 	rm -rf omi-1.0.8/output
 	ln -s output_openssl_1.0.0 omi-1.0.8/output
 	$(MAKE) -C omi-1.0.8
-	$(MAKE) -C omi-1.0.8/installbuilder SSL_VERSION=100 BUILD_RPM=$(BUILD_RPM) BUILD_DPKG=$(BUILD_DPKG)
+	$(MAKE) -C omi-1.0.8/installbuilder SSL_VERSION=100 BUILD_RPM=$(BUILD_RPM) BUILD_DPKG=$(BUILD_DPKG) SSL_BUILD=1.0.0
 
 omi110:
 	$(MAKE) configureomi110
 	rm -rf omi-1.0.8/output
 	ln -s output_openssl_1.1.0 omi-1.0.8/output
 	$(MAKE) -C omi-1.0.8
-	$(MAKE) -C omi-1.0.8/installbuilder SSL_VERSION=110 BUILD_RPM=$(BUILD_RPM) BUILD_DPKG=$(BUILD_DPKG)
+	$(MAKE) -C omi-1.0.8/installbuilder SSL_VERSION=110 BUILD_RPM=$(BUILD_RPM) BUILD_DPKG=$(BUILD_DPKG) SSL_BUILD=1.1.0
 
 configureomi098:
 	(cd omi-1.0.8; ./configure $(DEBUG_FLAGS) --enable-preexec --prefix=/opt/omi --outputdirname=output_openssl_0.9.8 --localstatedir=/var/opt/omi --sysconfdir=/etc/opt/omi/conf --certsdir=/etc/opt/omi/ssl --opensslcflags="$(openssl098_cflags)" --openssllibs="-L$(current_dir)/ext/curl/current_platform/lib $(openssl098_libs)" --openssllibdir="$(openssl098_libdir)")

--- a/configure
+++ b/configure
@@ -107,26 +107,41 @@ fi
 
 pkgconfig=`which pkg-config`
 
-if [ -d "/usr/local_ssl_0.9.8" -a -d "/usr/local_ssl_1.0.0" -a -d "/usr/local_ssl_1.1.0" ]; then
-    case "`uname -m`" in
-        x86_64 )
+if [ -d "/usr/local_ssl_0.9.8" ] || [ -d "/usr/local_ssl_1.0.0" ] || [ -d "/usr/local_ssl_1.1.0" ]; then
+    if [ -d "/usr/local_ssl_0.9.8" ]; then
+        if [ "`uname -m`" == "x86_64" ]; then
             openssl098_libdir=/usr/local_ssl_0.9.8/lib
+        else
+            openssl098_libdir=/usr/local_ssl_0.9.8/lib
+        fi
+        openssl098_cflags=`PKG_CONFIG_PATH=$openssl098_libdir/pkgconfig $pkgconfig --cflags openssl`
+        openssl098_libs=`PKG_CONFIG_PATH=$openssl098_libdir/pkgconfig $pkgconfig --libs openssl`
+    else
+        echo -e "\e[33mYellow SSL version 0.9.8 is not found at path /usr/local_ssl_0.9.8. Skipping build for SSL 0.9.8.\e[0m"
+        BUILD_SSL_098=0
+    fi
+    if [ -d "/usr/local_ssl_1.0.0" ]; then
+        if [ "`uname -m`" == "x86_64" ]; then
             openssl100_libdir=/usr/local_ssl_1.0.0/lib64
-			openssl110_libdir=/usr/local_ssl_1.1.0/lib
-            ;;
-	
-        * )
-            openssl098_libdir=/usr/local_ssl_0.9.8/lib
+        else
             openssl100_libdir=/usr/local_ssl_1.0.0/lib
-			
-            ;;
-    esac
-    openssl098_cflags=`PKG_CONFIG_PATH=$openssl098_libdir/pkgconfig $pkgconfig --cflags openssl`
-    openssl098_libs=`PKG_CONFIG_PATH=$openssl098_libdir/pkgconfig $pkgconfig --libs openssl`
-    openssl100_cflags=`PKG_CONFIG_PATH=$openssl100_libdir/pkgconfig $pkgconfig --cflags openssl`
-    openssl100_libs=`PKG_CONFIG_PATH=$openssl100_libdir/pkgconfig $pkgconfig --libs openssl`
-	openssl110_cflags=`PKG_CONFIG_PATH=$openssl110_libdir/pkgconfig $pkgconfig --cflags openssl`
-    openssl110_libs=`PKG_CONFIG_PATH=$openssl110_libdir/pkgconfig $pkgconfig --libs openssl`
+        fi
+        openssl100_cflags=`PKG_CONFIG_PATH=$openssl100_libdir/pkgconfig $pkgconfig --cflags openssl`
+        openssl100_libs=`PKG_CONFIG_PATH=$openssl100_libdir/pkgconfig $pkgconfig --libs openssl`
+    else
+        echo -e "\e[33mYellow SSL version 1.0.0 is not found at path /usr/local_ssl_1.0.0. Skipping build for SSL 1.0.0.\e[0m"
+        BUILD_SSL_100=0
+    fi
+    if [ -d "/usr/local_ssl_1.1.0" ]; then
+        if [ "`uname -m`" == "x86_64" ]; then
+            openssl110_libdir=/usr/local_ssl_1.1.0/lib
+        fi
+        openssl110_cflags=`PKG_CONFIG_PATH=$openssl110_libdir/pkgconfig $pkgconfig --cflags openssl`
+        openssl110_libs=`PKG_CONFIG_PATH=$openssl110_libdir/pkgconfig $pkgconfig --libs openssl`
+    else
+        echo -e "\e[33mYellow SSL version 1.1.0 is not found at path /usr/local_ssl_1.1.0. Skipping build for SSL 1.1.0.\e[0m"
+        BUILD_SSL_110=0
+    fi
 fi
 
 cat <<EOF > config.mak


### PR DESCRIPTION
This fix has following changes:
  Makefile is passing SSL_BUILD environment variable to omi.
  Now Make file checks if particular version of ssl is not available, it will skip building DSC binaries with that version of SSL.