### PR TITLE
Fixing segmentation fault issue New Fix 

### DIFF
--- a/LCM/dsc/engine/ConfigurationManager/MSFT_DSCLocalConfigurationManager.c
+++ b/LCM/dsc/engine/ConfigurationManager/MSFT_DSCLocalConfigurationManager.c
@@ -22,8 +22,9 @@
 #include "EngineHelper.h"
 #include "EventWrapper.h"
 #include "Resources_LCM.h"
-
-
+#include <signal.h>
+// Variable to store old Signal for SIGCHLD
+struct sigaction oldAction ;
 void MI_CALL MSFT_DSCLocalConfigurationManager_Load(
     _Outptr_result_maybenull_ MSFT_DSCLocalConfigurationManager_Self** self,
     _In_opt_ MI_Module_Self* selfModule,
@@ -34,7 +35,10 @@ void MI_CALL MSFT_DSCLocalConfigurationManager_Load(
     MI_UNREFERENCED_PARAMETER(selfModule);
 
     *self = NULL;
-
+#if defined(BUILD_OMS)
+    memset(&oldAction, 0, sizeof(struct sigaction));
+    sigaction(SIGCHLD, NULL, &oldAction);
+#endif
     //load will not be called by multiple threads
     miResult = InitHandler(MI_T("MSFT_DSCLocalConfigurationManager_Load"), &cimErrorDetails);
 
@@ -53,6 +57,14 @@ void MI_CALL MSFT_DSCLocalConfigurationManager_Unload(
     _In_ MI_Context* context)
 {
     UnloadFromProvider(self, context);
+
+#if defined(BUILD_OMS)
+        // Set the SIGCHLD signal to default
+        // This is to ensure that if any provider has overriden this specific signal
+        // provider DSC reset it back to the previous signal. 
+    sigaction(SIGCHLD, &oldAction, NULL);
+#endif
+    memset(&oldAction, 0, sizeof(struct sigaction));
 }
 
 void MI_CALL MSFT_DSCLocalConfigurationManager_Invoke_SendConfiguration(

--- a/LCM/dsc/engine/ConfigurationManager/MSFT_DSCLocalConfigurationManager.c
+++ b/LCM/dsc/engine/ConfigurationManager/MSFT_DSCLocalConfigurationManager.c
@@ -22,9 +22,13 @@
 #include "EngineHelper.h"
 #include "EventWrapper.h"
 #include "Resources_LCM.h"
+
+#if defined(BUILD_OMS)
 #include <signal.h>
 // Variable to store old Signal for SIGCHLD
-struct sigaction oldAction ;
+static struct sigaction oldAction ;
+#endif
+
 void MI_CALL MSFT_DSCLocalConfigurationManager_Load(
     _Outptr_result_maybenull_ MSFT_DSCLocalConfigurationManager_Self** self,
     _In_opt_ MI_Module_Self* selfModule,

--- a/Providers/PythonProvider.cpp
+++ b/Providers/PythonProvider.cpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <cstring>
+#include <vector>
 #include <errno.h>
 #include <fcntl.h>
 #include <functional>
@@ -259,46 +260,21 @@ PythonProvider::~PythonProvider ()
     {
         close (m_FD);
     }
-    if (m_pid != -2)
+    if( m_pid > 0 )
     {
 	waitpid(m_pid, NULL, 0);
     }
-}
-
-/* PythonProvider::init() creates a child process (referenced by m_pid) to execute dsc python resources using client.py script.
-   When execution of python resource (child process) is completed, it doesn’t disappear completely.
-   Instead it becomes Zombie which is not capable to execute anything.
-   Any further call to client.py (via socket) will fail.
-
-   The Zombie processes can be simply removed by registering for SIGCHLD signal and calling waitpid API from handler.
-
-   This method is a SIGCHLD handler, which is raised when a child process is terminated.
-*/
-void PythonProvider::handleChildSignal(int sig) {
-    int saved_errno = errno;
-
-    // Obtain information about the child whose state has changed, and release it.
-    // Only one instance of SIGCHLD can be queued, so it becomes necessary to reap
-    // several zombie processes during one invocation of the handler function.
-    while (waitpid((pid_t)(-1), 0, WNOHANG) > 0) {}
-    errno = saved_errno;
+    for(size_t xCount = 0 ; xCount < m_PreviousPid.size(); xCount++)
+    {
+	waitpid(m_PreviousPid[xCount] , NULL, WNOHANG);
+    }
+    m_pid.clear();
 }
 
 int
 PythonProvider::init ()
 {
     int rval = EXIT_SUCCESS;
-
-    // Register child process signal handler
-    if(CHILD_SIGNAL_REGISTERED == MI_FALSE)
-    {
-        struct sigaction sa;
-        sa.sa_handler = &handleChildSignal;
-        sigemptyset(&sa.sa_mask);
-        sa.sa_flags = SA_RESTART | SA_NOCLDSTOP;
-        sigaction(SIGCHLD, &sa, 0);
-        CHILD_SIGNAL_REGISTERED = MI_TRUE;
-    }
 
 #if (PRINT_BOOKENDS)
     std::ostringstream strm;
@@ -548,13 +524,14 @@ PythonProvider::forkExec ()
     if (INVALID_SOCKET == m_FD)
     {
         int sockets[2];
+	int pid;
         int result = socketpair (AF_UNIX, SOCK_STREAM, 0, sockets);
         if (-1 != result)
         {
             // socketpair succeeded
             SCX_BOOKEND_PRINT ("socketpair - succeeded");
-            m_pid = fork ();
-            if (0 == m_pid)
+            pid = fork ();
+            if (0 == pid)
             {
                 // fork succeded, this is the child process
                 SCX_BOOKEND_PRINT ("fork - succeeded: this is the child");
@@ -581,8 +558,9 @@ PythonProvider::forkExec ()
                 strm.clear ();
                 rval = EXIT_FAILURE;
             }
-            else if (-1 != m_pid)
+            else if (-1 != pid)
             {
+	    	m_pid=pid;
                 // fork succeeded, this is the parent process
                 SCX_BOOKEND_PRINT ("fork - succeeded: this is the parent");
                 close (sockets[0]);
@@ -655,6 +633,10 @@ PythonProvider::verifySocketState ()
     }
     if (INVALID_SOCKET == m_FD)
     {
+        if(m_pid > 0 )
+        {
+           m_PreviousPid.push_back(m_pid);
+        }
         result = init ();
     }
     return result;

--- a/Providers/PythonProvider.hpp
+++ b/Providers/PythonProvider.hpp
@@ -30,6 +30,7 @@
 #include <sstream>
 #include <sys/socket.h>
 #include <unistd.h>
+#include <vector>
 
 
 namespace scx
@@ -150,6 +151,7 @@ private:
     std::string const m_Name;
     int m_FD;
     int m_pid;
+    std::vector<int> m_PreviousPid;
 };
 
 
@@ -164,7 +166,6 @@ PythonProvider::PythonProvider (
     T const& name)
     : m_Name (name)
     , m_FD (PythonProvider::INVALID_SOCKET)
-    , m_pid (-2)
 {
     // empty
 }


### PR DESCRIPTION
The issue is that when provider shared library is unloaded and loaded again in the same process, we have still registered signal handler. The address for the signal handler becomes invalid due to shared library reload causing crash whenever the process does a fork. 