### PR TITLE
Fixing fqdn for wli discovery packets

### DIFF
--- a/Providers/Modules/WLI/plugins/common/in_wlm_discovery.rb
+++ b/Providers/Modules/WLI/plugins/common/in_wlm_discovery.rb
@@ -46,6 +46,9 @@ module Fluent
       discovery_data = omi_lib.get_discovery_data()
       wlm_formatter = WLM::WLMDataFormatter.new(@wlm_class_file)
       discovery_data.each do |wclass|
+  	if wclass["class_name"].to_s == "Universal Linux Computer"
+	  wclass["discovery_data"][0][0]["CSName"] = OMS::Common.get_fully_qualified_domain_name
+	end
         discovery_xml = wlm_formatter.get_discovery_xml(wclass)
         instance = {}
         instance["Host"] = OMS::Common.get_fully_qualified_domain_name


### PR DESCRIPTION
The discovery data sent by the WLI discovery input plugin uses "SCX" provided host names, which are sometimes inconsistent with what the performance data sent by the input omi plugins. With this PR the WLI input plugin overwrites the SCX provided host names with the default fqdn.