### PR TITLE
ods-rate-limiting: update configuration to set appropriate retries

### DIFF
--- a/Providers/Modules/Plugins/Common/plugin/out_oms_changetracking_file.rb
+++ b/Providers/Modules/Plugins/Common/plugin/out_oms_changetracking_file.rb
@@ -383,7 +383,10 @@ module Fluent
 
     def handle_record_internal(key, record)
       @log.trace "Handling record : #{key}"
-      req = OMS::Common.create_ods_request(OMS::Configuration.ods_endpoint.path, record, @compress)
+      extra_headers = {
+        OMS::CaseSensitiveString.new('x-ms-client-request-retry-count') => "#{@num_errors}"
+      }
+      req = OMS::Common.create_ods_request(OMS::Configuration.ods_endpoint.path, record, @compress, extra_headers)
       unless req.nil?
         http = OMS::Common.create_ods_http(OMS::Configuration.ods_endpoint, @proxy_config)
         start = Time.now
@@ -605,3 +608,4 @@ module Fluent
  end #class UploadFileContent
 
 end # Module
+

--- a/Providers/Modules/Plugins/VMware/conf/vmware_esxi.conf
+++ b/Providers/Modules/Plugins/VMware/conf/vmware_esxi.conf
@@ -28,6 +28,7 @@
   buffer_path /var/opt/microsoft/omsagent/state/out_oms_api_vmware_logs*.buffer
   buffer_queue_limit 10
   flush_interval 20s
-  retry_limit 10
+  retry_limit 6
   retry_wait 30s
+  max_retry_wait 30m
 </match>

--- a/Providers/Modules/nxOMSAuditdPlugin/conf/auditd_plugin.conf
+++ b/Providers/Modules/nxOMSAuditdPlugin/conf/auditd_plugin.conf
@@ -23,7 +23,7 @@
   buffer_queue_limit 5
   buffer_queue_full_action drop_oldest_chunk
   flush_interval 20s
-  retry_limit 10
+  retry_limit 6
   retry_wait 30s
-  max_retry_wait 5m
+  max_retry_wait 30m
 </match>

--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSGenerateInventoryMof.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSGenerateInventoryMof.py
@@ -157,7 +157,7 @@ def GenerateInventoyConfContents(FeatureName, Instances, RunIntervalInSeconds, T
 </filter> \n \
 <match ' + Tag + '> \n \
   type out.' + Tag + '\n \
-  log_level trace \n \
+  log_level info \n \
   num_threads 5 \n \
   buffer_chunk_limit 5m \n \
   buffer_type file \n \
@@ -165,9 +165,9 @@ def GenerateInventoyConfContents(FeatureName, Instances, RunIntervalInSeconds, T
   buffer_queue_limit 10 \n \
   buffer_queue_full_action drop_oldest_chunk \n \
   flush_interval 20s \n \
-  retry_limit 10 \n \
+  retry_limit 6 \n \
   retry_wait 30s \n \
-  max_retry_wait 9m \n \
+  max_retry_wait 30m \n \
 ' + configurations + ' \n \
 </match> \n'
     return conf_file_contents

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSGenerateInventoryMof.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSGenerateInventoryMof.py
@@ -152,7 +152,7 @@ def GenerateInventoyConfContents(FeatureName, Instances, RunIntervalInSeconds, T
 </filter> \n \
 <match ' + Tag + '> \n \
   type out.' + Tag + '\n \
-  log_level trace \n \
+  log_level info \n \
   num_threads 5 \n \
   buffer_chunk_limit 5m \n \
   buffer_type file \n \
@@ -160,9 +160,9 @@ def GenerateInventoyConfContents(FeatureName, Instances, RunIntervalInSeconds, T
   buffer_queue_limit 10 \n \
   buffer_queue_full_action drop_oldest_chunk \n \
   flush_interval 20s \n \
-  retry_limit 10 \n \
+  retry_limit 6 \n \
   retry_wait 30s \n \
-  max_retry_wait 9m \n \
+  max_retry_wait 30m \n \
 ' + configurations + ' \n \
 </match> \n'
 

--- a/Providers/Scripts/3.x/Scripts/nxOMSGenerateInventoryMof.py
+++ b/Providers/Scripts/3.x/Scripts/nxOMSGenerateInventoryMof.py
@@ -152,7 +152,7 @@ def GenerateInventoyConfContents(FeatureName, Instances, RunIntervalInSeconds, T
 </filter> \n \
 <match ' + Tag + '> \n \
   type out.' + Tag + '\n \
-  log_level trace \n \
+  log_level info \n \
   num_threads 5 \n \
   buffer_chunk_limit 5m \n \
   buffer_type file \n \
@@ -160,9 +160,9 @@ def GenerateInventoyConfContents(FeatureName, Instances, RunIntervalInSeconds, T
   buffer_queue_limit 10 \n \
   buffer_queue_full_action drop_oldest_chunk \n \
   flush_interval 20s \n \
-  retry_limit 10 \n \
+  retry_limit 6 \n \
   retry_wait 30s \n \
-  max_retry_wait 9m \n \
+  max_retry_wait 30m \n \
 ' + configurations + ' \n \
 </match> \n'
 

--- a/Providers/nxOMSContainers/containers/conf/container.conf
+++ b/Providers/nxOMSContainers/containers/conf/container.conf
@@ -107,8 +107,9 @@
 	buffer_path %STATE_DIR_WS%/out_oms_api_kubernetes*.buffer
 	buffer_queue_limit 10
 	flush_interval 20s
-	retry_limit 10
+	retry_limit 6
 	retry_wait 30s
+  max_retry_wait 30m
 </match>
 
 
@@ -120,9 +121,9 @@
   buffer_path %STATE_DIR_WS%/out_oms_containerinventory*.buffer
   buffer_queue_limit 20
   flush_interval 20s
-  retry_limit 10
-  retry_wait 15s
-  max_retry_wait 9m
+  retry_limit 6
+  retry_wait 30s
+  max_retry_wait 30m
 </match>
 
 
@@ -135,7 +136,7 @@
   buffer_path %STATE_DIR_WS%/out_oms_docker*.buffer
   buffer_queue_limit 20
   flush_interval 20s
-  retry_limit 10
-  retry_wait 15s
-  max_retry_wait 9m
+  retry_limit 6
+  retry_wait 30s
+  max_retry_wait 30m
 </match>

--- a/Providers/nxOMSContainers/containers/conf/container.conf
+++ b/Providers/nxOMSContainers/containers/conf/container.conf
@@ -100,15 +100,15 @@
 </filter>
 
 <match oms.api.KubePodInventory** oms.api.KubeEvents**>
-	type out_oms_api
-	log_level debug
-	buffer_chunk_limit 5m
-	buffer_type file
-	buffer_path %STATE_DIR_WS%/out_oms_api_kubernetes*.buffer
-	buffer_queue_limit 10
-	flush_interval 20s
-	retry_limit 6
-	retry_wait 30s
+  type out_oms_api
+  log_level debug
+  buffer_chunk_limit 5m
+  buffer_type file
+  buffer_path %STATE_DIR_WS%/out_oms_api_kubernetes*.buffer
+  buffer_queue_limit 10
+  flush_interval 20s
+  retry_limit 6
+  retry_wait 30s
   max_retry_wait 30m
 </match>
 


### PR DESCRIPTION
In order to support the new ODS rate limiting, some configs need to be updated with the following values:

  retry_limit 6
  retry_wait 5s
  max_retry_wait 30m