### PR TITLE
Enabling Logging in our OMS_MetaConfigHelper.py and PerformInventory.py file (Fixes #343)

### DIFF
--- a/LCM/dsc/engine/ca/CAInfrastructure/CAEngineInternal.h
+++ b/LCM/dsc/engine/ca/CAInfrastructure/CAEngineInternal.h
@@ -39,7 +39,7 @@
 
   Example output in the CIM_Error instance that is returned is:
 
-    Failed to apply the configuration.  These resources produced errors: [nxSshAuthorizedKeys]rootKey, [nxFile]MyFile1. Detailed error information can be found in the log file.
+    Failed to apply the configuration.  These resources produced errors: [nxSshAuthorizedKeys]rootKey, [nxFile]MyFile1.
 */
 
 typedef struct _ResourceError ResourceError;

--- a/LCM/dsc/engine/lcm/strings.inc
+++ b/LCM/dsc/engine/lcm/strings.inc
@@ -547,7 +547,7 @@ INTERNAL_Intlstr_Define0( ID_PULL_RESTARTINGSERVER,
 INTERNAL_Intlstr_Define1( ID_APPLYCONFIG_RESOURCEERRORLIST,
 			  ID_APPLYCONFIG_RESOURCEERRORLIST,
       			  _In_z_ const PAL_Char*, firstString,
-                 	  "Failed to apply the configuration.  These resources produced errors: "  Intlstr_tstr(1) ". Detailed error information can be found in the log file.")
+                 	  "Failed to apply the configuration.  These resources produced errors: "  Intlstr_tstr(1))
 
 INTERNAL_Intlstr_Define1( ID_PULL_REPORTINGFAILED,
 			  ID_PULL_REPORTINGFAILED,


### PR DESCRIPTION
Adding Berhe's logging tool to our OMS_MetaConfigHelpr.py file and our PerformInventory.py file so that all of the output from these files will go to our log file.

Also fixed #343 
