### PR TITLE
Update npmd_agent_x64 binary to point 2.0 version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -517,7 +517,7 @@ nxFileInventory:
 
 nxOMSAgentNPMConfig:
 	rm -rf output/staging; \
-	VERSION="1.9"; \
+	VERSION="2.0"; \
 	PROVIDERS="nxOMSAgentNPMConfig"; \
 	STAGINGDIR="output/staging/$@/DSCResources"; \
 	cat Providers/Modules/$@.psd1 | sed "s@<MODULE_VERSION>@$${VERSION}@" > intermediate/Modules/$@.psd1; \


### PR DESCRIPTION
This PR is to bundle npmd_agent_x64 latest binary and also update version to 2.0 in Makefile so that latest binary will be picked while creating pkg.