### PR TITLE
Vakarana/npmcpu hog fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -517,7 +517,7 @@ nxFileInventory:
 
 nxOMSAgentNPMConfig:
 	rm -rf output/staging; \
-	VERSION="2.1"; \
+	VERSION="2.2"; \
 	PROVIDERS="nxOMSAgentNPMConfig"; \
 	STAGINGDIR="output/staging/$@/DSCResources"; \
 	cat Providers/Modules/$@.psd1 | sed "s@<MODULE_VERSION>@$${VERSION}@" > intermediate/Modules/$@.psd1; \


### PR DESCRIPTION
This PR is to update npmd_agent_x64 binary of nxOMSAgentNPMConfig pkg.
Binary contains fix for CPU Hog issue.
Also, updated version number of pkg to 2.2.