### PR TITLE
Fix Uncaught Errors in nxFile Scripts

### DIFF
--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxFile.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxFile.py
@@ -453,9 +453,9 @@ def RemoveTree(path):
 def RemovePath(path):
     error = None
     if os.path.islink(path) or os.path.isfile(path):
-        RemoveFile(path)
+        error = RemoveFile(path)
     elif os.path.isdir(path):
-        RemoveTree(path)
+        error = RemoveTree(path)
     else:
         print("Error: Unknown file type for file: " + path, file=sys.stderr)
         LG().Log('ERROR', "Error: Unknown file type for file: " + path)
@@ -464,9 +464,13 @@ def RemovePath(path):
 
 def TestOwnerGroupMode(DestinationPath, SourcePath, fc):
     stat_info = LStatFile(DestinationPath)
+    if stat_info is None :
+        return False
 
     if SourcePath:
         stat_info_src = LStatFile(SourcePath)
+        if stat_info_src is None :
+            return False
 
     if fc.Owner:
         try:
@@ -648,7 +652,8 @@ def SetOwnerGroupMode(DestinationPath, SourcePath, fc):
 
 def SetDirectoryRecursive(DestinationPath, SourcePath, fc):
     if not os.path.exists(DestinationPath):
-        MakeDirs(DestinationPath)
+        if MakeDirs(DestinationPath) is not None:
+            return False
     if SetOwnerGroupMode(DestinationPath, SourcePath, fc) is False:
         return False
     Destination_subfiles = ListDir(DestinationPath)
@@ -695,7 +700,8 @@ def SetFile(DestinationPath, SourcePath, fc):
     error = None
     if os.path.exists(DestinationPath) and (os.path.islink(DestinationPath) or os.path.isdir(DestinationPath)):
         if fc.Force :
-            RemovePath(DestinationPath)
+            if RemovePath(DestinationPath) is not None:
+                return False
         else:
             print("Error: " + DestinationPath + " is not a file; cannot overwrite without the 'Force' option being true")
             LG().Log("ERROR", DestinationPath + " is not a file; cannot overwrite without the 'Force' option being true")
@@ -716,7 +722,7 @@ def SetFile(DestinationPath, SourcePath, fc):
         else:
             should_copy_file = True
         if should_copy_file:
-            if CopyFile(SourcePath, DestinationPath) is False :
+            if CopyFile(SourcePath, DestinationPath) is not None:
                 return False
     elif fc.Contents:
         if WriteFile(DestinationPath, fc.Contents) is not None:
@@ -735,14 +741,16 @@ def SetFile(DestinationPath, SourcePath, fc):
             LG().Log('ERROR', "Exception creating file " + DestinationPath + " Error Code: " + str(error.errno) + " Error: " + error.message + error.strerror)
     SetOwnerGroupMode(DestinationPath, SourcePath, fc)
     if len(fc.LocalPath) > 0 :
-        RemoveFile(fc.LocalPath)
+        if RemoveFile(fc.LocalPath) is not None:
+            return False
     return True
 
 
 def SetDirectory(DestinationPath, SourcePath, fc):
     if os.path.exists(DestinationPath) and not os.path.isdir(DestinationPath):
         if fc.Force :
-            RemovePath(DestinationPath)
+            if RemovePath(DestinationPath) is not None:
+                return False
         else:
             print("Error: Unable to overwrite currently existing non-directory object at " + DestinationPath + " without the Force option being true.")
             LG().Log("ERROR", "Unable to overwrite currently existing non-directory object at " + DestinationPath + " without the Force option being true.")
@@ -759,7 +767,8 @@ def SetLink(DestinationPath, SourcePath, fc):
 
     if os.path.exists(DestinationPath) and not os.path.islink(DestinationPath) :
         if fc.Force :
-            RemovePath(DestinationPath)
+            if RemovePath(DestinationPath) is not None:
+                return False
         else:
             print("Error: Unable to overwrite currently existing non-link object at " + DestinationPath + " without the Force option being true.")
             LG().Log("ERROR", "Unable to overwrite currently existing non-link object at " + DestinationPath + " without the Force option being true.")
@@ -836,8 +845,8 @@ def Set(DestinationPath, SourcePath, Ensure, Type, Force, Contents, Checksum, Re
                 return [-1]
 
     elif fc.Ensure == "absent":
-        RemovePath(DestinationPath)
-        return [0]
+        if RemovePath(DestinationPath) is not None:
+            return [-1]
 
     return [0]
 

--- a/Providers/Scripts/3.x/Scripts/nxFile.py
+++ b/Providers/Scripts/3.x/Scripts/nxFile.py
@@ -469,9 +469,9 @@ def RemoveTree(path):
 def RemovePath(path):
     error = None
     if os.path.islink(path) or os.path.isfile(path):
-        RemoveFile(path)
+        error = RemoveFile(path)
     elif os.path.isdir(path):
-        RemoveTree(path)
+        error = RemoveTree(path)
     else:
         print("Error: Unknown file type for file: " + path, file=sys.stderr)
         LG().Log('ERROR', "Error: Unknown file type for file: " + path)
@@ -480,9 +480,13 @@ def RemovePath(path):
 
 def TestOwnerGroupMode(DestinationPath, SourcePath, fc):
     stat_info = LStatFile(DestinationPath)
+    if stat_info is None :
+        return False
 
     if SourcePath:
         stat_info_src = LStatFile(SourcePath)
+        if stat_info_src is None :
+            return False
 
     if fc.Owner:
         try:
@@ -664,7 +668,8 @@ def SetOwnerGroupMode(DestinationPath, SourcePath, fc):
 
 def SetDirectoryRecursive(DestinationPath, SourcePath, fc):
     if not os.path.exists(DestinationPath):
-        MakeDirs(DestinationPath)
+        if MakeDirs(DestinationPath) is not None:
+            return False
     if SetOwnerGroupMode(DestinationPath, SourcePath, fc) is False:
         return False
     Destination_subfiles = ListDir(DestinationPath)
@@ -711,7 +716,8 @@ def SetFile(DestinationPath, SourcePath, fc):
     error = None
     if os.path.exists(DestinationPath) and (os.path.islink(DestinationPath) or os.path.isdir(DestinationPath)):
         if fc.Force :
-            RemovePath(DestinationPath)
+            if RemovePath(DestinationPath) is not None:
+                return False
         else:
             print("Error: " + DestinationPath + " is not a file; cannot overwrite without the 'Force' option being true")
             LG().Log("ERROR", DestinationPath + " is not a file; cannot overwrite without the 'Force' option being true")
@@ -732,7 +738,7 @@ def SetFile(DestinationPath, SourcePath, fc):
         else:
             should_copy_file = True
         if should_copy_file:
-            if CopyFile(SourcePath, DestinationPath) is False :
+            if CopyFile(SourcePath, DestinationPath) is not None :
                 return False
     elif fc.Contents:
         if WriteFile(DestinationPath, fc.Contents) is not None:
@@ -751,14 +757,16 @@ def SetFile(DestinationPath, SourcePath, fc):
             LG().Log('ERROR', "Exception creating file " + DestinationPath + " Error Code: " + str(error.errno) + " Error: " + error.strerror)
     SetOwnerGroupMode(DestinationPath, SourcePath, fc)
     if len(fc.LocalPath) > 0 :
-        RemoveFile(fc.LocalPath)
+        if RemoveFile(fc.LocalPath) is not None:
+            return False
     return True
 
 
 def SetDirectory(DestinationPath, SourcePath, fc):
     if os.path.exists(DestinationPath) and not os.path.isdir(DestinationPath):
         if fc.Force :
-            RemovePath(DestinationPath)
+            if RemovePath(DestinationPath) is not None:
+                return False
         else:
             print("Error: Unable to overwrite currently existing non-directory object at " + DestinationPath + " without the Force option being true.")
             LG().Log("ERROR", "Unable to overwrite currently existing non-directory object at " + DestinationPath + " without the Force option being true.")
@@ -775,7 +783,8 @@ def SetLink(DestinationPath, SourcePath, fc):
 
     if os.path.exists(DestinationPath) and not os.path.islink(DestinationPath) :
         if fc.Force :
-            RemovePath(DestinationPath)
+            if RemovePath(DestinationPath) is not None:
+                return False
         else:
             print("Error: Unable to overwrite currently existing non-link object at " + DestinationPath + " without the Force option being true.")
             LG().Log("ERROR", "Unable to overwrite currently existing non-link object at " + DestinationPath + " without the Force option being true.")
@@ -852,8 +861,8 @@ def Set(DestinationPath, SourcePath, Ensure, Type, Force, Contents, Checksum, Re
                 return [-1]
 
     elif fc.Ensure == "absent":
-        RemovePath(DestinationPath)
-        return [0]
+        if RemovePath(DestinationPath) is not None:
+            return [-1]
 
     return [0]
 


### PR DESCRIPTION
I fixed all the cases I found where a function was returning an error object that was not being properly evaluated in the calling function.
I also fixed the bad conversion between and error object and a boolean for the evaluation of CopyFile that was causing erroneous returns from DSC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/powershell-dsc-for-linux/409)
<!-- Reviewable:end -->
