### PR TITLE
Don't upload the files which are greater than specified size

### DIFF
--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxFileInventory.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxFileInventory.py
@@ -126,7 +126,7 @@ def Inventory_Marshall(DestinationPath, Recurse, Links, Checksum, Type, MaxConte
         d['DestinationPath'] = protocol.MI_String(d['DestinationPath'])
         d['Checksum'] = protocol.MI_String(d['Checksum'])
         d['Type'] = protocol.MI_String(d['Type'])
-        d['Contents'] = protocol.MI_String(d['Contents'])
+        d['Contents'] = protocol.MI_String(MaxContentsReturnable)
         d['ModifiedDate'] = protocol.MI_Timestamp.from_time(d['ModifiedDate'])
         d['CreatedDate'] = protocol.MI_Timestamp.from_time(d['CreatedDate'])
         d['Mode'] = protocol.MI_String(d['Mode'])

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxFileInventory.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxFileInventory.py
@@ -129,7 +129,7 @@ def Inventory_Marshall(DestinationPath, Recurse, Links, Checksum, Type, MaxConte
         d['DestinationPath'] = protocol.MI_String(d['DestinationPath'])
         d['Checksum'] = protocol.MI_String(d['Checksum'])
         d['Type'] = protocol.MI_String(d['Type'])
-        d['Contents'] = protocol.MI_String(d['Contents'])
+        d['Contents'] = protocol.MI_String(MaxContentsReturnable)
         d['ModifiedDate'] = protocol.MI_Timestamp.from_time(d['ModifiedDate'])
         d['CreatedDate'] = protocol.MI_Timestamp.from_time(d['CreatedDate'])
         d['Mode'] = protocol.MI_String(d['Mode'])

--- a/Providers/Scripts/3.x/Scripts/nxFileInventory.py
+++ b/Providers/Scripts/3.x/Scripts/nxFileInventory.py
@@ -129,7 +129,7 @@ def Inventory_Marshall(DestinationPath, Recurse, Links, Checksum, Type, MaxConte
         d['DestinationPath'] = protocol.MI_String(d['DestinationPath'])
         d['Checksum'] = protocol.MI_String(d['Checksum'])
         d['Type'] = protocol.MI_String(d['Type'])
-        d['Contents'] = protocol.MI_String(d['Contents'])
+        d['Contents'] = protocol.MI_String(MaxContentsReturnable)
         d['ModifiedDate'] = protocol.MI_Timestamp.from_time(d['ModifiedDate'])
         d['CreatedDate'] = protocol.MI_Timestamp.from_time(d['CreatedDate'])
         d['Mode'] = protocol.MI_String(d['Mode'])


### PR DESCRIPTION
This checkin, allows file upload to be controlled by settings from AMS.
The files below the specified file size will be uploaded. The specified file size will now come through 'ContentLength' in the change records returned by the resource.