### PR TITLE
Add Permissions to Log File on Install

### DIFF
--- a/LCM/scripts/InstallModule.py
+++ b/LCM/scripts/InstallModule.py
@@ -8,10 +8,13 @@ import sys
 import platform
 
 from os.path import basename, dirname, join, realpath, split
+
 pathToCurrentScript = realpath(__file__)
 pathToCommonScriptsFolder = dirname(pathToCurrentScript)
+
 helperLibPath = join(pathToCommonScriptsFolder, 'helperlib.py')
 helperlib = imp.load_source('helperlib', helperLibPath)
+
 fullPathDSCLogger = os.path.join(pathToCommonScriptsFolder, 'nxDSCLog.py')
 nxDSCLog = imp.load_source('nxDSCLog', fullPathDSCLogger)
 logger = nxDSCLog.ConsoleAndFileLogger()

--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -198,13 +198,20 @@ chgrp omsagent /var/opt/microsoft/omsconfig
 chmod 755 /var/opt/microsoft/omsconfig
 
 # Set up log file
-if [! -f /var/opt/microsoft/omsconfig/omsconfig.log ]
-then
+if [ ! -f /var/opt/microsoft/omsconfig/omsconfig.log ]; then
     touch /var/opt/microsoft/omsconfig/omsconfig.log
 fi
 chown omsagent /var/opt/microsoft/omsconfig/omsconfig.log
 chgrp omsagent /var/opt/microsoft/omsconfig/omsconfig.log
 chmod 644 /var/opt/microsoft/omsconfig/omsconfig.log
+
+# Set up detailed log file
+if [ ! -f /var/opt/microsoft/omsconfig/omsconfigdetailed.log ]; then
+    touch /var/opt/microsoft/omsconfig/omsconfigdetailed.log
+fi
+chown omsagent /var/opt/microsoft/omsconfig/omsconfigdetailed.log
+chgrp omsagent /var/opt/microsoft/omsconfig/omsconfigdetailed.log
+chmod 644 /var/opt/microsoft/omsconfig/omsconfigdetailed.log
 
 #endif
 

--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -96,6 +96,7 @@ SHLIB_EXT: 'so'
 /etc/opt/omi/conf;                                        755; root; root; sysdir
 /etc/opt/omi/conf/${{SHORT_NAME}};                        755; ${{RUN_AS_USER}}; root
 /etc/logrotate.d;                                         755; root; root; sysdir
+
 #if BUILD_OMS == 1
 /etc/opt/microsoft/omsagent/conf/omsagent.d; 755; ${{RUN_AS_USER}}; root; sysdir
 #endif
@@ -194,6 +195,16 @@ chmod 700 $CONFIG_SYSCONFDIR/${{SHORT_NAME}}
 mkdir -p /var/opt/microsoft/omsconfig
 chown omsagent /var/opt/microsoft/omsconfig
 chgrp omsagent /var/opt/microsoft/omsconfig
+chmod 755 /var/opt/microsoft/omsconfig
+
+# Set up log file
+if [! -f /var/opt/microsoft/omsconfig/omsconfig.log ]
+then
+    touch /var/opt/microsoft/omsconfig/omsconfig.log
+fi
+chown omsagent /var/opt/microsoft/omsconfig/omsconfig.log
+chgrp omsagent /var/opt/microsoft/omsconfig/omsconfig.log
+chmod 644 /var/opt/microsoft/omsconfig/omsconfig.log
 
 #endif
 


### PR DESCRIPTION
Added setting permissions of the log folder in the OMS DSC installer.
Added creation (if does not exist) of the OMS DSC log file that all the python scripts access as omsagent in the installer.
Added setting of owner, group, and permissions of the OMS DSC log file in the installer.

@Indhukrishna This is the other log file permission change that is slated for the next release.
@mbreakey3  will test with a full OMS Agent build today.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/powershell-dsc-for-linux/407)
<!-- Reviewable:end -->
