### PR TITLE
Add proper JSON encoding and shorten operation names for telemetry

### DIFF
--- a/LCM/scripts/OperationStatusUtility.py
+++ b/LCM/scripts/OperationStatusUtility.py
@@ -2,6 +2,7 @@
 from datetime   import datetime
 from errno      import EINVAL
 from imp        import load_source
+from json       import dump
 from os         import chmod, mkdir, stat
 from os.path    import dirname, join, isdir, isfile, realpath
 from re         import search
@@ -202,13 +203,13 @@ def get_log_since_datetime(startDateTime):
     return logSinceDateTime
 
 def get_status_file_content(operation, success, message = ''):
-    return '''
-{
-    "operation": "Dsc''' + str(operation) + '''",
-    "success": "''' + str(success) + '''",
-    "message": "''' + str(message) + '''"
-}
-'''
+    status_file_content = {
+        "operation": "Dsc" + str(operation),
+        "success": str(success),
+        "message": str(message)
+    }
+
+    return status_file_content
 
 def write_to_status_file(operation, success, message = ''):
     statusFolderName = 'status'
@@ -231,7 +232,7 @@ def write_to_status_file(operation, success, message = ''):
 
     statusFileHandle = open(statusFilePath, 'w')
     try:
-        statusFileHandle.write(statusFileContent)
+        dump(statusFileContent, statusFileHandle)
     finally:
         statusFileHandle.close()
 

--- a/LCM/scripts/PerformRequiredConfigurationChecks.py
+++ b/LCM/scripts/PerformRequiredConfigurationChecks.py
@@ -14,7 +14,7 @@ helperlib = load_source('helperlib', helperLibPath)
 operationStatusUtilityPath = join(pathToCommonScriptsFolder, 'OperationStatusUtility.py')
 operationStatusUtility = load_source('operationStatusUtility', operationStatusUtilityPath)
 
-operation = 'PerformRequiredConfigurationChecks'
+operation = 'PerformConsistency'
 
 def main():
     try:

--- a/LCM/scripts/SetDscLocalConfigurationManager.py
+++ b/LCM/scripts/SetDscLocalConfigurationManager.py
@@ -14,7 +14,7 @@ helperlib = load_source('helperlib', helperLibPath)
 operationStatusUtilityPath = join(pathToCommonScriptsFolder, 'OperationStatusUtility.py')
 operationStatusUtility = load_source('operationStatusUtility', operationStatusUtilityPath)
 
-operation = 'SetDscLocalConfigurationManager'
+operation = 'SetLCM'
 
 def usage():
     print("Usage:")


### PR DESCRIPTION
Added proper JSON encoding to OperationStatusUtility.py so that the string message can be properly escaped. This means that this script will no longer work with Python 2.4/2.5 but omsagent does not seem to run on these Python version anyway.
 
Also shortened operation names for telemetry so that it will work better with the waagent.
PerformRequiredConfigurationChecks --> PerformConsistency
SetDscLocalConfigurationManager --> SetLCM

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/powershell-dsc-for-linux/418)
<!-- Reviewable:end -->
