### PR TITLE
npm: updating module version to 1.3 for NPM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -513,7 +513,7 @@ nxFileInventory:
 
 nxOMSAgentNPMConfig:
 	rm -rf output/staging; \
-	VERSION="1.2"; \
+	VERSION="1.3"; \
 	PROVIDERS="nxOMSAgentNPMConfig"; \
 	STAGINGDIR="output/staging/$@/DSCResources"; \
 	cat Providers/Modules/$@.psd1 | sed "s@<MODULE_VERSION>@$${VERSION}@" > intermediate/Modules/$@.psd1; \


### PR DESCRIPTION
NPM 1.2 was already checked in long back. Hence agents might not
receive the new bits. Updating module to 1.3.