### PR TITLE
Fix log file creation during install

### DIFF
--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -188,6 +188,16 @@ mkdir -p $CONFIG_DATADIR/${{SHORT_NAME}}/configuration/schema
 mkdir -p $CONFIG_DATADIR/${{SHORT_NAME}}/configuration/registration
 chmod 700 $CONFIG_SYSCONFDIR/${{SHORT_NAME}}
 
+#if BUILD_OMS == 1
+
+# Set up logging directory
+mkdir -p /var/opt/microsoft/omsconfig
+chown omsagent /var/opt/microsoft/omsconfig
+chgrp omsagent /var/opt/microsoft/omsconfig
+
+#endif
+
+
 # Create links in omi's directories for DSC data
 
 #if BUILD_OMS == 1
@@ -300,11 +310,6 @@ mv /etc/crontabtmp /etc/crontab
 /opt/omi/bin/service_control restart
 
 #if BUILD_OMS == 1
-
-# Set up logging directory
-mkdir -p /var/opt/microsoft/omsconfig
-chown omsagent /var/opt/microsoft/omsconfig
-chgrp omsagent /var/opt/microsoft/omsconfig
 
 # If omsadmin.conf exists, let's apply the metaconfig
 if [ -f /etc/opt/microsoft/omsagent/conf/omsadmin.conf ]; then


### PR DESCRIPTION
OMS Agent package was printing an error to the console that it could not write to the log file from InstallModule.py during OMS Agent install.

This should be fixed by moving the log folder creation to before the InstallModule.py is called in the installer, and by opening the logger with permissions to create the file if it not there in the logger.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/powershell-dsc-for-linux/374)
<!-- Reviewable:end -->
