### PR TITLE
Telemetry Compatibility

### DIFF
--- a/Providers/Modules/Plugins/Common/plugin/agent_common.rb
+++ b/Providers/Modules/Plugins/Common/plugin/agent_common.rb
@@ -1,0 +1,117 @@
+# This file extends the OMS::Common class and with
+# methods shared by the topology and telemetry scripts.
+# It remains separate in order to retain compatibility between
+# plugins from DSC modules and those in the shell bundle.
+
+class StrongTypedClass
+  def self.strongtyped_accessor(name, type)
+    # setter
+    self.class_eval("def #{name}=(value);
+    if !value.is_a? #{type} and !value.nil?
+        raise ArgumentError, \"Invalid data type. #{name} should be type #{type}\"
+    end
+    @#{name}=value
+    end")
+
+    # getter
+    self.class_eval("def #{name};@#{name};end")
+  end
+
+  def self.strongtyped_arch(name)
+    # setter
+    self.class_eval("def #{name}=(value);
+    if (value != 'x64' && value != 'x86')
+        raise ArgumentError, \"Invalid data for ProcessorArchitecture.\"
+    end
+    @#{name}=value
+    end")
+  end
+end
+
+module OMS
+
+  # Error codes and categories:
+  # User configuration/parameters:
+  INVALID_OPTION_PROVIDED = 2
+  NON_PRIVELEGED_USER_ERROR_CODE = 3
+  # System configuration:
+  MISSING_CONFIG_FILE = 4
+  MISSING_CONFIG = 5
+  MISSING_CERTS = 6
+  # Service/network-related:
+  HTTP_NON_200 = 7
+  ERROR_SENDING_HTTP = 8
+  ERROR_EXTRACTING_ATTRIBUTES = 9
+  MISSING_CERT_UPDATE_ENDPOINT = 10
+  # Internal errors:
+  ERROR_GENERATING_CERTS = 11
+  ERROR_WRITING_TO_FILE = 12
+
+  class Common
+
+    require 'syslog/logger'
+
+    class << self
+
+      # Helper method that returns true if a file exists and is non-empty
+      def file_exists_nonempty(file_path)
+        return (!file_path.nil? and File.exist?(file_path) and !File.zero?(file_path))
+      end
+
+      # Return logger from provided log facility
+      def get_logger(log_facility)
+
+        facility = case log_facility
+          # Custom log facilities supported by both Ruby and bash logger
+          when "auth"     then Syslog::LOG_AUTHPRIV  # LOG_AUTH is deprecated
+          when "authpriv" then Syslog::LOG_AUTHPRIV
+          when "cron"     then Syslog::LOG_CRON
+          when "daemon"   then Syslog::LOG_DAEMON
+          when "ftp"      then Syslog::LOG_FTP
+          when "kern"     then Syslog::LOG_KERN
+          when "lpr"      then Syslog::LOG_LRP
+          when "mail"     then Syslog::LOG_MAIL
+          when "news"     then Syslog::LOG_NEWS
+          when "security" then Syslog::LOG_SECURITY
+          when "syslog"   then Syslog::LOG_SYSLOG
+          when "user"     then Syslog::LOG_USER
+          when "uucp"     then Syslog::LOG_UUCP
+
+          when "local0"   then Syslog::LOG_LOCAL0
+          when "local1"   then Syslog::LOG_LOCAL1
+          when "local2"   then Syslog::LOG_LOCAL2
+          when "local3"   then Syslog::LOG_LOCAL3
+          when "local4"   then Syslog::LOG_LOCAL4
+          when "local5"   then Syslog::LOG_LOCAL5
+          when "local6"   then Syslog::LOG_LOCAL6
+          when "local7"   then Syslog::LOG_LOCAL7
+
+          # default logger will be local0
+          else Syslog::LOG_LOCAL0
+        end
+
+        if !Syslog.opened?
+          Syslog::Logger.syslog = Syslog.open("omsagent", Syslog::LOG_PID, facility)
+        end
+        return Syslog::Logger.new
+      end
+
+      # Return a POST request with the specified headers, URI, and body, and an
+      #     HTTP to execute that request
+      def form_post_request_and_http(headers, uri_string, body, cert, key, proxy)
+        uri = URI.parse(uri_string)
+        req = Net::HTTP::Post.new(uri.request_uri, headers)
+        req.body = body
+
+        http = create_secure_http(uri, OMS::Configuration.get_proxy_config(proxy))
+        http.cert = cert
+        http.key = key
+
+        return req, http
+      end # form_post_request_and_http
+
+    end
+
+  end
+
+end

--- a/Providers/Modules/Plugins/Common/plugin/agent_telemetry_script.rb
+++ b/Providers/Modules/Plugins/Common/plugin/agent_telemetry_script.rb
@@ -2,7 +2,7 @@ require 'optparse'
 
 module OMS
 
-  require_relative 'agent_topology_request_script' # for StrongTypedClass
+  require_relative 'agent_common'
 
   # Operation Types
   SEND_BATCH = "SendBatch"

--- a/Providers/Modules/Plugins/Common/plugin/in_agent_telemetry.rb
+++ b/Providers/Modules/Plugins/Common/plugin/in_agent_telemetry.rb
@@ -10,7 +10,6 @@ module Fluent
       super
       require_relative 'agent_telemetry_script'
       require_relative 'oms_configuration'
-      require_relative 'omslog'
     end
 
     config_param :query_interval, :time, :default => '5m'
@@ -44,18 +43,22 @@ module Fluent
 
     def start
       super
-      @telemetry_script = OMS::Telemetry.new(@omsadmin_conf_path, @cert_path, @key_path, @pid_path,
-                                             @proxy_path, @os_info, @install_info, @log)
+      if defined?(OMS::Configuration.telemetry_interval) # ensure new modules are in place, otherwise do not start
+        @telemetry_script = OMS::Telemetry.new(@omsadmin_conf_path, @cert_path, @key_path, @pid_path,
+                                              @proxy_path, @os_info, @install_info, @log)
 
-      if @query_interval and @poll_interval
-        @finished = false
-        @thread = Thread.new(&method(:run_periodic))
+        if @query_interval and @poll_interval
+          @finished = false
+          @thread = Thread.new(&method(:run_periodic))
+        end
       end
     end
 
-    def shutdown 
-      @finished = true 
-      @thread.join
+    def shutdown
+      if defined?(OMS::Configuration.telemetry_interval)
+        @finished = true
+        @thread.join
+      end
       super
     end
 

--- a/Providers/Modules/Plugins/Common/plugin/oms_common.rb
+++ b/Providers/Modules/Plugins/Common/plugin/oms_common.rb
@@ -1,22 +1,5 @@
 module OMS
 
-  # Error codes and categories:
-  # User configuration/parameters:
-  INVALID_OPTION_PROVIDED = 2
-  NON_PRIVELEGED_USER_ERROR_CODE = 3
-  # System configuration:
-  MISSING_CONFIG_FILE = 4
-  MISSING_CONFIG = 5
-  MISSING_CERTS = 6
-  # Service/network-related:
-  HTTP_NON_200 = 7
-  ERROR_SENDING_HTTP = 8
-  ERROR_EXTRACTING_ATTRIBUTES = 9
-  MISSING_CERT_UPDATE_ENDPOINT = 10
-  # Internal errors:
-  ERROR_GENERATING_CERTS = 11
-  ERROR_WRITING_TO_FILE = 12
-
   class RetryRequestException < Exception
     # Throw this exception to tell the fluentd engine to retry and
     # inform the output plugin that it is indeed retryable
@@ -32,7 +15,6 @@ module OMS
     require 'digest'
     require 'date'
     require 'securerandom'
-    require 'syslog/logger'
 
     require_relative 'omslog'
     require_relative 'oms_configuration'
@@ -670,71 +652,12 @@ module OMS
         return @@AgentVersion
       end
 
-      # Return the certificate text as a single formatted string
-      def get_cert_server(cert_path)
-        cert_server = ""
-
-        cert_file_contents = File.readlines(cert_path)
-        for i in 1..(cert_file_contents.length-2) #skip first and last line in file
-          line = cert_file_contents[i]
-          cert_server.concat(line[0..-2])
-          if i < (cert_file_contents.length-2)
-            cert_server.concat(" ")
-          end
-        end
-
-        return cert_server
-      end
-
       def format_time(time)
         Time.at(time).utc.iso8601(3) # UTC with milliseconds
       end
 
       def format_time_str(time)
         DateTime.parse(time).strftime("%FT%H:%M:%S.%3NZ")
-      end
-
-      # Helper method that returns true if a file exists and is non-empty
-      def file_exists_nonempty(file_path)
-        return true if !file_path.nil? and File.exist?(file_path) and !File.zero?(file_path)
-      end
-
-      # Return logger from provided log facility
-      def get_logger(log_facility)
-
-        facility = case log_facility
-          # Custom log facilities supported by both Ruby and bash logger
-          when "auth"     then Syslog::LOG_AUTHPRIV  # LOG_AUTH is deprecated
-          when "authpriv" then Syslog::LOG_AUTHPRIV
-          when "cron"     then Syslog::LOG_CRON
-          when "daemon"   then Syslog::LOG_DAEMON
-          when "ftp"      then Syslog::LOG_FTP
-          when "kern"     then Syslog::LOG_KERN
-          when "lpr"      then Syslog::LOG_LRP
-          when "mail"     then Syslog::LOG_MAIL
-          when "news"     then Syslog::LOG_NEWS
-          when "security" then Syslog::LOG_SECURITY
-          when "syslog"   then Syslog::LOG_SYSLOG
-          when "user"     then Syslog::LOG_USER
-          when "uucp"     then Syslog::LOG_UUCP
-
-          when "local0"   then Syslog::LOG_LOCAL0
-          when "local1"   then Syslog::LOG_LOCAL1
-          when "local2"   then Syslog::LOG_LOCAL2
-          when "local3"   then Syslog::LOG_LOCAL3
-          when "local4"   then Syslog::LOG_LOCAL4
-          when "local5"   then Syslog::LOG_LOCAL5
-          when "local6"   then Syslog::LOG_LOCAL6
-          when "local7"   then Syslog::LOG_LOCAL7
-
-          # default logger will be local0
-          else Syslog::LOG_LOCAL0
-        end
-
-        if !Syslog.opened?
-          Syslog::Logger.syslog = Syslog.open("omsagent", Syslog::LOG_PID, facility)
-        end
-        return Syslog::Logger.new
       end
 
       def create_error_tag(tag)
@@ -815,20 +738,6 @@ module OMS
         end
         return req
       end # create_ods_request
-
-      # Return a POST request with the specified headers, URI, and body, and an
-      #     HTTP to execute that request
-      def form_post_request_and_http(headers, uri_string, body, cert, key, proxy)
-        uri = URI.parse(uri_string)
-        req = Net::HTTP::Post.new(uri.request_uri, headers)
-        req.body = body
-
-        http = create_secure_http(uri, OMS::Configuration.get_proxy_config(proxy))
-        http.cert = cert
-        http.key = key
-
-        return req, http
-      end # form_post_request_and_http
 
       # parses the json record with appropriate encoding
       # parameters:

--- a/Providers/Modules/Plugins/Common/plugin/oms_configuration.rb
+++ b/Providers/Modules/Plugins/Common/plugin/oms_configuration.rb
@@ -182,8 +182,8 @@ module OMS
       end
 
       # load the configuration from the configuration file, cert, and key path
-      def load_configuration(conf_path, cert_path, key_path, force_reload=false)
-        return true if @@ConfigurationLoaded and !force_reload
+      def load_configuration(conf_path, cert_path, key_path)
+        return true if @@ConfigurationLoaded
         return false if !test_onboard_file(conf_path) or !test_onboard_file(cert_path) or !test_onboard_file(key_path)
 
         @@ProxyConfig = get_proxy_config(@@ProxyConfigFilePath)

--- a/Providers/Modules/Plugins/Common/plugin/out_oms.rb
+++ b/Providers/Modules/Plugins/Common/plugin/out_oms.rb
@@ -16,6 +16,7 @@ module Fluent
       require_relative 'omslog'
       require_relative 'oms_configuration'
       require_relative 'oms_common'
+      require_relative 'agent_telemetry_script'
     end
 
     config_param :omsadmin_conf_path, :string, :default => '/etc/opt/microsoft/omsagent/conf/omsadmin.conf'

--- a/Providers/Modules/Plugins/Common/plugin/out_oms_blob.rb
+++ b/Providers/Modules/Plugins/Common/plugin/out_oms_blob.rb
@@ -23,6 +23,7 @@ module Fluent
       require_relative 'oms_configuration'
       require_relative 'oms_common'
       require_relative 'blocklock'
+      require_relative 'agent_telemetry_script'
     end
 
     config_param :omsadmin_conf_path, :string, :default => '/etc/opt/microsoft/omsagent/conf/omsadmin.conf'

--- a/Providers/Modules/Plugins/Common/plugin/out_oms_changetracking_file.rb
+++ b/Providers/Modules/Plugins/Common/plugin/out_oms_changetracking_file.rb
@@ -23,6 +23,7 @@ module Fluent
       require_relative 'omslog'
       require_relative 'oms_configuration'
       require_relative 'oms_common'
+      require_relative 'agent_telemetry_script'
     end
 
     config_param :omsadmin_conf_path, :string, :default => '/etc/opt/microsoft/omsagent/conf/omsadmin.conf'

--- a/Providers/Modules/Plugins/Common/plugin/out_oms_diag.rb
+++ b/Providers/Modules/Plugins/Common/plugin/out_oms_diag.rb
@@ -13,6 +13,7 @@ module Fluent
       require_relative 'oms_configuration'
       require_relative 'oms_common'
       require_relative 'oms_diag_lib'
+      require_relative 'agent_telemetry_script'
     end
 
     config_param :omsadmin_conf_path, :string, :default => '/etc/opt/microsoft/omsagent/conf/omsadmin.conf'


### PR DESCRIPTION
Issues were identified where new shell bundle + old dsc modules would lead to failure. The cause was code shared between topology/telemetry scripts was moved into oms_common, which is part of the dsc module. If the new bundle was installed before dsc modules deployed, the telemetry and topology scripts would reference methods in oms_common that did not exist.

As a solution, I have added the file agent_common which contains the bits shared between topology and telemetry scripts. It patches the OMS::Common class. I updated the tests with required includes.

Additionally, if the new bundle preceded the new modules, the telemetry script would attempt to start, which requires new elements in oms_configuration. To prevent resulting errors, the in_agent_telemetry will check for one of the necessary methods in oms_configuration and only begin telemetry collection if it is defined.

Matches [this](https://github.com/Microsoft/OMS-Agent-for-Linux/pull/916) PR in the bundle repo.