### PR TITLE
Fix for duplicate logs at restart in OMS agent custom logs

### DIFF
--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSCustomLog.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSCustomLog.py
@@ -119,7 +119,7 @@ def UpdateConf(CustomLogObjects):
         for customlog in CustomLogObjects:
             logname = customlog['LogName']
             filepaths = ','.join(customlog['FilePath'])
-            new_source+='\n<source>\n  type tail\n  path ' + filepaths + '\n  pos_file /var/opt/microsoft/omsagent/state/' + logname + '.pos\n  read_from_head true\n  tag oms.blob.CustomLog.' + logname + '.*\n  format none\n</source>\n'
+            new_source+='\n<source>\n  type tail\n  path ' + filepaths + '\n  pos_file /var/opt/microsoft/omsagent/state/' + logname + '.pos\n  read_from_head false\n  tag oms.blob.CustomLog.' + logname + '.*\n  format none\n</source>\n'
     txt = header + new_source
     if os.path.isfile(conf_path): 
         shutil.copy2(conf_path, conf_path + '.bak')

--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSSudoCustomLog.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSSudoCustomLog.py
@@ -200,7 +200,7 @@ def UpdateConf(CustomLogObjects):
         for customlog in CustomLogObjects:
             logname = customlog['LogName']
             filepaths = ','.join(customlog['FilePath'])
-            new_source += '\n<source>\n  type sudo_tail\n  path ' + filepaths + '\n  pos_file /var/opt/microsoft/omsagent/state/' + logname + '.pos\n  read_from_head true\n  run_interval 60\n  tag oms.blob.CustomLog.' + logname + '.*\n  format none\n</source>\n'
+            new_source += '\n<source>\n  type sudo_tail\n  path ' + filepaths + '\n  pos_file /var/opt/microsoft/omsagent/state/' + logname + '.pos\n  read_from_head false\n  run_interval 60\n  tag oms.blob.CustomLog.' + logname + '.*\n  format none\n</source>\n'
     txt = header + new_source
     if os.path.isfile(conf_path):
         shutil.copy2(conf_path, conf_path + '.bak')

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSCustomLog.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSCustomLog.py
@@ -120,7 +120,7 @@ def UpdateConf(CustomLogObjects):
         for customlog in CustomLogObjects:
             logname = customlog['LogName']
             filepaths = ','.join(customlog['FilePath'])
-            new_source+='\n<source>\n  type tail\n  path ' + filepaths + '\n  pos_file /var/opt/microsoft/omsagent/state/' + logname + '.pos\n  read_from_head true\n  tag oms.blob.CustomLog.' + logname + '.*\n  format none\n</source>\n'
+            new_source+='\n<source>\n  type tail\n  path ' + filepaths + '\n  pos_file /var/opt/microsoft/omsagent/state/' + logname + '.pos\n  read_from_head false\n  tag oms.blob.CustomLog.' + logname + '.*\n  format none\n</source>\n'
     txt = header + new_source
     if os.path.isfile(conf_path): 
         shutil.copy2(conf_path, conf_path + '.bak')

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSSudoCustomLog.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSSudoCustomLog.py
@@ -200,7 +200,7 @@ def UpdateConf(CustomLogObjects):
         for customlog in CustomLogObjects:
             logname = customlog['LogName']
             filepaths = ','.join(customlog['FilePath'])
-            new_source += '\n<source>\n  type sudo_tail\n  path ' + filepaths + '\n  pos_file /var/opt/microsoft/omsagent/state/' + logname + '.pos\n  read_from_head true\n  run_interval 60\n  tag oms.blob.CustomLog.' + logname + '.*\n  format none\n</source>\n'
+            new_source += '\n<source>\n  type sudo_tail\n  path ' + filepaths + '\n  pos_file /var/opt/microsoft/omsagent/state/' + logname + '.pos\n  read_from_head false\n  run_interval 60\n  tag oms.blob.CustomLog.' + logname + '.*\n  format none\n</source>\n'
     txt = header + new_source
     if os.path.isfile(conf_path):
         shutil.copy2(conf_path, conf_path + '.bak')

--- a/Providers/Scripts/3.x/Scripts/nxOMSCustomLog.py
+++ b/Providers/Scripts/3.x/Scripts/nxOMSCustomLog.py
@@ -120,7 +120,7 @@ def UpdateConf(CustomLogObjects):
         for customlog in CustomLogObjects:
             logname = customlog['LogName']
             filepaths = ','.join(customlog['FilePath'])
-            new_source+='\n<source>\n  type tail\n  path ' + filepaths + '\n  pos_file /var/opt/microsoft/omsagent/state/' + logname + '.pos\n  read_from_head true\n  tag oms.blob.CustomLog.' + logname + '.*\n  format none\n</source>\n'
+            new_source+='\n<source>\n  type tail\n  path ' + filepaths + '\n  pos_file /var/opt/microsoft/omsagent/state/' + logname + '.pos\n  read_from_head false\n  tag oms.blob.CustomLog.' + logname + '.*\n  format none\n</source>\n'
     txt = header + new_source
     if os.path.isfile(conf_path): 
         shutil.copy2(conf_path, conf_path + '.bak')

--- a/Providers/Scripts/3.x/Scripts/nxOMSSudoCustomLog.py
+++ b/Providers/Scripts/3.x/Scripts/nxOMSSudoCustomLog.py
@@ -197,7 +197,7 @@ def UpdateConf(CustomLogObjects):
         for customlog in CustomLogObjects:
             logname = customlog['LogName']
             filepaths = ','.join(customlog['FilePath'])
-            new_source += '\n<source>\n  type sudo_tail\n  path ' + filepaths + '\n  pos_file /var/opt/microsoft/omsagent/state/' + logname + '.pos\n  read_from_head true\n  run_interval 60\n  tag oms.blob.CustomLog.' + logname + '.*\n  format none\n</source>\n'
+            new_source += '\n<source>\n  type sudo_tail\n  path ' + filepaths + '\n  pos_file /var/opt/microsoft/omsagent/state/' + logname + '.pos\n  read_from_head false\n  run_interval 60\n  tag oms.blob.CustomLog.' + logname + '.*\n  format none\n</source>\n'
     txt = header + new_source
     if os.path.isfile(conf_path):
         shutil.copy2(conf_path, conf_path + '.bak')


### PR DESCRIPTION
The read_from_head parameter causes the plugin to read files from top of file
every time agent restarts. When it is false, the plugin reads the position in
the pos file and reads lines from there.