### PR TITLE
Fixing segmentation fault issue in Dsc Engine

### DIFF
--- a/LCM/dsc/engine/ConfigurationManager/LocalConfigManagerHelper.c
+++ b/LCM/dsc/engine/ConfigurationManager/LocalConfigManagerHelper.c
@@ -6747,7 +6747,10 @@ void handleSIGCHLDSignal(int sig)
     // the OMS providers of cleaning up zombie processes.
     // Only one instance of SIGCHLD can be queued, so it becomes necessary to reap
     // several zombie processes during one invocation of the handler function.
-    while (waitpid((pid_t)(-1), 0, WNOHANG) > 0) {}
+    while (waitpid((pid_t)(-1), 0, WNOHANG) > 0) 
+    {
+	DSC_EventWriteMessageWaitForChildProcess();
+    }
     errno = saved_errorno;
 }
 #endif

--- a/LCM/dsc/engine/ConfigurationManager/LocalConfigManagerHelper.c
+++ b/LCM/dsc/engine/ConfigurationManager/LocalConfigManagerHelper.c
@@ -6741,16 +6741,16 @@ MI_Result SetLCMStatusBusy()
 void handleSIGCHLDSignal(int sig)
 {
     int saved_errorno = errno;
+
+    DSC_EventWriteMessageWaitForChildProcess();
+
     // OMS providers registers the SIGINT handler but may not have
     // an opportunity to clean up before getting unloaded.
     // This code is to ensure that OMSConfig picks up the work left off by
     // the OMS providers of cleaning up zombie processes.
     // Only one instance of SIGCHLD can be queued, so it becomes necessary to reap
     // several zombie processes during one invocation of the handler function.
-    while (waitpid((pid_t)(-1), 0, WNOHANG) > 0) 
-    {
-	DSC_EventWriteMessageWaitForChildProcess();
-    }
+    while (waitpid((pid_t)(-1), 0, WNOHANG) > 0) { }
     errno = saved_errorno;
 }
 #endif

--- a/LCM/dsc/engine/ConfigurationManager/LocalConfigManagerHelper.c
+++ b/LCM/dsc/engine/ConfigurationManager/LocalConfigManagerHelper.c
@@ -38,6 +38,9 @@
 #include "OMI_LocalConfigManagerHelper.h"
 #endif
 
+#if defined(BUILD_OMS)
+#include <signal.h>
+#endif
 
 #define NOT_INITIALIZED         0
 #define INITIALIZED             1
@@ -6734,12 +6737,36 @@ MI_Result SetLCMStatusBusy()
         return r;
 }
 
+#if defined(BUILD_OMS)
+void handleSIGCHLDSignal(int sig)
+{
+    int saved_errorno = errno;
+    // OMS providers registers the SIGINT handler but may not have
+    // an opportunity to clean up before getting unloaded.
+    // This code is to ensure that OMSConfig picks up the work left off by
+    // the OMS providers of cleaning up zombie processes.
+    // Only one instance of SIGCHLD can be queued, so it becomes necessary to reap
+    // several zombie processes during one invocation of the handler function.
+    while (waitpid((pid_t)(-1), 0, WNOHANG) > 0) {}
+    errno = saved_errorno;
+}
+#endif
+
 MI_Result SetLCMStatusReady()
 {
         MI_Uint32 lcmStatus;
         MI_Instance *extendedError;
         MI_Result r;
-
+#if defined(BUILD_OMS)
+        struct sigaction sa;
+        sa.sa_handler = &handleSIGCHLDSignal;
+        sigemptyset(&sa.sa_mask);
+        sa.sa_flags = SA_RESTART | SA_NOCLDSTOP;
+        sigaction(SIGCHLD, &sa, 0);
+        DSC_EventWriteMessageRegisterProcessHandler();
+#endif
+   
+ 
         if (!g_LCMPendingReboot)
         {
                 lcmStatus = LCM_STATUSCODE_READY;

--- a/LCM/dsc/engine/EngineHelper/EventWrapper.h
+++ b/LCM/dsc/engine/EngineHelper/EventWrapper.h
@@ -360,6 +360,8 @@ void DSCFilePutLog(
 #define DSC_EventWriteMessageRegisterProcessHandler() \
     ExpandEvent(MessageDscEngineRegisteringSignalHandler( g_ConfigurationDetails.jobGuidString))
 
+#define DSC_EventWriteMessageWaitForChildProcess() \
+    ExpandEvent(MessageDscEngineSignalHandlerWaitingForPorces( g_ConfigurationDetails.jobGuidString))
 
 //Messages output in the operational channel
 #define DSC_EventWriteMessageScheduleTaskAfterReboot() \

--- a/LCM/dsc/engine/EngineHelper/EventWrapper.h
+++ b/LCM/dsc/engine/EngineHelper/EventWrapper.h
@@ -351,6 +351,16 @@ void DSCFilePutLog(
 #define DSC_EventWriteMessageDscOperationCompleted(dscOperationName, totalExecutionTimeInSec) \
     ExpandEvent(MessageDscOperationCompleted( g_ConfigurationDetails.jobGuidString, dscOperationName, totalExecutionTimeInSec))
 
+#define DSC_EventWriteMessageLoadingDscEngineProvider() \
+    ExpandEvent(MessageDscEngineProviderLoaded( g_ConfigurationDetails.jobGuidString))
+
+#define DSC_EventWriteMessageUnLoadingDscEngineProvider() \
+    ExpandEvent(MessageDscEngineProviderUnLoaded( g_ConfigurationDetails.jobGuidString))
+
+#define DSC_EventWriteMessageRegisterProcessHandler() \
+    ExpandEvent(MessageDscEngineRegisteringSignalHandler( g_ConfigurationDetails.jobGuidString))
+
+
 //Messages output in the operational channel
 #define DSC_EventWriteMessageScheduleTaskAfterReboot() \
     ExpandEvent(MessageScheduleTaskAfterReboot( g_ConfigurationDetails.jobGuidString))

--- a/LCM/dsc/engine/eventing/oidsc.h
+++ b/LCM/dsc/engine/eventing/oidsc.h
@@ -912,4 +912,11 @@ FILE_EVENT1(4334, MessageDscEngineProviderUnLoaded_Impl, LOG_WARNING, PAL_T("Job
 #endif
 FILE_EVENT1(4335, MessageDscEngineRegisteringSignalHandler_Impl, LOG_WARNING, PAL_T("Job %s : \nRegistered Process Signal Handler for SIGCHLD Event"), const TChar*)
 
+#if defined(CONFIG_ENABLE_DEBUG)
+#define MessageDscEngineSignalHandlerWaitingForPorcess(a0) MessageDscEngineSignalHandlerWaitingForPorcess_Impl(__FILE__, __LINE__, tcs(a0))
+#else
+#define MessageDscEngineSignalHandlerWaitingForPorcess(a0) MessageDscEngineSignalHandlerWaitingForPorcess_Impl(0, 0, tcs(a0))
+#endif
+FILE_EVENT1(4336, MessageDscEngineSignalHandlerWaitingForPorcess_Impl, LOG_WARNING, PAL_T("Job %s : \nDsc Engine waiting for Child Process to Terminate"), const TChar*)
+
 

--- a/LCM/dsc/engine/eventing/oidsc.h
+++ b/LCM/dsc/engine/eventing/oidsc.h
@@ -892,3 +892,24 @@ FILE_EVENT2(4331, MessageStartingDscOperation_Impl, LOG_WARNING, PAL_T("Job %s :
 #define MessageDscOperationCompleted(a0, a1, a2) MessageDscOperationCompleted_Impl(0, 0, tcs(a0), tcs(a1), tcs(a2))
 #endif
 FILE_EVENT3(4332, MessageDscOperationCompleted_Impl, LOG_WARNING, PAL_T("Job %s : %s DSC operation completed in %s seconds."), const TChar*, const TChar*, const TChar*)
+
+#if defined(CONFIG_ENABLE_DEBUG)
+#define MessageDscEngineProviderLoaded(a0) MessageDscEngineProviderLoaded_Impl(__FILE__, __LINE__, tcs(a0))
+#else
+#define MessageDscEngineProviderLoaded(a0) MessageDscEngineProviderLoaded_Impl(0, 0, tcs(a0))
+#endif
+FILE_EVENT1(4333, MessageDscEngineProviderLoaded_Impl,LOG_WARNING, PAL_T("Job %s : \nLoading DSC Engine Provider"), const TChar*)
+#if defined(CONFIG_ENABLE_DEBUG)
+#define MessageDscEngineProviderUnLoaded(a0) MessageDscEngineProviderUnLoaded_Impl(__FILE__, __LINE__, tcs(a0))
+#else
+#define MessageDscEngineProviderUnLoaded(a0) MessageDscEngineProviderUnLoaded_Impl(0, 0, tcs(a0))
+#endif
+FILE_EVENT1(4334, MessageDscEngineProviderUnLoaded_Impl, LOG_WARNING, PAL_T("Job %s : \nUnLoading DSC Engine Provider"), const TChar*)
+#if defined(CONFIG_ENABLE_DEBUG)
+#define MessageDscEngineRegisteringSignalHandler(a0) MessageDscEngineRegisteringSignalHandler_Impl(__FILE__, __LINE__, tcs(a0))
+#else
+#define MessageDscEngineRegisteringSignalHandler(a0) MessageDscEngineRegisteringSignalHandler_Impl(0, 0, tcs(a0))
+#endif
+FILE_EVENT1(4335, MessageDscEngineRegisteringSignalHandler_Impl, LOG_WARNING, PAL_T("Job %s : \nRegistered Process Signal Handler for SIGCHLD Event"), const TChar*)
+
+

--- a/LCM/dsc/engine/eventing/oidsc.h
+++ b/LCM/dsc/engine/eventing/oidsc.h
@@ -898,25 +898,25 @@ FILE_EVENT3(4332, MessageDscOperationCompleted_Impl, LOG_WARNING, PAL_T("Job %s 
 #else
 #define MessageDscEngineProviderLoaded(a0) MessageDscEngineProviderLoaded_Impl(0, 0, tcs(a0))
 #endif
-FILE_EVENT1(4333, MessageDscEngineProviderLoaded_Impl,LOG_WARNING, PAL_T("Job %s : \nLoading DSC Engine Provider"), const TChar*)
+FILE_EVENT1(4333, MessageDscEngineProviderLoaded_Impl,LOG_INFO, PAL_T("Job %s : \nLoading DSC Engine Provider"), const TChar*)
 #if defined(CONFIG_ENABLE_DEBUG)
 #define MessageDscEngineProviderUnLoaded(a0) MessageDscEngineProviderUnLoaded_Impl(__FILE__, __LINE__, tcs(a0))
 #else
 #define MessageDscEngineProviderUnLoaded(a0) MessageDscEngineProviderUnLoaded_Impl(0, 0, tcs(a0))
 #endif
-FILE_EVENT1(4334, MessageDscEngineProviderUnLoaded_Impl, LOG_WARNING, PAL_T("Job %s : \nUnLoading DSC Engine Provider"), const TChar*)
+FILE_EVENT1(4334, MessageDscEngineProviderUnLoaded_Impl, LOG_INFO, PAL_T("Job %s : \nUnLoading DSC Engine Provider"), const TChar*)
 #if defined(CONFIG_ENABLE_DEBUG)
 #define MessageDscEngineRegisteringSignalHandler(a0) MessageDscEngineRegisteringSignalHandler_Impl(__FILE__, __LINE__, tcs(a0))
 #else
 #define MessageDscEngineRegisteringSignalHandler(a0) MessageDscEngineRegisteringSignalHandler_Impl(0, 0, tcs(a0))
 #endif
-FILE_EVENT1(4335, MessageDscEngineRegisteringSignalHandler_Impl, LOG_WARNING, PAL_T("Job %s : \nRegistered Process Signal Handler for SIGCHLD Event"), const TChar*)
+FILE_EVENT1(4335, MessageDscEngineRegisteringSignalHandler_Impl, LOG_DEBUG, PAL_T("Job %s : \nRegistered Process Signal Handler for SIGCHLD Event"), const TChar*)
 
 #if defined(CONFIG_ENABLE_DEBUG)
 #define MessageDscEngineSignalHandlerWaitingForPorcess(a0) MessageDscEngineSignalHandlerWaitingForPorcess_Impl(__FILE__, __LINE__, tcs(a0))
 #else
 #define MessageDscEngineSignalHandlerWaitingForPorcess(a0) MessageDscEngineSignalHandlerWaitingForPorcess_Impl(0, 0, tcs(a0))
 #endif
-FILE_EVENT1(4336, MessageDscEngineSignalHandlerWaitingForPorcess_Impl, LOG_WARNING, PAL_T("Job %s : \nDsc Engine waiting for Child Process to Terminate"), const TChar*)
+FILE_EVENT1(4336, MessageDscEngineSignalHandlerWaitingForPorcess_Impl, LOG_DEBUG, PAL_T("Job %s : \nDsc Engine waiting for Child Process to Terminate"), const TChar*)
 
 

--- a/Providers/PythonProvider.cpp
+++ b/Providers/PythonProvider.cpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <cstring>
+#include <vector>
 #include <errno.h>
 #include <fcntl.h>
 #include <functional>
@@ -259,46 +260,21 @@ PythonProvider::~PythonProvider ()
     {
         close (m_FD);
     }
-    if (m_pid != -2)
+    if( m_pid > 0 )
     {
 	waitpid(m_pid, NULL, 0);
     }
-}
-
-/* PythonProvider::init() creates a child process (referenced by m_pid) to execute dsc python resources using client.py script.
-   When execution of python resource (child process) is completed, it doesn’t disappear completely.
-   Instead it becomes Zombie which is not capable to execute anything.
-   Any further call to client.py (via socket) will fail.
-
-   The Zombie processes can be simply removed by registering for SIGCHLD signal and calling waitpid API from handler.
-
-   This method is a SIGCHLD handler, which is raised when a child process is terminated.
-*/
-void PythonProvider::handleChildSignal(int sig) {
-    int saved_errno = errno;
-
-    // Obtain information about the child whose state has changed, and release it.
-    // Only one instance of SIGCHLD can be queued, so it becomes necessary to reap
-    // several zombie processes during one invocation of the handler function.
-    while (waitpid((pid_t)(-1), 0, WNOHANG) > 0) {}
-    errno = saved_errno;
+    for(size_t xCount = 0 ; xCount < m_PreviousPid.size(); xCount++)
+    {
+	waitpid(m_PreviousPid[xCount] , NULL, WNOHANG);
+    }
+    m_PreviousPid.clear();
 }
 
 int
 PythonProvider::init ()
 {
     int rval = EXIT_SUCCESS;
-
-    // Register child process signal handler
-    if(CHILD_SIGNAL_REGISTERED == MI_FALSE)
-    {
-        struct sigaction sa;
-        sa.sa_handler = &handleChildSignal;
-        sigemptyset(&sa.sa_mask);
-        sa.sa_flags = SA_RESTART | SA_NOCLDSTOP;
-        sigaction(SIGCHLD, &sa, 0);
-        CHILD_SIGNAL_REGISTERED = MI_TRUE;
-    }
 
 #if (PRINT_BOOKENDS)
     std::ostringstream strm;
@@ -548,13 +524,14 @@ PythonProvider::forkExec ()
     if (INVALID_SOCKET == m_FD)
     {
         int sockets[2];
+	int pid;
         int result = socketpair (AF_UNIX, SOCK_STREAM, 0, sockets);
         if (-1 != result)
         {
             // socketpair succeeded
             SCX_BOOKEND_PRINT ("socketpair - succeeded");
-            m_pid = fork ();
-            if (0 == m_pid)
+            pid = fork ();
+            if (0 == pid)
             {
                 // fork succeded, this is the child process
                 SCX_BOOKEND_PRINT ("fork - succeeded: this is the child");
@@ -581,8 +558,9 @@ PythonProvider::forkExec ()
                 strm.clear ();
                 rval = EXIT_FAILURE;
             }
-            else if (-1 != m_pid)
+            else if (-1 != pid)
             {
+	    	m_pid=pid;
                 // fork succeeded, this is the parent process
                 SCX_BOOKEND_PRINT ("fork - succeeded: this is the parent");
                 close (sockets[0]);
@@ -655,6 +633,18 @@ PythonProvider::verifySocketState ()
     }
     if (INVALID_SOCKET == m_FD)
     {
+        //Release previous disconnected child process if any
+        if( m_pid > 0 )
+        {
+           // It is possible that disconnected process is still running, in that case
+           // try to do cleanup when the provider is unloaded.
+            if( waitpid(m_pid , NULL, WNOHANG) == 0 )
+            {
+                //If process isn't done, cleanup will be done when the provider is unloaded
+                m_PreviousPid.push_back(m_pid);
+            }
+            m_pid = -2;
+        }
         result = init ();
     }
     return result;

--- a/Providers/PythonProvider.hpp
+++ b/Providers/PythonProvider.hpp
@@ -30,6 +30,7 @@
 #include <sstream>
 #include <sys/socket.h>
 #include <unistd.h>
+#include <vector>
 
 
 namespace scx
@@ -150,6 +151,7 @@ private:
     std::string const m_Name;
     int m_FD;
     int m_pid;
+    std::vector<int> m_PreviousPid;
 };
 
 
@@ -164,7 +166,6 @@ PythonProvider::PythonProvider (
     T const& name)
     : m_Name (name)
     , m_FD (PythonProvider::INVALID_SOCKET)
-    , m_pid (-2)
 {
     // empty
 }

--- a/Providers/PythonProvider.hpp
+++ b/Providers/PythonProvider.hpp
@@ -166,6 +166,7 @@ PythonProvider::PythonProvider (
     T const& name)
     : m_Name (name)
     , m_FD (PythonProvider::INVALID_SOCKET)
+    , m_pid(-2)
 {
     // empty
 }


### PR DESCRIPTION
The issue is that when provider shared library is unloaded and loaded again in the same process, we have still registered signal handler. The address for the signal handler becomes invalid due to shared library reload causing crash whenever the process does a fork.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/powershell-dsc-for-linux/380)
<!-- Reviewable:end -->
