### PR TITLE
Regex bug fix and plugin comparison removal from customlog module

### DIFF
--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSSudoCustomLog.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSSudoCustomLog.py
@@ -139,10 +139,7 @@ def Test(EnableCustomLogConfiguration, Ensure, CustomLogObjects):
        
         if Ensure == "Absent":
             return [-1]
-        elif Ensure == "Present":
-            if (not(CompareFiles(PLUGIN, AGENT_PLUGIN)) or not(CompareFiles(SCRIPT, AGENT_SCRIPT))):
-                return [-1]
-         
+        
     return [0] 
 
 def Get(EnableCustomLogConfiguration, Ensure, CustomLogObjects):
@@ -175,7 +172,7 @@ def ReadConf():
     if not os.path.isfile(conf_path):
         return [];
     txt = codecs.open(conf_path, 'r', 'utf8').read().encode('ascii','ignore')
-    customlog_src_srch_str = r'\n<source>\n  type sudo_tail.*?path (.*?)\n.*?pos_file /var/opt/microsoft/omsagent/state/(.*?)\.pos.*?run_interval ([0-9]+[a-z]*).*?tag oms\.blob\.CustomLog\.(.*?)\.\*.*?format none.*?</source>\n'
+    customlog_src_srch_str = r'\n<source>\n  type sudo_tail.*?path (.*?)\n.*?pos_file /var/opt/microsoft/omsagent/state/(.*?)\.pos\n.*?run_interval ([0-9]+[a-z]*).*?tag oms\.blob\.CustomLog\.(.*?)\.\*.*?format none.*?</source>\n'
     customlog_src_srch = re.compile(customlog_src_srch_str, re.M|re.S)
     new_customlogs = []
     sources = customlog_src_srch.findall(txt)

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSSudoCustomLog.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSSudoCustomLog.py
@@ -139,9 +139,6 @@ def Test(EnableCustomLogConfiguration, Ensure, CustomLogObjects):
        
         if Ensure == "Absent":
             return [-1]
-        elif Ensure == "Present":
-            if (not(CompareFiles(PLUGIN, AGENT_PLUGIN)) or not(CompareFiles(SCRIPT, AGENT_SCRIPT))):
-                return [-1]
          
     return [0] 
 
@@ -175,7 +172,7 @@ def ReadConf():
     if not os.path.isfile(conf_path):
         return [];
     txt = codecs.open(conf_path, 'r', 'utf8').read().encode('ascii','ignore')
-    customlog_src_srch_str = r'\n<source>\n  type sudo_tail.*?path (.*?)\n.*?pos_file /var/opt/microsoft/omsagent/state/(.*?)\.pos.*?run_interval ([0-9]+[a-z]*).*?tag oms\.blob\.CustomLog\.(.*?)\.\*.*?format none.*?</source>\n'
+    customlog_src_srch_str = r'\n<source>\n  type sudo_tail.*?path (.*?)\n.*?pos_file /var/opt/microsoft/omsagent/state/(.*?)\.pos\n.*?run_interval ([0-9]+[a-z]*).*?tag oms\.blob\.CustomLog\.(.*?)\.\*.*?format none.*?</source>\n'
     customlog_src_srch = re.compile(customlog_src_srch_str, re.M|re.S)
     new_customlogs = []
     sources = customlog_src_srch.findall(txt)

--- a/Providers/Scripts/3.x/Scripts/nxOMSSudoCustomLog.py
+++ b/Providers/Scripts/3.x/Scripts/nxOMSSudoCustomLog.py
@@ -136,10 +136,7 @@ def Test(EnableCustomLogConfiguration, Ensure, CustomLogObjects):
        
         if Ensure == "Absent":
             return [-1]
-        elif Ensure == "Present":
-            if (not(CompareFiles(PLUGIN, AGENT_PLUGIN)) or not(CompareFiles(SCRIPT, AGENT_SCRIPT))):
-                return [-1]
-         
+        
     return [0] 
 
 def Get(EnableCustomLogConfiguration, Ensure, CustomLogObjects):
@@ -172,7 +169,7 @@ def ReadConf():
     if not os.path.isfile(conf_path):
         return [];
     txt = codecs.open(conf_path, 'r', 'utf8').read()
-    customlog_src_srch_str = r'\n<source>\n  type sudo_tail.*?path (.*?)\n.*?pos_file /var/opt/microsoft/omsagent/state/(.*?)\.pos.*?run_interval ([0-9]+[a-z]*).*?tag oms\.blob\.CustomLog\.(.*?)\.\*.*?format none.*?</source>\n'
+    customlog_src_srch_str = r'\n<source>\n  type sudo_tail.*?path (.*?)\n.*?pos_file /var/opt/microsoft/omsagent/state/(.*?)\.pos\n.*?run_interval ([0-9]+[a-z]*).*?tag oms\.blob\.CustomLog\.(.*?)\.\*.*?format none.*?</source>\n'
     customlog_src_srch = re.compile(customlog_src_srch_str, re.M|re.S)
     new_customlogs = []
     sources = customlog_src_srch.findall(txt)


### PR DESCRIPTION
1) Added a regex bug fix for the nxOMSSudoCustomlog.py module where it tries to search for the tag of the custom log (ex. CUSTOM_LOG_BLOB.<customlogname>) by stripping the word between "pos_file /var/opt/microsoft/omsagent/state/" and ".pos". Added a '\n' character at the end of the ".pos" to prevent incorrect matching for any custom log names starting with "pos". For example, for a custom log name - postgresql, the tag would be **CUSTOM_LOG_BLOB.postgresql.pos** the regex would have incorrectly matched with the first ".pos" of postgresql and not the intended file extension ".pos" at the end. 

2) Removed the comparison checks for DSC plugins with OMSAgent plugins for custom log because we no longer store our plugins for customlog in the DSC modules. 