### PR TITLE
Increase wait time for registration reload

### DIFF
--- a/LCM/dsc/engine/EngineHelper/EngineHelperInternal.h
+++ b/LCM/dsc/engine/EngineHelper/EngineHelperInternal.h
@@ -478,7 +478,7 @@ typedef MI_InstancePtr* MI_InstancePtrPtr;
 #define OAAS_THUMBPRINTPATH CONFIG_CERTSDIR MI_T("/") OAAS_THUMBPRINT
 #endif
 
-#define OMI_RELOAD_COMMAND MI_T("touch /var/opt/omi/omiusers/reload_dispatcher; sleep 2")
+#define OMI_RELOAD_COMMAND MI_T("touch /var/opt/omi/omiusers/reload_dispatcher; sleep 5")
 #define CONFIGURATION_SYSTEMDIR CONFIG_SYSCONFDIR PATH_SEPARATOR DSC_CONFIG_DIRNAME  MI_T("/configuration")
 #define CONFIGURATION_PROGFILES CONFIG_DATADIR PATH_SEPARATOR DSC_CONFIG_DIRNAME MI_T("/configuration")
 #define AGENTID_FILE_PATH CONFIG_SYSCONFDIR PATH_SEPARATOR DSC_CONFIG_DIRNAME "/agentid"


### PR DESCRIPTION
With the new architecture of the OMI service, reloading registration information may take a little longer so it was recommended to increase this wait time to 5 seconds instead of 2.