### PR TITLE
Set ownership of omsconfig file from omsconfig installer

### DIFF
--- a/LCM/scripts/OperationStatusUtility.py
+++ b/LCM/scripts/OperationStatusUtility.py
@@ -239,11 +239,30 @@ def write_to_status_file(operation, success, message = ''):
     # Ensure that the status file has the correct permissions (644) if it exists after writing status
     ensure_file_permissions(statusFilePath, '644')
 
+def write_to_status_to_log_file(operation, success, message = ''):
+    logFilePath = join(helperlib.PYTHON_PID_DIR, 'omsconfig.log')
+
+    # Ensure that the omsconfig.log file has the correct permissions (644) if it exists before writing log
+    ensure_file_permissions(logFilePath, '644')
+
+    logFileContent = get_status_file_content(operation, success, message)
+
+    logFileHandle = open(logFilePath, 'a')
+    try:
+        dump(logFileContent, logFileHandle)
+    finally:
+        logFileHandle.close()
+
+    # Ensure that the status file has the correct permissions (644) if it exists after writing status
+    ensure_file_permissions(logFilePath, '644')
+
 def write_success_to_status_file(operation):
     write_to_status_file(operation, 'true', 'Succeeded')
+    write_to_status_to_log_file(operation, 'true', 'Succeeded')
 
 def write_failure_to_status_file_no_log(operation, errorMessage):
     write_to_status_file(operation, 'false', errorMessage)
+    write_to_status_to_log_file(operation, 'false', errorMessage)
 
 def write_failure_to_status_file(operation, startDateTime, errorMessage):
     logSinceDateTime = get_log_since_datetime(startDateTime)

--- a/LCM/scripts/OperationStatusUtility.py
+++ b/LCM/scripts/OperationStatusUtility.py
@@ -239,17 +239,18 @@ def write_to_status_file(operation, success, message = ''):
     # Ensure that the status file has the correct permissions (644) if it exists after writing status
     ensure_file_permissions(statusFilePath, '644')
 
-def write_to_status_to_log_file(operation, success, message = ''):
+def write_to_status_to_log_file(operation, message = ''):
     logFilePath = join(helperlib.PYTHON_PID_DIR, 'omsconfig.log')
 
     # Ensure that the omsconfig.log file has the correct permissions (644) if it exists before writing log
     ensure_file_permissions(logFilePath, '644')
 
-    logFileContent = get_status_file_content(operation, success, message)
+    timestamp = get_current_timestamp()
+    logMessage = timestamp + ": operation: " + operation + ", message: " + message + "\n"
 
     logFileHandle = open(logFilePath, 'a')
     try:
-        dump(logFileContent, logFileHandle)
+        logFileHandle.write(logMessage)
     finally:
         logFileHandle.close()
 
@@ -258,11 +259,11 @@ def write_to_status_to_log_file(operation, success, message = ''):
 
 def write_success_to_status_file(operation):
     write_to_status_file(operation, 'true', 'Succeeded')
-    write_to_status_to_log_file(operation, 'true', 'Succeeded')
+    write_to_status_to_log_file(operation, 'Succeeded')
 
 def write_failure_to_status_file_no_log(operation, errorMessage):
     write_to_status_file(operation, 'false', errorMessage)
-    write_to_status_to_log_file(operation, 'false', errorMessage)
+    write_to_status_to_log_file(operation, errorMessage)
 
 def write_failure_to_status_file(operation, startDateTime, errorMessage):
     logSinceDateTime = get_log_since_datetime(startDateTime)

--- a/LCM/scripts/PerformInventory.py
+++ b/LCM/scripts/PerformInventory.py
@@ -54,7 +54,7 @@ def main(args):
     except Exception:
         # Python 2.4-2.7 and 2.6-3 recognize different formats for exceptions. This methods works in all versions.
         formattedExceptionMessage = format_exc()
-        operationStatusUtility.write_failure_to_status_file_no_log(operation, 'Python exception raised from PerformRequiredConfigurationChecks.py: ' + formattedExceptionMessage)
+        operationStatusUtility.write_failure_to_status_file_no_log(operation, 'Python exception raised from PerformInventory.py: ' + formattedExceptionMessage)
         raise
 
 def perform_inventory(args):

--- a/LCM/scripts/SetDscLocalConfigurationManager.py
+++ b/LCM/scripts/SetDscLocalConfigurationManager.py
@@ -30,7 +30,7 @@ def main(args):
     except Exception:
         # Python 2.4-2.7 and 2.6-3 recognize different formats for exceptions. This methods works in all versions.
         formattedExceptionMessage = format_exc()
-        operationStatusUtility.write_failure_to_status_file_no_log(operation, 'Python exception raised from PerformRequiredConfigurationChecks.py: ' + formattedExceptionMessage)
+        operationStatusUtility.write_failure_to_status_file_no_log(operation, 'Python exception raised from SetDscLocalConfigurationManager.py: ' + formattedExceptionMessage)
         raise
 
 def apply_meta_config(args):

--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -290,6 +290,7 @@ if [ -f "/etc/opt/omi/conf/omsconfig/inventory_lock" ]; then chown omsagent:omiu
 if [ -f "/etc/opt/omi/conf/omsconfig/keymgmtring.gpg" ]; then chown omsagent:omiusers "/etc/opt/omi/conf/omsconfig/keymgmtring.gpg"; fi
 if [ -f "/etc/opt/omi/conf/omsconfig/keyring.gpg" ]; then chown omsagent:omiusers "/etc/opt/omi/conf/omsconfig/keyring.gpg"; fi
 if [ -f "/etc/opt/omi/conf/omsconfig/last_statusreport" ]; then chown omsagent:omiusers "/etc/opt/omi/conf/omsconfig/last_statusreport"; fi
+if [ -d "/var/opt/microsoft/omsconfig" ]; then chown -R omsagent:omiusers /var/opt/microsoft/omsconfig/*; fi
 
 #else
 

--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -283,6 +283,14 @@ fi
 # Ensure .reg files all have correct permissions
 chmod 644 $OMI_REGISTER_DIR/root-oms/*.reg
 
+if [ -f "/etc/opt/omi/conf/omsconfig/agentid" ]; then chown omsagent:omiusers "/etc/opt/omi/conf/omsconfig/agentid"; fi
+if [ -f "/etc/opt/omi/conf/omsconfig/generated_meta_config.mof" ]; then chown omsagent:omiusers "/etc/opt/omi/conf/omsconfig/generated_meta_config.mof"; fi
+if [ -d "/etc/opt/omi/conf/omsconfig/.gnupg" ]; then chown omsagent:omiusers "/etc/opt/omi/conf/omsconfig/.gnupg"; fi
+if [ -f "/etc/opt/omi/conf/omsconfig/inventory_lock" ]; then chown omsagent:omiusers "/etc/opt/omi/conf/omsconfig/inventory_lock"; fi
+if [ -f "/etc/opt/omi/conf/omsconfig/keymgmtring.gpg" ]; then chown omsagent:omiusers "/etc/opt/omi/conf/omsconfig/keymgmtring.gpg"; fi
+if [ -f "/etc/opt/omi/conf/omsconfig/keyring.gpg" ]; then chown omsagent:omiusers "/etc/opt/omi/conf/omsconfig/keyring.gpg"; fi
+if [ -f "/etc/opt/omi/conf/omsconfig/last_statusreport" ]; then chown omsagent:omiusers "/etc/opt/omi/conf/omsconfig/last_statusreport"; fi
+
 #else
 
 # Set up built-in resource module for DIY DSC


### PR DESCRIPTION
1.
It is observed that when omsagent removes and adds the omiusers group during auto upgrade, sometimes omsconfig file ownership point to the old omiusers group id (which doesn’t exist)
And because of this, update management and change tracking solutions stop sending data.

Now omsconfig installer will set file ownership explicitly to omsagent:omiusers user.

2. 
	Adding operational logs from dsc python scripts to omsconfig.log file.


Example of additional logs
Successful Inventory operation:

2018/10/11 20:30:57: WARNING: null(0): EventId=2 Priority=WARNING Job E23599A9-C479-4363-83A4-68000356C82F : PerformInventoryOOB DSC operation completed in 8.1521 seconds.
2018/10/11 20:30:57: operation: PerformInventory, message: Succeeded

Example of error from PerformInventory.py

2018/10/11 20:26:29: WARNING: null(0): EventId=2 Priority=WARNING Job 39AA7588-8A84-481D-A4B1-F2A2F5DE47B3 : Starting PerformInventoryOOB DSC operation.
2018/10/11 20:26:29: DEBUG: Scripts/nxPackage.pyc(248):
PackageGroup value is False
2018/10/11 20:26:29: DEBUG: Scripts/nxPackage.pyc(251):
PackageGroup type is <type 'bool'>
2018/10/11 20:26:30: WARNING: null(0): EventId=2 Priority=WARNING Job 39AA7588-8A84-481D-A4B1-F2A2F5DE47B3 : PerformInventoryOOB DSC operation completed in 1.4522 seconds.
2018/10/11 20:26:30: operation: PerformInventory, message: Succeeded
2018/10/11 20:30:01: WARNING: null(0): EventId=2 Priority=WARNING Job E5BA2353-11FA-4169-9E9C-BA95555D8993 : Starting PerformRequiredConfigurationChecks DSC operation.
2018/10/11 20:30:10: operation: PerformInventory, message: Python exception raised from PerformInventory.py: Traceback (most recent call last):
  File "/opt/microsoft/omsconfig/Scripts/PerformInventory.py", line 51, in main
    perform_inventory(args)
  File "/opt/microsoft/omsconfig/Scripts/PerformInventory.py", line 140, in perform_inventory
    operationStatusUtility.ensure_file_permissions(inventorylock_path, '644')
  File "/opt/microsoft/omsconfig/Scripts/OperationStatusUtility.py", line 57, in ensure_file_permissions
    chmod(filePath, desiredPermission)
OSError: [Errno 1] Operation not permitted: '/etc/opt/omi/conf/omsconfig/inventory_lock'

