### PR TITLE
Add Remote file retry logic to nxFile resource 

### DIFF
--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxFile.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxFile.py
@@ -77,7 +77,7 @@ def Set_Marshall(DestinationPath, SourcePath, Ensure, Type, Force, Contents, Che
     return retval
 
 
-def Test_Marshall(DestinationPath, SourcePath, Ensure, Type, Force, Contents, Checksum, Recurse, Links, Owner, Group, Mode):
+def Test_Marshall(DestinationPath, SourcePath, Ensure, Type, Force, Contents, Checksum, Recurse, Links, Owner, Group, Mode):    
     DestinationPath, SourcePath, Ensure, Type, Force, Contents, Checksum, Recurse, Links, Owner, Group, Mode \
                      = init_locals(DestinationPath, SourcePath, Ensure, Type, Force, Contents, Checksum, Recurse, Links, Owner, Group, Mode)
     retval = Test(DestinationPath, SourcePath, Ensure, Type, Force, Contents, Checksum, Recurse, Links, Owner, Group, Mode)
@@ -1069,25 +1069,32 @@ def SetProxyFromConf():
     return
 
 def GetRemoteFileWithRetries(fc):
-  retryCount = 0
-  ret = GetRemoteFile(fc)
-  while ret!=0 and retryCount<RemoteFileRetryCount :
-    print("Exception Getting Remote File '" + fc.SourcePath  + "' Sleeping for " + str(RemoteFileRetryInterval) + " seconds Then Retrying again")
-    LG().Log('ERROR', "Exception Getting Remote File '" + fc.SourcePath  + "' Sleeping for " + str(RemoteFileRetryInterval) + " seconds Then Retrying again")
-    time.sleep(RemoteFileRetryInterval)
-    ret = GetRemoteFile(fc)
-    retryCount = retryCount + 1
-  return ret
+    retryCount = 0
+    ret = 1
+    while True:
+      try:
+			ret = GetRemoteFile(fc)
+      except urllib2.URLError , e:
+          print("Exception encountered when getting Remote File '" + fc.SourcePath  + "', No Retry attempts will be done - " + repr(e))
+          LG().Log('ERROR', "Exception encountered when getting Remote File '" + fc.SourcePath  + "', No Retry attempts will be done - " + repr(e))
+          if hasattr(e, 'code'):
+             # Client code are not likely to succeed on retry
+             if e.code >= 400 and e.code < 500:
+                return 1
+      retryCount = retryCount + 1	
+      if ret == 0 or retryCount > RemoteFileRetryCount:
+         return ret
+      print("Exception encountered when getting Remote File, Sleeping for " + str(RemoteFileRetryInterval) + " seconds Then Retrying again")
+      LG().Log('ERROR', "Exception encountered when getting Remote File, Sleeping for " + str(RemoteFileRetryInterval) + " seconds Then Retrying again")
+      time.sleep(RemoteFileRetryInterval)
+      
+    return ret
+        
         
 def GetRemoteFile(fc):
     SetProxyFromConf()
     req = urllib2.Request(fc.SourcePath)
-    try:
-        resp = urllib2.urlopen(req)
-    except urllib2.URLError , e:
-        print(repr(e))
-        LG().Log('ERROR', repr(e))
-        return 1
+    resp = urllib2.urlopen(req)
     fc.LocalPath = '/tmp/'+os.path.basename(fc.DestinationPath)+'_remote'
     data=b'keep going'
     hasWritten = False
@@ -1112,26 +1119,32 @@ def GetRemoteFile(fc):
     return 0
 
 def TestRemoteFileWithRetries(fc):
-  retryCount = 0
-  ret = TestRemoteFile(fc)
-  while not ret and retryCount<RemoteFileRetryCount :
-    print("Exception Getting Remote File '" + fc.SourcePath  + "' Sleeping for " + str(RemoteFileRetryInterval) + " seconds Then Retrying again")
-    LG().Log('ERROR', "Exception Getting Remote File '" + fc.SourcePath  + "' Sleeping for " + str(RemoteFileRetryInterval) + " seconds Then Retrying again")
-    time.sleep(RemoteFileRetryInterval)
-    ret = TestRemoteFile(fc)
-    retryCount = retryCount + 1
-  return ret
+    retryCount = 0
+    ret = False
+    while True:
+      try:
+			ret = TestRemoteFile(fc)
+      except urllib2.URLError , e:
+          print("Exception encountered when getting Remote File '" + fc.SourcePath  + "', No Retry attempts will be done - " + repr(e))
+          LG().Log('ERROR', "Exception encountered when getting Remote File '" + fc.SourcePath  + "', No Retry attempts will be done - " + repr(e))
+          if hasattr(e, 'code'):
+             # Client code are not likely to succeed on retry
+             if e.code >= 400 and e.code < 500:
+                return 1
+      retryCount = retryCount + 1	
+      if ret or retryCount > RemoteFileRetryCount:
+         return ret
+      print("ERROR encountered when getting Remote File "+ fc.SourcePath  + " Sleeping for " + str(RemoteFileRetryInterval) + " seconds Then Retrying again")
+      LG().Log('ERROR', "ERROR encountered when getting Remote File "+ fc.SourcePath  + " Sleeping for " + str(RemoteFileRetryInterval) + " seconds Then Retrying again")
+      time.sleep(RemoteFileRetryInterval)
+
+    return ret
 
 
 def TestRemoteFile(fc):
     SetProxyFromConf()
     req = urllib2.Request(fc.SourcePath)
-    try:
-        resp = urllib2.urlopen(req)
-    except urllib2.URLError , e:
-        print(repr(e))
-        LG().Log('ERROR', repr(e))
-        return False
+    resp = urllib2.urlopen(req)
     h = resp.info()
     if fc.Checksum != 'md5' :  # if not 'md5' check the last_modified header time before we download
         lm = h.getheader('last-modified')
@@ -1149,13 +1162,13 @@ def TestRemoteFile(fc):
             return True
         else:
             return False
-    #md5
+    #md5    
     if not os.path.exists(fc.DestinationPath):
         return False
     src_data=b'keep going'
     dest_data=b'keep going'
     src_hash = md5const()
-    dest_hash = md5const()
+    dest_hash = md5const()    
     with (open(fc.DestinationPath, 'rb')) as F:
         try:
             while src_data or dest_data:
@@ -1164,8 +1177,10 @@ def TestRemoteFile(fc):
                 dest_data = F.read(1048576)
                 dest_hash.update(dest_data)
                 if src_hash.hexdigest() != dest_hash.hexdigest():
+                    print("Hash MisMatch found between Source File "+ fc.SourcePath  + " and Destination File " + fc.DestinationPath)
+                    LG().Log('ERROR', "Hash MisMatch found between Source File "+ fc.SourcePath  + " and Destination File " + fc.DestinationPath)
                     return False
-        except Exception, e:
+        except Exception, e:           
             F.close()
             return False
     return True
@@ -1215,4 +1230,3 @@ class FileContext:
                 Mode = ""
 
         self.Mode = Mode
-        

--- a/Providers/Scripts/3.x/Scripts/nxFile.py
+++ b/Providers/Scripts/3.x/Scripts/nxFile.py
@@ -31,7 +31,7 @@ BLOCK_SIZE = 8192
 
 global show_mof
 show_mof = False
-RemoteFileRetryCount = 4
+RemoteFileRetryCount = 5
 RemoteFileRetryInterval = 10
 
 
@@ -1093,7 +1093,7 @@ def GetRemoteFileWithRetries(fc):
     time.sleep(RemoteFileRetryInterval)
     ret = GetRemoteFile(fc)
     retryCount = retryCount + 1
-    
+      
   return ret
         
 def GetRemoteFile(fc):
@@ -1134,7 +1134,7 @@ def TestRemoteFileWithRetries(fc):
   while not ret and retryCount<RemoteFileRetryCount :
     print("Exception Getting Remote File '" + fc.SourcePath  + "' Sleeping for " + str(RemoteFileRetryInterval) + " seconds Then Retrying again")
     LG().Log('ERROR', "Exception Getting Remote File '" + fc.SourcePath  + "' Sleeping for " + str(RemoteFileRetryInterval) + " seconds Then Retrying again")
-	time.sleep(RemoteFileRetryInterval)
+    time.sleep(RemoteFileRetryInterval)
     ret = TestRemoteFile(fc)
     retryCount = retryCount + 1
   return ret

--- a/Providers/Scripts/3.x/Scripts/nxFile.py
+++ b/Providers/Scripts/3.x/Scripts/nxFile.py
@@ -31,6 +31,8 @@ BLOCK_SIZE = 8192
 
 global show_mof
 show_mof = False
+RemoteFileRetryCount = 4
+RemoteFileRetryInterval = 10
 
 
 def init_locals(DestinationPath, SourcePath, Ensure, Type, Force, Contents,
@@ -716,7 +718,7 @@ def SetFile(DestinationPath, SourcePath, fc):
             return False
     if SourcePath and len(SourcePath) > 0:
         if '://' in SourcePath and fc.LocalPath == '':
-            ret = GetRemoteFile(fc)
+            ret = GetRemoteFileWithRetries(fc)
             if ret != 0:
                 raise Exception('Unable to retrieve remote resource '+fc.SourcePath+' Error is ' + str(ret))
             else:
@@ -914,7 +916,7 @@ def TestFile(DestinationPath, SourcePath, fc):
         return False
 
     if '://' in SourcePath:
-        return TestRemoteFile(fc)
+        return TestRemoteFileWithRetries(fc)
 
     if TestOwnerGroupMode(DestinationPath, SourcePath, fc) is False:
         return False
@@ -1081,6 +1083,18 @@ def SetProxyFromConf():
             if 'http:' in info:
                 os.environ['HTTP_PROXY'] = info
     return
+
+def GetRemoteFileWithRetries(fc):
+  retryCount = 0
+  ret = GetRemoteFile(fc)
+  while ret!=0 and retryCount<RemoteFileRetryCount :
+    print("Exception Getting Remote File '" + fc.SourcePath  + "' Sleeping for " + str(RemoteFileRetryInterval) + " seconds Then Retrying again")
+    LG().Log('ERROR', "Exception Getting Remote File '" + fc.SourcePath  + "' Sleeping for " + str(RemoteFileRetryInterval) + " seconds Then Retrying again")
+    time.sleep(RemoteFileRetryInterval)
+    ret = GetRemoteFile(fc)
+    retryCount = retryCount + 1
+    
+  return ret
         
 def GetRemoteFile(fc):
     SetProxyFromConf()
@@ -1113,6 +1127,18 @@ def GetRemoteFile(fc):
             LG().Log('ERROR', repr(e))
             return 1
     return 0
+
+def TestRemoteFileWithRetries(fc):
+  retryCount = 0
+  ret = TestRemoteFile(fc)
+  while not ret and retryCount<RemoteFileRetryCount :
+    print("Exception Getting Remote File '" + fc.SourcePath  + "' Sleeping for " + str(RemoteFileRetryInterval) + " seconds Then Retrying again")
+    LG().Log('ERROR', "Exception Getting Remote File '" + fc.SourcePath  + "' Sleeping for " + str(RemoteFileRetryInterval) + " seconds Then Retrying again")
+	time.sleep(RemoteFileRetryInterval)
+    ret = TestRemoteFile(fc)
+    retryCount = retryCount + 1
+  return ret
+
 
 def TestRemoteFile(fc):
     SetProxyFromConf()


### PR DESCRIPTION
Added Retry logic in the nxFile.py for RemoteFile pulling 
changes was implemented for python version 2.4,2.7,3.x

For each version of nxFile.py manual test was execute to validate the new retry logic was working as expected
**Test1:**
Set_Marshall & Test_Marshall was invokerd with valid URI - while disconnect from Ethernet work
after N retries enable network connection again and see it has successfully completed
**Test 2:**
Created a Dsc configuration which uses nxFile resource and has the source path a URI - 
Run StartDscConfiguration.py while disconnect from Ethernet work
after N retries enable network connection again and see it has successfully downloaded the file


