### PR TITLE
Fixing The File Permissions For The OMI Registration Files

### DIFF
--- a/LCM/scripts/InstallModule.py
+++ b/LCM/scripts/InstallModule.py
@@ -309,12 +309,6 @@ def main(args):
 
         if helperlib.DSC_NAMESPACE == "root/Microsoft/DesiredStateConfiguration":
             shutil.copy(resourceOmiRegistrationFileSourcePath, resourceOmiRegistrationFileDestinationPath)
-            os.chmod(resourceOmiRegistrationFileDestinationPath, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
-            filePermission = oct(os.stat(resourceOmiRegistrationFileDestinationPath).st_mode & octMode)
-            if filePermission == "0644" or filePermission == "0o644":
-                printVerboseMessage("Updated permissions of file: " + resourceOmiRegistrationFileDestinationPath + " to " + filePermission)
-            else:
-                exitWithError("Permissions on file: " + resourceOmiRegistrationFileDestinationPath + " set incorrectly: " + filePermission)
 
         else:
             # Read the resource OMI registration file
@@ -333,6 +327,13 @@ def main(args):
                 resourceOmiRegistrationFileDesintationHandle.write(resourceOmiRegistrationFileContentWithOmsLib)
             finally:
                 resourceOmiRegistrationFileDesintationHandle.close()
+
+        os.chmod(resourceOmiRegistrationFileDestinationPath, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
+        filePermission = oct(os.stat(resourceOmiRegistrationFileDestinationPath).st_mode & octMode)
+        if filePermission == "0644" or filePermission == "0o644":
+            printVerboseMessage("Updated permissions of file: " + resourceOmiRegistrationFileDestinationPath + " to " + filePermission)
+        else:
+            exitWithError("Permissions on file: " + resourceOmiRegistrationFileDestinationPath + " set incorrectly: " + filePermission)
 
     # Regenerate the DSC Python scripts init files
     regenerateDscPythonScriptInitFiles()

--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -269,6 +269,9 @@ chmod 644 $OMI_REGISTER_DIR/root-oms/*.reg
 # Set up built-in resource module for DIY DSC
 /opt/microsoft/dsc/Scripts/InstallModule.py /opt/microsoft/dsc/module_packages/nx_1.0.zip 0
 
+# Ensure .reg files all have correct permissions
+chmod 644 $OMI_REGISTER_DIR/root-Microsoft-DesiredStateConfiguration/*.reg
+
 #endif
 
 if [ -d  $OMI_LIB/Scripts ]; then

--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -269,9 +269,6 @@ chmod 644 $OMI_REGISTER_DIR/root-oms/*.reg
 # Set up built-in resource module for DIY DSC
 /opt/microsoft/dsc/Scripts/InstallModule.py /opt/microsoft/dsc/module_packages/nx_1.0.zip 0
 
-# Ensure .reg files all have correct permissions
-chmod 644 $OMI_REGISTER_DIR/root-Microsoft-DesiredStateConfiguration/*.reg
-
 #endif
 
 if [ -d  $OMI_LIB/Scripts ]; then

--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -205,7 +205,6 @@ mkdir -p $OMI_REGISTER_DIR/root-oms
 chmod 755 $OMI_REGISTER_DIR/root-oms
 cp -f /opt/microsoft/${{SHORT_NAME}}/etc/*.reg $OMI_REGISTER_DIR/root-oms
 cp -f /opt/microsoft/${{SHORT_NAME}}/etc/omsconfig.reg $OMI_REGISTER_DIR/root-oms
-chmod 644 $OMI_REGISTER_DIR/root-oms/*.reg
 ln -fs /opt/microsoft/${{SHORT_NAME}}/lib/libomsconfig.so $OMI_HOME/lib/libomsconfig.so
 ln -fs /opt/microsoft/${{SHORT_NAME}}/bin/OMSConsistencyInvoker $OMI_HOME/bin/OMSConsistencyInvoker
 
@@ -261,6 +260,9 @@ if [ -f /opt/microsoft/dsc/Scripts/InstallModule.py ]; then
     /opt/microsoft/dsc/Scripts/InstallModule.py /opt/microsoft/dsc/module_packages/nx_1.0.zip 0
   fi
 fi
+
+# Ensure .reg files all have correct permissions
+chmod 644 $OMI_REGISTER_DIR/root-oms/*.reg
 
 #else
 


### PR DESCRIPTION
My last PR didn't catch all of the files that had permission issues - now they should all be being set correctly. I have tested that these changes work with a new build and I confirmed that these changes fix the issue where the umask is set to something other than the default (022).