### PR TITLE
Issue #883: Syslog messages are garbled due to incorrect utf-8 encoding

### DIFF
--- a/Providers/Modules/Plugins/Common/plugin/oms_common.rb
+++ b/Providers/Modules/Plugins/Common/plugin/oms_common.rb
@@ -7,6 +7,7 @@ module OMS
 
   class Common
     require 'json'
+    require 'yajl'
     require 'net/http'
     require 'net/https'
     require 'time'
@@ -742,16 +743,18 @@ module OMS
       def parse_json_record_encoding(record)
         msg = nil
         begin
-          msg = JSON.dump(record)
+          msg = Yajl.dump(record)
         rescue => error 
           # failed encoding, encode to utf-8, iso-8859-1 and try again
           begin
+            OMS::Log.warn_once("Yajl.dump() failed due to encoding, will try iso-8859-1 for #{record}: #{error}")
+
             if !record["DataItems"].nil?
               record["DataItems"].each do |item|
                 item["Message"] = item["Message"].encode('utf-8', 'iso-8859-1')
               end
             end
-            msg = JSON.dump(record)
+            msg = Yajl.dump(record)
           rescue => error
             # at this point we've given up up, we don't recognize
             # the encode, so return nil and log_warning for the 


### PR DESCRIPTION
json module in the oms ruby distribution fails to encrypt non-English characters,