### PR TITLE
Delink nxOMSPlugin and nxOMSWLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -581,7 +581,7 @@ nxOMSContainers:
 
 nxOMSWLI:
 	rm -rf output/staging; \
-	VERSION="1.2"; \
+	VERSION="1.3"; \
 	PROVIDERS="nxOMSWLI"; \
 	STAGINGDIR="output/staging/$@/DSCResources"; \
 	cat Providers/Modules/$@.psd1 | sed "s@<MODULE_VERSION>@$${VERSION}@" > intermediate/Modules/$@.psd1; \

--- a/Providers/Modules/WLI/conf/baseOS/wlm_baseOS.conf
+++ b/Providers/Modules/WLI/conf/baseOS/wlm_baseOS.conf
@@ -6,56 +6,52 @@
 </source>
 
 <source>
-  type oms_omi
+  type wlm_oms_omi
   object_name "Memory"
   instance_regex ".*"
   counter_name_regex ".*"
   interval 30s
   omi_mapping_path %CONF_DIR_WS%/wlm_monitor_mapping.json
-  wlm_enabled true
   tag oms.wlm.monitor
 </source>
 
 <source>
-  type oms_omi
+  type wlm_oms_omi
   object_name "Logical Disk"
   instance_regex ".*"
   counter_name_regex ".*"
   interval 30s
   omi_mapping_path %CONF_DIR_WS%/wlm_monitor_mapping.json
-  wlm_enabled true
   tag oms.wlm.monitor
 </source>
 
 <source>
-  type oms_omi
+  type wlm_oms_omi
   object_name "Physical Disk"
   instance_regex ".*"
   counter_name_regex ".*"
   interval 30s
   omi_mapping_path %CONF_DIR_WS%/wlm_monitor_mapping.json
-  wlm_enabled true
   tag oms.wlm.monitor
 </source>
 
 <source>
-  type oms_omi
+  type wlm_oms_omi
   object_name "Network Adapter"
   instance_regex ".*"
   counter_name_regex ".*"
   interval 30s
   omi_mapping_path %CONF_DIR_WS%/wlm_monitor_mapping.json
-  wlm_enabled true
   tag oms.wlm.monitor
 </source>
 
 <source>
-  type oms_omi
+  type wlm_oms_omi
   object_name "Processor"
   instance_regex ".*"
   counter_name_regex ".*"
   interval 30s
   omi_mapping_path %CONF_DIR_WS%/wlm_monitor_mapping.json
-  wlm_enabled true
   tag oms.wlm.monitor
 </source>
+

--- a/Providers/Modules/WLI/plugins/common/in_wlm_discovery.rb
+++ b/Providers/Modules/WLI/plugins/common/in_wlm_discovery.rb
@@ -46,9 +46,9 @@ module Fluent
       discovery_data = omi_lib.get_discovery_data()
       wlm_formatter = WLM::WLMDataFormatter.new(@wlm_class_file)
       discovery_data.each do |wclass|
-  	if wclass["class_name"].to_s == "Universal Linux Computer"
-	  wclass["discovery_data"][0][0]["CSName"] = OMS::Common.get_fully_qualified_domain_name
-	end
+        if wclass["class_name"].to_s == "Universal Linux Computer"
+          wclass["discovery_data"][0]["CSName"] = OMS::Common.get_fully_qualified_domain_name
+        end
         discovery_xml = wlm_formatter.get_discovery_xml(wclass)
         instance = {}
         instance["Host"] = OMS::Common.get_fully_qualified_domain_name

--- a/Providers/Modules/WLI/plugins/common/in_wlm_oms_omi.rb
+++ b/Providers/Modules/WLI/plugins/common/in_wlm_oms_omi.rb
@@ -1,0 +1,74 @@
+#!/usr/local/bin/ruby
+
+module Fluent
+
+  class WLM_OMS_OMI_Input < Input
+    Plugin.register_input('wlm_oms_omi', self)
+
+    def initialize
+      super
+      require_relative 'wlm_oms_omi_lib'
+    end
+
+    config_param :object_name, :string
+    config_param :instance_regex, :string, :default => ".*"
+    config_param :counter_name_regex, :string, :default => ".*"
+    config_param :interval, :time, :default => nil
+    config_param :tag, :string, :default => "oms.omi"
+    config_param :omi_mapping_path, :string, :default => "/etc/opt/microsoft/omsagent/conf/omsagent.d/wlm_monitor_mapping.json"
+    config_param :wlm_data_type, :string, :default => "WLM_LINUX_PERF_DATA_BLOB"
+    config_param :wlm_ip, :string, :default => "InfrastructureInsights"
+
+    def configure (conf)
+      super
+    end
+
+    def start
+      @omi_lib = WlmOmiOms.new(@object_name, @instance_regex, @counter_name_regex, @omi_mapping_path)
+
+      if @interval
+        @finished = false
+        @condition = ConditionVariable.new
+        @mutex = Mutex.new
+        @thread = Thread.new(&method(:run_periodic))
+      else
+        enumerate
+      end
+    end
+
+    def shutdown
+      if @interval
+        @mutex.synchronize {
+          @finished = true
+          @condition.signal
+        }
+        @thread.join
+      end
+      @omi_lib.disconnect
+    end
+
+    def enumerate
+      wrapper = nil
+      time = Time.now.to_f
+      wrapper = @omi_lib.enumerate(time, @wlm_data_type, @wlm_ip)
+      router.emit(@tag, time, wrapper) if wrapper
+    end
+
+    def run_periodic
+      @mutex.lock
+      done = @finished
+      until done
+        @condition.wait(@mutex, @interval)
+        done = @finished
+        @mutex.unlock
+        if !done
+          enumerate
+        end
+        @mutex.lock
+      end
+      @mutex.unlock
+    end
+
+  end # WLM_OMS_OMI_Input
+
+end # module

--- a/Providers/Modules/WLI/plugins/common/wlm_formatter.rb
+++ b/Providers/Modules/WLI/plugins/common/wlm_formatter.rb
@@ -205,11 +205,9 @@ module WLM
             wlm_instance.add_key_property(key,value)
           end # do |key, value|
         end # if
-        instance.each do |properties|
-          properties.each do |key,value|
-            wlm_instance.add_cim_property(key,value)
-          end # do |key,value|
-        end # do |properties|
+        instance.each do |key,value|
+          wlm_instance.add_cim_property(key,value)
+        end # do |key,value|
         discovery.add_instance(wlm_instance)
         if wclass["class_name"] == "Universal Linux Computer"
           @parent_key_properties["Universal Linux Computer"] = wlm_instance.get_key_properties

--- a/Providers/Modules/WLI/plugins/common/wlm_omi_discovery_lib.rb
+++ b/Providers/Modules/WLI/plugins/common/wlm_omi_discovery_lib.rb
@@ -59,13 +59,11 @@ module WLM
     end # method get_cim_data
     
     def get_cim_values(instance,specific_mapping)
-      cim_values = []
+      cim_values = {}
       cim_properties = specific_mapping["CimProperties"]
       instance.each do |property,value|
        if cim_properties.include? property
-         property_pair = {}
-         property_pair[property] = value
-         cim_values.push(property_pair)
+         cim_values[property] = value
        end # if
       end # each
       return cim_values

--- a/Providers/Modules/WLI/plugins/common/wlm_oms_omi_lib.rb
+++ b/Providers/Modules/WLI/plugins/common/wlm_oms_omi_lib.rb
@@ -1,0 +1,51 @@
+require_relative 'oms_omi_lib'
+
+class WlmOmiOms < OmiOms
+
+  def initialize(object_name, instance_regex, counter_name_regex, omi_mapping_path, omi_interface=nil, common=nil)
+    super
+    @hostname = OMS::Common.get_fully_qualified_domain_name unless common
+  end
+
+  def omi_to_oms_instance(omi_instance, timestamp)
+    oms_instance = super
+    oms_instance["Host"] = @hostname
+    oms_instance[@object_name] = omi_instance[@specific_mapping["InstanceProperty"]]
+    return oms_instance
+  end
+
+  def enumerate(time, data_type, ip_name)
+    return nil if @conf_error
+    namespace = @specific_mapping["Namespace"]
+    cim_class_name = @specific_mapping["CimClassName"]
+    items = [[namespace, cim_class_name]]
+    record_txt = @omi_interface.enumerate(items)
+    instances = JSON.parse record_txt
+
+    # Filter based on instance names
+    begin
+      instances.select!{ |instance|
+        /#{@instance_regex}/.match(instance[@instance_property])
+      }
+    rescue RegexpError => e
+      @conf_error = true
+      $log.error "Regex error on instance_regex : #{e}"
+      return
+    end
+
+    timestamp = OMS::Common.format_time(time)
+    # Convert instances to oms format
+    instances.map!{ |instance|
+      omi_to_oms_instance(instance, timestamp)
+    }
+
+    if instances.length > 0
+      wrapper = {
+        "DataType"=>data_type,
+        "IPName"=>ip_name,
+        "DataItems"=>instances
+      }
+      return wrapper
+    end
+  end
+end #WlmOmsOmi


### PR DESCRIPTION
This pull request is for delinking nxOMSPlugin and nxOMSWLI DSC modules.

Context: Today nxOMSWLI uses the the oms_omi input plugin for getting the Perf metrics for WLI. This requires a release of nxOMSPlugin if there is some modifications to the way Perf metrics are collected for WLI.

This PR de-links them by creating a wlm_oms_omi input plugin which is an extension of the oms_omi plugin.

In this PR:

* Delink the dsc resources .
* Seperated out the wlm specific unit tests.
* Added additional unit test for WLI.