### PR TITLE
Fix for OMS agent build failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,7 @@ dsc100: lcm100 providers
 	  sed "s@<DSC_MODULES_PATH>@$(DSC_MODULES_PATH)@" > intermediate/Scripts/`basename $$f`; \
 	  chmod a+x intermediate/Scripts/`basename $$f`; \
 	done
+	if [ -f ../dsc.version ]; then cp -f ../dsc.version build/dsc.version; else cp -f build/Makefile.version build/dsc.version; fi
 
 dsc110: lcm110 providers
 	mkdir -p intermediate/Scripts


### PR DESCRIPTION
Now that OMS agent has dropped support for openssl 0.9.8, it was not calling dsc098 target and so the dsc.version file was not getting copied to build directory here. Hence adding this line to dsc100 target as well, as oms agent calls this target first.