### PR TITLE
Update npmd_agent to 2.4 version and related changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -530,7 +530,7 @@ nxFileInventory:
 
 nxOMSAgentNPMConfig:
 	rm -rf output/staging; \
-	VERSION="2.3"; \
+	VERSION="2.4"; \
 	PROVIDERS="nxOMSAgentNPMConfig"; \
 	STAGINGDIR="output/staging/$@/DSCResources"; \
 	cat Providers/Modules/$@.psd1 | sed "s@<MODULE_VERSION>@$${VERSION}@" > intermediate/Modules/$@.psd1; \

--- a/Providers/Modules/NPM/Plugin/plugin/in_npmd_server.rb
+++ b/Providers/Modules/NPM/Plugin/plugin/in_npmd_server.rb
@@ -675,11 +675,15 @@ module Fluent
                 unless is_npmd_seen_in_ps()
                     @npmdIntendedStop = false
                     _stderrFileName = "#{File.dirname(@location_unix_endpoint)}/stderror_#{SecureRandom.uuid}.log"
-                    @npmdProcessId = Process.spawn(@binary_invocation_cmd, :err=>_stderrFileName)
-                    @last_npmd_start = Time.now
-                    @stderrFileNameHash[@npmdProcessId] = _stderrFileName
-                    _t = Thread.new {handle_exit(@npmdProcessId)}
-                    Logger::logInfo "NPMD Agent running with process id #{@npmdProcessId}"
+                    begin
+                        @npmdProcessId = Process.spawn(@binary_invocation_cmd, :err=>_stderrFileName)
+                        @last_npmd_start = Time.now
+                        @stderrFileNameHash[@npmdProcessId] = _stderrFileName
+                        _t = Thread.new {handle_exit(@npmdProcessId)}
+                        Logger::logInfo "NPMD Agent running with process id #{@npmdProcessId}"
+                    rescue
+                        log_error "Unable to spawn NPMD Agent binary"
+                    end
                 else
                     Logger::logInfo "Npmd already seen in PS"
                 end

--- a/Providers/Modules/NPM/Plugin/plugin/npmd_config_lib.rb
+++ b/Providers/Modules/NPM/Plugin/plugin/npmd_config_lib.rb
@@ -650,7 +650,7 @@ module NPMDConfig
                         _rule["AppThresholdLatency"] = _test["AppThreshold"].nil? ? "-3.0" : (_test["AppThreshold"].has_key?("Latency") ? _test["AppThreshold"]["Latency"] : "-2.0")
                         _rule["NetworkThresholdLoss"] = _test["NetworkThreshold"].nil? ? "-3" : (_test["NetworkThreshold"].has_key?("Loss") ? _test["NetworkThreshold"]["Loss"] : "-2")
                         _rule["NetworkThresholdLatency"] = _test["NetworkThreshold"].nil? ? "-3.0" : (_test["NetworkThreshold"].has_key?("Latency") ? _test["NetworkThreshold"]["Latency"] : "-2.0")
-                        _rule["ValidStatusCodeRanges"] = _test.has_key?["ValidStatusCodeRanges"] ? _test["ValidStatusCodeRanges"] : nil
+                        _rule["ValidStatusCodeRanges"] = _test.has_key?("ValidStatusCodeRanges") ? _test["ValidStatusCodeRanges"] : String.new
 
                         _connectionMonitorId = _test.has_key?("ConnectionMonitorId") ? _test["ConnectionMonitorId"].to_s : String.new
 


### PR DESCRIPTION
This PR is to:

1. update npmd_agent binary version to 2.4
2. Keep npmd_agent binary spawning in exception block and log error in case of any failure.
3. Fix ruby plugin while parsing ValidStatusCodeRanges key in case of EPM.