### PR TITLE
Showing failure if OMS_MetaConfigHelper.py fails

### DIFF
--- a/LCM/scripts/OMS_MetaConfigHelper.py
+++ b/LCM/scripts/OMS_MetaConfigHelper.py
@@ -2,6 +2,7 @@
 import os
 import sys
 import imp
+import subprocess
 from os.path import basename, dirname, join, realpath, split
 
 conf_path = "/etc/opt/microsoft/omsagent/conf/omsadmin.conf"
@@ -206,9 +207,13 @@ else:
     commandToRun = "/opt/microsoft/omsconfig/Scripts/SetDscLocalConfigurationManager.py -configurationmof " + metamof_path
 
 # Apply the metaconfig using SetDscLocalConfiguration
-retval = os.system(commandToRun)
-if (retval != 0):
-    exitWithError("Error on running command: " + commandToRun)
+proc = subprocess.Popen(commandToRun, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, close_fds=True)
+exit_code = proc.wait()
+printVerboseMessage("Output from: " + commandToRun + ": " + proc.stdout.read())
+errorMsg = proc.stderr.read()
+
+if ((exit_code != 0) or (errorMsg)):
+    exitWithError(("Error on running command: " + commandToRun + " Error Message: " + errorMsg), exit_code)
 else:
     printVerboseMessage("Successfully configured omsconfig.")
 

--- a/LCM/scripts/OMS_MetaConfigHelper.py
+++ b/LCM/scripts/OMS_MetaConfigHelper.py
@@ -209,11 +209,12 @@ else:
 # Apply the metaconfig using SetDscLocalConfiguration
 proc = subprocess.Popen(commandToRun, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, close_fds=True)
 exit_code = proc.wait()
-printVerboseMessage("Output from: " + commandToRun + ": " + proc.stdout.read())
-errorMsg = proc.stderr.read()
 
-if ((exit_code != 0) or (errorMsg)):
-    exitWithError(("Error on running command: " + commandToRun + " Error Message: " + errorMsg), exit_code)
+stdout, stderr = proc.communicate()
+printVerboseMessage("Output from: " + commandToRun + ": " + stdout)
+
+if ((exit_code != 0) or (stderr)):
+    exitWithError(("Error on running command: " + commandToRun + " Error Message: " + stderr), exit_code)
 else:
     printVerboseMessage("Successfully configured omsconfig.")
 

--- a/LCM/scripts/SetDscLocalConfigurationManager.py
+++ b/LCM/scripts/SetDscLocalConfigurationManager.py
@@ -46,7 +46,7 @@ parameters.append("}")
 
 
 # Apply the metaconfig
-proc = subprocess.Popen(parameters, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+proc = subprocess.Popen(parameters, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
 exit_code = proc.wait()
 print(proc.stdout.read())
 errorMsg = proc.stderr.read()

--- a/LCM/scripts/SetDscLocalConfigurationManager.py
+++ b/LCM/scripts/SetDscLocalConfigurationManager.py
@@ -44,14 +44,17 @@ for token in outtokens:
 parameters.append("]")
 parameters.append("}")
 
-#s = ""
-#for param in parameters:
-#    s += param + " "
 
-p = subprocess.Popen(parameters, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-stdout, stderr = p.communicate()
+# Apply the metaconfig
+proc = subprocess.Popen(parameters, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+exit_code = proc.wait()
+print(proc.stdout.read())
+errorMsg = proc.stderr.read()
 
-print(stdout)
-print(stderr)
+if ((exit_code != 0) or (errorMsg)):
+    sys.stderr.write(errorMsg)
+    sys.exit(1)
+else:
+    print("Successfully applied metaconfig.")
 
 

--- a/LCM/scripts/SetDscLocalConfigurationManager.py
+++ b/LCM/scripts/SetDscLocalConfigurationManager.py
@@ -48,11 +48,12 @@ parameters.append("}")
 # Apply the metaconfig
 proc = subprocess.Popen(parameters, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
 exit_code = proc.wait()
-print(proc.stdout.read())
-errorMsg = proc.stderr.read()
 
-if ((exit_code != 0) or (errorMsg)):
-    sys.stderr.write(errorMsg)
+stdout, stderr = proc.communicate()
+print(stdout)
+
+if ((exit_code != 0) or (stderr)):
+    sys.stderr.write(stderr)
     sys.exit(1)
 else:
     print("Successfully applied metaconfig.")


### PR DESCRIPTION
Currently if there's any failures from this file, we still print 'Successfully configured omsconfig' because there was an incorrect check for whether the call to setlcm failed or not. This fixes that and ensures all of the errors are logged.