### PR TITLE
Pass path in quotes.

### DIFF
--- a/Providers/Modules/CustomLog/Plugin/in_sudo_tail.rb
+++ b/Providers/Modules/CustomLog/Plugin/in_sudo_tail.rb
@@ -99,7 +99,7 @@ module Fluent
     end
  
     def set_system_command
-      @command = "sudo " << RUBY_DIR << TAILSCRIPT << @path <<  " -p #{@pos_file}"
+      @command = "sudo " << RUBY_DIR << TAILSCRIPT << %Q{'@path} <<  " -p #{@pos_file}"
     end
 
     def run_periodic


### PR DESCRIPTION
Unix shell expands wildcard parameter to the paths present on the disk. Recent change in tailreader only reads the first argument breaking the scenario.
By passing those enclosed in quotes, those will not be expanded and when in_tailreader starts, it will get only one parameter with wildcard string and it will be able to expand it and use it