### PR TITLE
Fixing segmentation fault issue

### DIFF
--- a/Providers/PythonProvider.cpp
+++ b/Providers/PythonProvider.cpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <cstring>
+#include <vector>
 #include <errno.h>
 #include <fcntl.h>
 #include <functional>
@@ -259,46 +260,21 @@ PythonProvider::~PythonProvider ()
     {
         close (m_FD);
     }
-    if (m_pid != -2)
+    if( m_pid > 0 )
     {
 	waitpid(m_pid, NULL, 0);
     }
-}
-
-/* PythonProvider::init() creates a child process (referenced by m_pid) to execute dsc python resources using client.py script.
-   When execution of python resource (child process) is completed, it doesn’t disappear completely.
-   Instead it becomes Zombie which is not capable to execute anything.
-   Any further call to client.py (via socket) will fail.
-
-   The Zombie processes can be simply removed by registering for SIGCHLD signal and calling waitpid API from handler.
-
-   This method is a SIGCHLD handler, which is raised when a child process is terminated.
-*/
-void PythonProvider::handleChildSignal(int sig) {
-    int saved_errno = errno;
-
-    // Obtain information about the child whose state has changed, and release it.
-    // Only one instance of SIGCHLD can be queued, so it becomes necessary to reap
-    // several zombie processes during one invocation of the handler function.
-    while (waitpid((pid_t)(-1), 0, WNOHANG) > 0) {}
-    errno = saved_errno;
+    for(size_t xCount = 0 ; xCount < m_PreviousPid.size(); xCount++)
+    {
+	waitpid(m_PreviousPid[xCount] , NULL, WNOHANG);
+    }
+    m_pid.clear();
 }
 
 int
 PythonProvider::init ()
 {
     int rval = EXIT_SUCCESS;
-
-    // Register child process signal handler
-    if(CHILD_SIGNAL_REGISTERED == MI_FALSE)
-    {
-        struct sigaction sa;
-        sa.sa_handler = &handleChildSignal;
-        sigemptyset(&sa.sa_mask);
-        sa.sa_flags = SA_RESTART | SA_NOCLDSTOP;
-        sigaction(SIGCHLD, &sa, 0);
-        CHILD_SIGNAL_REGISTERED = MI_TRUE;
-    }
 
 #if (PRINT_BOOKENDS)
     std::ostringstream strm;
@@ -548,13 +524,14 @@ PythonProvider::forkExec ()
     if (INVALID_SOCKET == m_FD)
     {
         int sockets[2];
+	int pid;
         int result = socketpair (AF_UNIX, SOCK_STREAM, 0, sockets);
         if (-1 != result)
         {
             // socketpair succeeded
             SCX_BOOKEND_PRINT ("socketpair - succeeded");
-            m_pid = fork ();
-            if (0 == m_pid)
+            pid = fork ();
+            if (0 == pid)
             {
                 // fork succeded, this is the child process
                 SCX_BOOKEND_PRINT ("fork - succeeded: this is the child");
@@ -581,8 +558,9 @@ PythonProvider::forkExec ()
                 strm.clear ();
                 rval = EXIT_FAILURE;
             }
-            else if (-1 != m_pid)
+            else if (-1 != pid)
             {
+	    	m_pid=pid;
                 // fork succeeded, this is the parent process
                 SCX_BOOKEND_PRINT ("fork - succeeded: this is the parent");
                 close (sockets[0]);
@@ -655,6 +633,10 @@ PythonProvider::verifySocketState ()
     }
     if (INVALID_SOCKET == m_FD)
     {
+        if(m_pid > 0 )
+        {
+           m_PreviousPid.push_back(m_pid);
+        }
         result = init ();
     }
     return result;

--- a/Providers/PythonProvider.hpp
+++ b/Providers/PythonProvider.hpp
@@ -30,6 +30,7 @@
 #include <sstream>
 #include <sys/socket.h>
 #include <unistd.h>
+#include <vector>
 
 
 namespace scx
@@ -150,6 +151,7 @@ private:
     std::string const m_Name;
     int m_FD;
     int m_pid;
+    std::vector<int> m_PreviousPid;
 };
 
 
@@ -164,7 +166,6 @@ PythonProvider::PythonProvider (
     T const& name)
     : m_Name (name)
     , m_FD (PythonProvider::INVALID_SOCKET)
-    , m_pid (-2)
 {
     // empty
 }


### PR DESCRIPTION
The issue is that when provider shared library is unloaded and loaded again in the same process, we have still registered signal handler. The address for the signal handler becomes invalid due to shared library reload causing crash whenever the process does a fork.