### PR TITLE
Commented out debug log statements to mitigate stderr overflow issue

### DIFF
--- a/Providers/Modules/CustomLog/Plugin/tailfilereader.rb
+++ b/Providers/Modules/CustomLog/Plugin/tailfilereader.rb
@@ -188,7 +188,7 @@ module Tailscript
 
         def on_notify
           begin
-            @log.debug "Seeking to read file - #{@io.path} from #{@io.pos} position and file size is #{@io.stat.size}"
+            #@log.debug "Seeking to read file - #{@io.path} from #{@io.pos} position and file size is #{@io.stat.size}"
             read_more = false
             if @lines.empty?
               begin
@@ -198,7 +198,7 @@ module Tailscript
                   else
                     @buffer << @io.readpartial(2048, @iobuf)
                   end
-                  @log.debug "The buffer length is #{@buffer.length}"
+                  #@log.debug "The buffer length is #{@buffer.length}"
                   while idx = @buffer.index(@SEPARATOR)
                     @lines << @buffer.slice!(0, idx + 1)
                   end


### PR DESCRIPTION
According to this [comment](https://github.com/microsoft/PowerShell-DSC-for-Linux/commit/8deac202cfc2f497cc6c820a6041bf05c6a84fec#commitcomment-34642228) These debug statements inside a Loop cause STDERR pipe to get filled and thus tailfilereader.rb OS process gets into Hung state. Thus commenting them out for now. 