### PR TITLE
NPM changes to set permissions to npmd_agent binary

### DIFF
--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSAgentNPMConfig.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSAgentNPMConfig.py
@@ -36,6 +36,7 @@ AGENT_SCRIPT_PATH = '/opt/microsoft/omsconfig/Scripts/NPMAgentBinaryCap.sh'
 
 # Constants
 X64 = '64bit'
+AGENT_BINARY_NAME = 'npmd_agent'
 def enum(**enums):
     return type('Enum', (), enums)
 Commands = enum(LogNPM = 'ErrorLog', StartNPM = 'StartNPM', StopNPM = 'StopNPM', Config = 'Config', Purge = 'Purge')
@@ -321,8 +322,9 @@ def UpdateAgentBinary(newVersion):
     # set capabilities to binary
     src_files = os.listdir(src)
     for file_name in src_files:
-        full_file_name = os.path.join(AGENT_BINARY_PATH, file_name) # assuming only file in directory
-        break
+        if AGENT_BINARY_NAME in file_name:
+            full_file_name = os.path.join(AGENT_BINARY_PATH, file_name) # assuming only file in directory
+            break
     retval &= NPM_ACTION.binary_setcap(full_file_name)
 
     # Notify ruby plugin

--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSAgentNPMConfig.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSAgentNPMConfig.py
@@ -323,7 +323,7 @@ def UpdateAgentBinary(newVersion):
     src_files = os.listdir(src)
     for file_name in src_files:
         if AGENT_BINARY_NAME in file_name:
-            full_file_name = os.path.join(AGENT_BINARY_PATH, file_name) # assuming only file in directory
+            full_file_name = os.path.join(AGENT_BINARY_PATH, file_name)
             break
     retval &= NPM_ACTION.binary_setcap(full_file_name)
 

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSAgentNPMConfig.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSAgentNPMConfig.py
@@ -321,7 +321,7 @@ def UpdateAgentBinary(newVersion):
     src_files = os.listdir(src)
     for file_name in src_files:
         if AGENT_BINARY_NAME in file_name:
-            full_file_name = os.path.join(AGENT_BINARY_PATH, file_name) # assuming only file in directory
+            full_file_name = os.path.join(AGENT_BINARY_PATH, file_name)
             break
     retval &= NPM_ACTION.binary_setcap(full_file_name)
 

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSAgentNPMConfig.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSAgentNPMConfig.py
@@ -35,6 +35,7 @@ AGENT_SCRIPT_PATH = '/opt/microsoft/omsconfig/Scripts/NPMAgentBinaryCap.sh'
 
 # Constants
 X64 = '64bit'
+AGENT_BINARY_NAME = 'npmd_agent'
 def enum(**enums):
     return type('Enum', (), enums)
 Commands = enum(LogNPM = 'ErrorLog', StartNPM = 'StartNPM', StopNPM = 'StopNPM', Config = 'Config', Purge = 'Purge')
@@ -319,8 +320,9 @@ def UpdateAgentBinary(newVersion):
     # set capabilities to binary
     src_files = os.listdir(src)
     for file_name in src_files:
-        full_file_name = os.path.join(AGENT_BINARY_PATH, file_name) # assuming only file in directory
-        break
+        if AGENT_BINARY_NAME in file_name:
+            full_file_name = os.path.join(AGENT_BINARY_PATH, file_name) # assuming only file in directory
+            break
     retval &= NPM_ACTION.binary_setcap(full_file_name)
 
     # Notify ruby plugin

--- a/Providers/Scripts/3.x/Scripts/nxOMSAgentNPMConfig.py
+++ b/Providers/Scripts/3.x/Scripts/nxOMSAgentNPMConfig.py
@@ -36,6 +36,7 @@ AGENT_SCRIPT_PATH = '/opt/microsoft/omsconfig/Scripts/NPMAgentBinaryCap.sh'
 
 # Constants
 X64 = '64bit'
+AGENT_BINARY_NAME = 'npmd_agent'
 def enum(**enums):
     return type('Enum', (), enums)
 Commands = enum(LogNPM = 'ErrorLog', StartNPM = 'StartNPM', StopNPM = 'StopNPM', Config = 'Config', Purge = 'Purge')
@@ -320,8 +321,9 @@ def UpdateAgentBinary(newVersion):
     # set capabilities to binary
     src_files = os.listdir(src)
     for file_name in src_files:
-        full_file_name = os.path.join(AGENT_BINARY_PATH, file_name) # assuming only file in directory
-        break
+        if AGENT_BINARY_NAME in file_name:
+            full_file_name = os.path.join(AGENT_BINARY_PATH, file_name) # assuming only file in directory
+            break
     retval &= NPM_ACTION.binary_setcap(full_file_name)
 
     # Notify ruby plugin

--- a/Providers/Scripts/3.x/Scripts/nxOMSAgentNPMConfig.py
+++ b/Providers/Scripts/3.x/Scripts/nxOMSAgentNPMConfig.py
@@ -322,7 +322,7 @@ def UpdateAgentBinary(newVersion):
     src_files = os.listdir(src)
     for file_name in src_files:
         if AGENT_BINARY_NAME in file_name:
-            full_file_name = os.path.join(AGENT_BINARY_PATH, file_name) # assuming only file in directory
+            full_file_name = os.path.join(AGENT_BINARY_PATH, file_name)
             break
     retval &= NPM_ACTION.binary_setcap(full_file_name)
 


### PR DESCRIPTION
This PR is to look for npmd_agent binary in the list of available files in the folder and try to run the script only on that particular binary but not on all files in the folder.