### PR TITLE
Adding logging and explicit permissions checks on files

### DIFF
--- a/LCM/scripts/InstallModule.py
+++ b/LCM/scripts/InstallModule.py
@@ -286,9 +286,17 @@ def main(args):
 
         resourceLibraryFileDestinationPath = join(helperlib.CONFIG_LIBDIR, resourceLibraryFileDestinationName)
 
+        # Python 2.4 and 3 recognize different formats for octal
+        if sys.version_info >= (3, 0):
+            strMask = "0o777"
+        else:
+            strMask = "0777"
+
+        octMask = int(strMask, base=8)
+
         shutil.copy(resourceLibraryFileSourcePath, resourceLibraryFileDestinationPath)
-        os.chmod(resourceLibraryFileDestinationPath , 0o644)
-        filePermission = oct(os.stat(resourceLibraryFileDestinationPath).st_mode & 0o777)
+        os.chmod(resourceLibraryFileDestinationPath , stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
+        filePermission = oct(os.stat(resourceLibraryFileDestinationPath).st_mode & octMask)
         if filePermission == "0644" or filePermission == "0o644":
             printVerboseMessage("Updated permissions of file: " + resourceLibraryFileDestinationPath + " to " + filePermission)
         else:
@@ -301,8 +309,8 @@ def main(args):
 
         if helperlib.DSC_NAMESPACE == "root/Microsoft/DesiredStateConfiguration":
             shutil.copy(resourceOmiRegistrationFileSourcePath, resourceOmiRegistrationFileDestinationPath)
-            os.chmod(resourceOmiRegistrationFileDestinationPath, 0o644)
-            filePermission = oct(os.stat(resourceOmiRegistrationFileDestinationPath).st_mode & 0o777)
+            os.chmod(resourceOmiRegistrationFileDestinationPath, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
+            filePermission = oct(os.stat(resourceOmiRegistrationFileDestinationPath).st_mode & octMask)
             if filePermission == "0644" or filePermission == "0o644":
                 printVerboseMessage("Updated permissions of file: " + resourceOmiRegistrationFileDestinationPath + " to " + filePermission)
             else:

--- a/LCM/scripts/InstallModule.py
+++ b/LCM/scripts/InstallModule.py
@@ -131,7 +131,7 @@ def main(args):
             moduleZipExtrationPath = helperlib.DSC_MODULES_PATH
         else:
             moduleZipExtrationPath = join(helperlib.DSC_MODULES_PATH, moduleName)
-        
+
         # Extract module to destination path
         printVerboseMessage("Extracting module zip file from " + moduleZipFilePath + " to " + moduleZipExtrationPath)
         moduleZipFile.extractall(moduleZipExtrationPath)
@@ -149,7 +149,7 @@ def main(args):
         exitWithError("Unable to find the DSCResources directory under the module directory at the path " + moduleDscResourcesDestinationPath + " after extracting module from zip to the path.")
 
     # Populate commom main DSC path
-    dscMainFolderPath = join(helperlib.CONFIG_SYSCONFDIR, helperlib.CONFIG_SYSCONFDIR_DSC) 
+    dscMainFolderPath = join(helperlib.CONFIG_SYSCONFDIR, helperlib.CONFIG_SYSCONFDIR_DSC)
 
     # Verify the module checksum if specified
     if verifyChecksum:
@@ -169,7 +169,7 @@ def main(args):
         sha256SumsFilePath = join(moduleDestinationPath, sha256SumsFileName)
         if not os.path.isfile(sha256SumsFilePath):
             exitWithError("Unable to find module SHA256 sums file at " + sha256SumsFilePath)
-            
+
         # Verify the SHA256 sums file with the keyring and asc files
         verifySha256SumsCommand = "HOME=" + dscMainFolderPath + " gpg --no-default-keyring --keyring " + keyringFilePath + " --verify " + ascFilePath  + " " + sha256SumsFilePath
         verifySha256SumsResult = subprocess.call(verifySha256SumsCommand, shell = True)
@@ -206,7 +206,7 @@ def main(args):
     # Install the module's resources
     moduleResources = os.listdir(moduleDscResourcesDestinationPath)
 
-    for resource in moduleResources: 
+    for resource in moduleResources:
         resourceFolderPath = join(moduleDscResourcesDestinationPath, resource)
 
         # Skip anything that is not a directory
@@ -286,6 +286,8 @@ def main(args):
         resourceLibraryFileDestinationPath = join(helperlib.CONFIG_LIBDIR, resourceLibraryFileDestinationName)
 
         shutil.copy(resourceLibraryFileSourcePath, resourceLibraryFileDestinationPath)
+        os.chmod(resourceLibraryFileDestinationPath , stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
+        printVerboseMessage("Updated permissions of file: " + resourceLibraryFileDestinationPath + " to  644")
 
         # Copy or write the OMI registration file to the OMI registration folder
         resourceOmiRegistrationFileName = resource + ".reg"
@@ -294,6 +296,9 @@ def main(args):
 
         if helperlib.DSC_NAMESPACE == "root/Microsoft/DesiredStateConfiguration":
             shutil.copy(resourceOmiRegistrationFileSourcePath, resourceOmiRegistrationFileDestinationPath)
+            os.chmod(resourceOmiRegistrationFileDestinationPath, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
+            printVerboseMessage("Updated permissions of file: " + resourceOmiRegistrationFileDestinationPath + " to  644")
+
         else:
             # Read the resource OMI registration file
             resourceOmiRegistrationFileSourceHandle = open(resourceOmiRegistrationFileSourcePath, "r")

--- a/LCM/scripts/InstallModule.py
+++ b/LCM/scripts/InstallModule.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 import imp
 import os
+import stat
 import shutil
 import subprocess
 import sys
@@ -287,7 +288,11 @@ def main(args):
 
         shutil.copy(resourceLibraryFileSourcePath, resourceLibraryFileDestinationPath)
         os.chmod(resourceLibraryFileDestinationPath , stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
-        printVerboseMessage("Updated permissions of file: " + resourceLibraryFileDestinationPath + " to  644")
+        filePermission = oct(os.stat(resourceLibraryFileDestinationPath).st_mode & 0o777)
+        if filePermission == "0644":
+            printVerboseMessage("Updated permissions of file: " + resourceLibraryFileDestinationPath + " to " + filePermission)
+        else:
+            exitWithError("Permissions on file: " + resourceLibraryFileDestinationPath + " set incorrectly: " + filePermission)
 
         # Copy or write the OMI registration file to the OMI registration folder
         resourceOmiRegistrationFileName = resource + ".reg"
@@ -297,7 +302,11 @@ def main(args):
         if helperlib.DSC_NAMESPACE == "root/Microsoft/DesiredStateConfiguration":
             shutil.copy(resourceOmiRegistrationFileSourcePath, resourceOmiRegistrationFileDestinationPath)
             os.chmod(resourceOmiRegistrationFileDestinationPath, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
-            printVerboseMessage("Updated permissions of file: " + resourceOmiRegistrationFileDestinationPath + " to  644")
+            filePermission = oct(os.stat(resourceOmiRegistrationFileDestinationPath).st_mode & 0o777)
+            if filePermission == "0644":
+                printVerboseMessage("Updated permissions of file: " + resourceOmiRegistrationFileDestinationPath + " to " + filePermission)
+            else:
+                exitWithError("Permissions on file: " + resourceOmiRegistrationFileDestinationPath + " set incorrectly: " + filePermission)
 
         else:
             # Read the resource OMI registration file

--- a/LCM/scripts/InstallModule.py
+++ b/LCM/scripts/InstallModule.py
@@ -288,15 +288,15 @@ def main(args):
 
         # Python 2.4 and 3 recognize different formats for octal
         if sys.version_info >= (3, 0):
-            strMask = "0o777"
+            strMode = "0o777"
         else:
-            strMask = "0777"
+            strMode = "0777"
 
-        octMask = int(strMask, base=8)
+        octMode = int(strMode, base=8)
 
         shutil.copy(resourceLibraryFileSourcePath, resourceLibraryFileDestinationPath)
         os.chmod(resourceLibraryFileDestinationPath , stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
-        filePermission = oct(os.stat(resourceLibraryFileDestinationPath).st_mode & octMask)
+        filePermission = oct(os.stat(resourceLibraryFileDestinationPath).st_mode & octMode)
         if filePermission == "0644" or filePermission == "0o644":
             printVerboseMessage("Updated permissions of file: " + resourceLibraryFileDestinationPath + " to " + filePermission)
         else:
@@ -310,7 +310,7 @@ def main(args):
         if helperlib.DSC_NAMESPACE == "root/Microsoft/DesiredStateConfiguration":
             shutil.copy(resourceOmiRegistrationFileSourcePath, resourceOmiRegistrationFileDestinationPath)
             os.chmod(resourceOmiRegistrationFileDestinationPath, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
-            filePermission = oct(os.stat(resourceOmiRegistrationFileDestinationPath).st_mode & octMask)
+            filePermission = oct(os.stat(resourceOmiRegistrationFileDestinationPath).st_mode & octMode)
             if filePermission == "0644" or filePermission == "0o644":
                 printVerboseMessage("Updated permissions of file: " + resourceOmiRegistrationFileDestinationPath + " to " + filePermission)
             else:

--- a/LCM/scripts/InstallModule.py
+++ b/LCM/scripts/InstallModule.py
@@ -287,9 +287,9 @@ def main(args):
         resourceLibraryFileDestinationPath = join(helperlib.CONFIG_LIBDIR, resourceLibraryFileDestinationName)
 
         shutil.copy(resourceLibraryFileSourcePath, resourceLibraryFileDestinationPath)
-        os.chmod(resourceLibraryFileDestinationPath , stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
+        os.chmod(resourceLibraryFileDestinationPath , 0o644)
         filePermission = oct(os.stat(resourceLibraryFileDestinationPath).st_mode & 0o777)
-        if filePermission == "0644":
+        if filePermission == "0644" or filePermission == "0o644":
             printVerboseMessage("Updated permissions of file: " + resourceLibraryFileDestinationPath + " to " + filePermission)
         else:
             exitWithError("Permissions on file: " + resourceLibraryFileDestinationPath + " set incorrectly: " + filePermission)
@@ -301,9 +301,9 @@ def main(args):
 
         if helperlib.DSC_NAMESPACE == "root/Microsoft/DesiredStateConfiguration":
             shutil.copy(resourceOmiRegistrationFileSourcePath, resourceOmiRegistrationFileDestinationPath)
-            os.chmod(resourceOmiRegistrationFileDestinationPath, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
+            os.chmod(resourceOmiRegistrationFileDestinationPath, 0o644)
             filePermission = oct(os.stat(resourceOmiRegistrationFileDestinationPath).st_mode & 0o777)
-            if filePermission == "0644":
+            if filePermission == "0644" or filePermission == "0o644":
                 printVerboseMessage("Updated permissions of file: " + resourceOmiRegistrationFileDestinationPath + " to " + filePermission)
             else:
                 exitWithError("Permissions on file: " + resourceOmiRegistrationFileDestinationPath + " set incorrectly: " + filePermission)

--- a/LCM/scripts/InstallModule.py
+++ b/LCM/scripts/InstallModule.py
@@ -256,6 +256,14 @@ def main(args):
 
         pythonVersionFileNames = ['2.4x-2.5x', '2.6x-2.7x', '3.x']
 
+        # Python 2.4 and 3 recognize different formats for octal
+        if sys.version_info >= (3, 0):
+            strMode = "0o777"
+        else:
+            strMode = "0777"
+
+        octMode = int(strMode, base=8)
+
         for pythonVersionFileName in pythonVersionFileNames:
             resourceScriptsPythonVersionFolderPath = join(resourceScriptsFolderPath, pythonVersionFileName)
             if not os.path.isdir(resourceScriptsPythonVersionFolderPath):
@@ -285,14 +293,6 @@ def main(args):
             resourceLibraryFileDestinationName = resourceLibraryFileName.replace('.so', "_" + omiNamespaceFolderName + ".so")
 
         resourceLibraryFileDestinationPath = join(helperlib.CONFIG_LIBDIR, resourceLibraryFileDestinationName)
-
-        # Python 2.4 and 3 recognize different formats for octal
-        if sys.version_info >= (3, 0):
-            strMode = "0o777"
-        else:
-            strMode = "0777"
-
-        octMode = int(strMode, base=8)
 
         shutil.copy(resourceLibraryFileSourcePath, resourceLibraryFileDestinationPath)
         os.chmod(resourceLibraryFileDestinationPath , stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)

--- a/LCM/scripts/InstallModule.py
+++ b/LCM/scripts/InstallModule.py
@@ -207,6 +207,14 @@ def main(args):
     # Install the module's resources
     moduleResources = os.listdir(moduleDscResourcesDestinationPath)
 
+    # Python 2.4 and 3 recognize different formats for octal
+    if sys.version_info >= (3, 0):
+        strMode = "0o777"
+    else:
+        strMode = "0777"
+
+    octMode = int(strMode, base=8)
+
     for resource in moduleResources:
         resourceFolderPath = join(moduleDscResourcesDestinationPath, resource)
 
@@ -255,14 +263,6 @@ def main(args):
             exitWithError("Unable to find the resource library scripts folder for the resource " + resource + " and platform architecture " + resourceArchitectureFolderName + " at the path " + resourceScriptsFolderPath + " in the extracted module.")
 
         pythonVersionFileNames = ['2.4x-2.5x', '2.6x-2.7x', '3.x']
-
-        # Python 2.4 and 3 recognize different formats for octal
-        if sys.version_info >= (3, 0):
-            strMode = "0o777"
-        else:
-            strMode = "0777"
-
-        octMode = int(strMode, base=8)
 
         for pythonVersionFileName in pythonVersionFileNames:
             resourceScriptsPythonVersionFolderPath = join(resourceScriptsFolderPath, pythonVersionFileName)

--- a/LCM/scripts/PerformInventory.py
+++ b/LCM/scripts/PerformInventory.py
@@ -121,11 +121,11 @@ if len(dsc_sysconfdir) < 10:
 # If inventory lock files already exists update its permissions.
 if os.path.isfile(inventorylock_path):
     os.chmod(inventorylock_path , stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
-    printVerboseMessage("Updated permissions of file: " + inventorylock_path + " to  644")
+    printVerboseMessage("Updated permissions of file: " + inventorylock_path + " to 0644")
 
 # open the inventory lock file, this also creates a file if it does not exist so we are using 644 permissions
 filehandle = os.open(inventorylock_path, os.O_WRONLY | os.O_CREAT , 0o644)
-printVerboseMessage("Opened file: " + inventorylock_path + "with permissions set to 644")
+printVerboseMessage("Opened file: " + inventorylock_path + " with permissions set to 0644")
 inventory_lock = os.fdopen(filehandle, 'w')
 
 # Acquire inventory file lock

--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -202,8 +202,10 @@ chgrp omsagent /var/opt/microsoft/omsconfig
 
 #if BUILD_OMS == 1
 mkdir -p $OMI_REGISTER_DIR/root-oms
+chmod 755 $OMI_REGISTER_DIR/root-oms
 cp -f /opt/microsoft/${{SHORT_NAME}}/etc/*.reg $OMI_REGISTER_DIR/root-oms
 cp -f /opt/microsoft/${{SHORT_NAME}}/etc/omsconfig.reg $OMI_REGISTER_DIR/root-oms
+chmod 644 $OMI_REGISTER_DIR/root-oms/*.reg
 ln -fs /opt/microsoft/${{SHORT_NAME}}/lib/libomsconfig.so $OMI_HOME/lib/libomsconfig.so
 ln -fs /opt/microsoft/${{SHORT_NAME}}/bin/OMSConsistencyInvoker $OMI_HOME/bin/OMSConsistencyInvoker
 


### PR DESCRIPTION
We've had multiple issues come in about file permissions getting changed/set incorrectly. These changes will explicitly set the permissions of the files that we've seen issues with and throw an error if the permissions are set wrong during installation.

I've tested these changes with a custom OMS build.