### PR TITLE
fix HOME path for processes started as nxautomation user

### DIFF
--- a/Providers/nxOMSAutomationWorker/automationworker/worker/runtime.py
+++ b/Providers/nxOMSAutomationWorker/automationworker/worker/runtime.py
@@ -58,8 +58,8 @@ class Runtime:
         env = os.environ.copy()
         env.update({"AUTOMATION_JOB_ID": str(self.job_data.job_id),
                     "AUTOMATION_ACTIVITY_ID": str(tracer.u_activity_id),
-                    "PYTHONPATH": str(
-                        configuration.get_source_directory_path())})  # windows env have to be str (not unicode)
+                    "PYTHONPATH": str(configuration.get_source_directory_path()),
+                    "HOME": str(os.getcwd())})  # windows env have to be str (not unicode)
         self.runbook_subprocess = subprocessfactory.create_subprocess(cmd=cmd,
                                                                       env=env,
                                                                       stdout=subprocess.PIPE,


### PR DESCRIPTION
DSC is running as omsagent user, then spawns a subprocess to run hybrid worker as nxautomation user.
The Python subprocess module has behavior where the subprocess inherits the $HOME env variable from omsagent, so $HOME in the subprocess environment points to the wrong home directory.