### PR TITLE
Update OMSAuditdPlugin.sh to not set the audit rules when audit config is locked for the current session

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -536,7 +536,7 @@ nxOMSAgentNPMConfig:
 
 nxOMSAuditdPlugin:
 	rm -rf output/staging; \
-	VERSION="1.5"; \
+	VERSION="1.6"; \
 	PROVIDERS="nxOMSAuditdPlugin"; \
 	STAGINGDIR="output/staging/$@/DSCResources"; \
 	cat Providers/Modules/$@.psd1 | sed "s@<MODULE_VERSION>@$${VERSION}@" > intermediate/Modules/$@.psd1; \

--- a/Providers/Modules/nxOMSAuditdPlugin/Scripts/OMSAuditdPlugin.sh
+++ b/Providers/Modules/nxOMSAuditdPlugin/Scripts/OMSAuditdPlugin.sh
@@ -276,10 +276,6 @@ case $1 in
         fi
 
         if [ -n "$4" ]; then
-            if /sbin/auditctl -s | grep -qe 'enabled[=| ]2'; then
-                echo "Audit configuration is locked for the current session. The system needs to be rebooted to update the auditing rules."
-                exit 4
-            fi
             if [ "$4" == "remove" ]; then
                 remove_rules
             else
@@ -340,6 +336,10 @@ case $1 in
         fi
 
         if [ -n "$7" ]; then
+            if /sbin/auditctl -s | grep -qe 'enabled[=| ]2'; then
+                echo "Audit configuration is locked for the current session. The system needs to be rebooted to update the auditing rules."
+                exit 7
+            fi
             TmpFile=$(mktemp /tmp/OMSAuditdPlugin.XXXXXXXX)
             cp $7 $TmpFile
             /sbin/auditctl -R $TmpFile

--- a/Providers/Modules/nxOMSAuditdPlugin/Scripts/OMSAuditdPlugin.sh
+++ b/Providers/Modules/nxOMSAuditdPlugin/Scripts/OMSAuditdPlugin.sh
@@ -276,6 +276,10 @@ case $1 in
         fi
 
         if [ -n "$4" ]; then
+            if /sbin/auditctl -s | grep -qe 'enabled[=| ]2'; then
+                echo "Audit configuration is locked for the current session. The system needs to be rebooted to update the auditing rules."
+                exit 4
+            fi
             if [ "$4" == "remove" ]; then
                 remove_rules
             else


### PR DESCRIPTION
On systems that have used "-e 2" in the audit rules, the nxOMSAuditdPlugin will still try to modify the loaded rules and this generates errors in syslog.

Updated OMSAuditdPlugin.sh to not set/modify the audit rules when audit config is locked for the current session.