### PR TITLE
Updated the Custom logs plugin and added more log statements

### DIFF
--- a/Providers/Modules/CustomLog/Plugin/tailfilereader.rb
+++ b/Providers/Modules/CustomLog/Plugin/tailfilereader.rb
@@ -39,12 +39,33 @@ module Tailscript
         path = date.strftime(path)
         if path.include?('*')
           Dir.glob(path).select { |p|
-            @log.info "Following tail of #{p}"
-            expanded_paths << p
+          begin
+            is_file = !File.directory?(p)
+            if File.readable?(p) && is_file
+              @log.info "Following tail of #{p}"
+              @log.debug "The current size of the file #{p} is #{File.size(p)}"
+              expanded_paths << p
+            elsif !File.readable?(p)
+              @log.warn "#{p} is excluded since it's unreadable or doesn't have proper permissions."
+            else
+              @log.warn "#{p} is a directory and thus cannot be tailed"
+            end
+          rescue Errno::ENOENT
+            @log.debug("#{p} is missing after refreshing file list")
+          end
           }
         else
           file = file_exists(path)
-          expanded_paths << file unless file.nil?
+          if !file.nil?
+            if File.readable?(path) && !File.directory?(path)
+              @log.debug "The current size of the file #{path} is #{File.size(path)}"
+              expanded_paths << file 
+            elsif !File.readable?(path)
+              @log.warn "#{path} is excluded since it's unreadable or doesn't have proper permissions."
+            else
+              @log.warn "#{path} is a directory and thus cannot be tailed"
+            end
+          end
         end
       }
       return expanded_paths
@@ -191,6 +212,7 @@ module Tailscript
               end
             end
 
+            @log.debug "Number of lines read from #{@io.path} : #{@lines.length}"           
             unless @lines.empty?
               if @receive_lines.call(@lines)
                 @pe.update_pos(@io.pos - @buffer.bytesize)
@@ -268,8 +290,9 @@ module Tailscript
     class PositionFile
       UNWATCHED_POSITION = 0xffffffffffffffff
 
-      def initialize(file, map, last_pos)
+      def initialize(file, file_mutex, map, last_pos)
         @file = file
+        @file_mutex = file_mutex
         @map = map
         @last_pos = last_pos
       end
@@ -279,29 +302,34 @@ module Tailscript
           return m
         end
 
-        @file.pos = @last_pos
-        @file.write path
-        @file.write "\t"
-        seek = @file.pos
-        @file.write "0000000000000000\t0000000000000000\n"
-        @last_pos = @file.pos
-
-        @map[path] = FilePositionEntry.new(@file, seek)
+        @file_mutex.synchronize {
+          @file.pos = @last_pos
+          @file.write "#{path}\t0000000000000000\t0000000000000000\n"
+          seek = @last_pos + path.bytesize + 1
+          @last_pos = @file.pos
+          @map[path] = FilePositionEntry.new(@file, @file_mutex, seek, 0, 0)
+        }
       end
 
       def self.parse(file)
         compact(file)
 
+        file_mutex = Mutex.new
         map = {}
         file.pos = 0
         file.each_line {|line|
           m = /^([^\t]+)\t([0-9a-fA-F]+)\t([0-9a-fA-F]+)/.match(line)
-          next unless m
+          unless m
+            $log.warn "Unparsable line in pos_file: #{line}"
+            next
+          end
           path = m[1]
+          pos = m[2].to_i(16)
+          ino = m[3].to_i(16)
           seek = file.pos - line.bytesize + path.bytesize + 1
-          map[path] = FilePositionEntry.new(file, seek)
+          map[path] = FilePositionEntry.new(file, file_mutex, seek, pos, ino)
         }
-        new(file, map, file.pos)
+        new(file, file_mutex, map, file.pos)
       end
 
       # Clean up unwatched file entries
@@ -309,7 +337,10 @@ module Tailscript
         file.pos = 0
         existent_entries = file.each_line.map { |line|
           m = /^([^\t]+)\t([0-9a-fA-F]+)\t([0-9a-fA-F]+)/.match(line)
-          next unless m
+          unless m
+            $log.warn "Unparsable line in pos_file: #{line}"
+            next
+          end
           path = m[1]
           pos = m[2].to_i(16)
           ino = m[3].to_i(16)
@@ -332,31 +363,37 @@ module Tailscript
       LN_OFFSET = 33
       SIZE = 34
 
-      def initialize(file, seek)
+      def initialize(file, file_mutex, seek, pos, inode)
         @file = file
+        @file_mutex = file_mutex
         @seek = seek
+        @pos = pos
+        @inode = inode
       end
 
       def update(ino, pos)
-        @file.pos = @seek
-        @file.write "%016x\t%016x" % [pos, ino]
+        @file_mutex.synchronize {
+          @file.pos = @seek
+          @file.write "%016x\t%016x" % [pos, ino]
+        }
+        @pos = pos
+        @inode = ino
       end
 
       def update_pos(pos)
-        @file.pos = @seek
-        @file.write "%016x" % pos
+        @file_mutex.synchronize {
+          @file.pos = @seek
+          @file.write "%016x" % pos
+        }
+        @pos = pos
       end
 
       def read_inode
-        @file.pos = @seek + INO_OFFSET
-        raw = @file.read(INO_SIZE)
-        raw ? raw.to_i(16) : 0
+        @inode
       end
 
       def read_pos
-        @file.pos = @seek
-        raw = @file.read(POS_SIZE)
-        raw ? raw.to_i(16) : 0
+        @pos
       end
     end
 


### PR DESCRIPTION
1) Updated the expand_paths method of tailfilereader.rb to add more logs and checks to make sure the file exists, is readable and is not a directory.
2) Ported changes in the position file code from fluentd's in_tail plugin into the tailfilereader.rb. Changes include adding mutex locks on the position file and updating the get/set methods.
3) Changed the log variable in sudo_tail from $log (global) to @log (inherited) so as to allow individual plugins to set their own log severity levels in configuration files or inherit the default from input.
4) Added a counter debug statement to keep track of the number lines being outputted from the sudo tail plugin
5) Added debug logs in tailfilereader.rb to output the file size to check if there has been any change at all in the files being tailed
6) Added debug logs in tailfilereader.rb to output the number of lines read from each of the files being tailed to confirm that the plugin is actually reading and outputting the lines to sudo tail

Testing Strategy -
1) Ran the recently added regression unit tests to make sure no functionality is broken
2) Conducted manual tests to confirm that the logs are flowing into the backend and are visible in the correct form on the portal.