### PR TITLE
Vakarana/npm binary update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -517,7 +517,7 @@ nxFileInventory:
 
 nxOMSAgentNPMConfig:
 	rm -rf output/staging; \
-	VERSION="2.0"; \
+	VERSION="2.1"; \
 	PROVIDERS="nxOMSAgentNPMConfig"; \
 	STAGINGDIR="output/staging/$@/DSCResources"; \
 	cat Providers/Modules/$@.psd1 | sed "s@<MODULE_VERSION>@$${VERSION}@" > intermediate/Modules/$@.psd1; \

--- a/Providers/Modules/NPM/Plugin/plugin/npmd_config_lib.rb
+++ b/Providers/Modules/NPM/Plugin/plugin/npmd_config_lib.rb
@@ -422,8 +422,8 @@ module NPMDConfig
                             _urls.push(_urlHash)
                         end
                         _msRule["URLs"] = _urls
+                        _ruleList.push(_msRule)
                     end
-                    _ruleList.push(_msRule)
                     _er[:"MSPeeringRules"] = _ruleList if !_ruleList.empty?
                 end
             end


### PR DESCRIPTION
This PR is to push latest npm_agent_x64 binary with all logging changes.
Chaged NPMConfig pkg version to 2.1
Updated Ruby plugin change related to ERConfig.