### PR TITLE
Fix regex pattern to lookup syslog source name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -370,7 +370,7 @@ nxOMSPerfCounter:
 
 nxOMSSyslog:
 	rm -rf output/staging; \
-        VERSION="2.4"; \
+        VERSION="2.5"; \
         PROVIDERS="nxOMSSyslog"; \
         STAGINGDIR="output/staging/$@/DSCResources"; \
         cat Providers/Modules/$@.psd1 | sed "s@<MODULE_VERSION>@$${VERSION}@" > intermediate/Modules/$@.psd1; \

--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSSyslog.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSSyslog.py
@@ -344,12 +344,15 @@ def UpdateSyslogNGConf(SyslogSource, WorkspaceID):
         return False
 
     # Extract the correct source from the conf file
-    source_search = r'^source (.*?src).*$'
+    # Different distros may use different source name:
+    # in redhat 7.4 the source is 's_sys'
+    # in ubuntu/debian the source is 's_src'
+    source_search = r'^source (.*){$'
     source_re = re.compile(source_search, re.M)
     source_result = source_re.search(txt)
     source_expr = 'src'
     if source_result:
-        source_expr = source_result.group(1)
+        source_expr = source_result.group(1).strip()
 
     port = ExtractFieldFromFluentDConf(WorkspaceID, 'port', default_port)
     protocol_type = ExtractFieldFromFluentDConf(WorkspaceID, 'protocol_type', default_protocol)

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSSyslog.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSSyslog.py
@@ -343,12 +343,15 @@ def UpdateSyslogNGConf(SyslogSource, WorkspaceID):
         return False
 
     # Extract the correct source from the conf file
-    source_search = r'^source (.*?src).*$'
+    # Different distros may use different source name:
+    # in redhat 7.4 the source is 's_sys'
+    # in ubuntu/debian the source is 's_src'
+    source_search = r'^source (.*){$'
     source_re = re.compile(source_search, re.M)
     source_result = source_re.search(txt)
     source_expr = 'src'
     if source_result:
-        source_expr = source_result.group(1)
+        source_expr = source_result.group(1).strip()
 
     port = ExtractFieldFromFluentDConf(WorkspaceID, 'port', default_port)
     protocol_type = ExtractFieldFromFluentDConf(WorkspaceID, 'protocol_type', default_protocol)

--- a/Providers/Scripts/3.x/Scripts/nxOMSSyslog.py
+++ b/Providers/Scripts/3.x/Scripts/nxOMSSyslog.py
@@ -339,12 +339,15 @@ def UpdateSyslogNGConf(SyslogSource, WorkspaceID):
         return False
 
     # Extract the correct source from the conf file
-    source_search = r'^source (.*?src).*$'
+    # Different distros may use different source name:
+    # in redhat 7.4 the source is 's_sys'
+    # in ubuntu/debian the source is 's_src'
+    source_search = r'^source (.*){$'
     source_re = re.compile(source_search, re.M)
     source_result = source_re.search(txt)
     source_expr = 'src'
     if source_result:
-        source_expr = source_result.group(1)
+        source_expr = source_result.group(1).strip()
 
     port = ExtractFieldFromFluentDConf(WorkspaceID, 'port', default_port)
     protocol_type = ExtractFieldFromFluentDConf(WorkspaceID, 'protocol_type', default_protocol)

--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -59,7 +59,7 @@ SHLIB_EXT: 'so'
 /opt/microsoft/omsconfig/Scripts/OMS_MetaConfigHelper.py; intermediate/Scripts/OMS_MetaConfigHelper.py; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nx_1.0.zip; release/nx_1.0.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSPerfCounter_2.2.zip; release/nxOMSPerfCounter_2.2.zip; 755; ${{RUN_AS_USER}}; root
-/opt/microsoft/omsconfig/module_packages/nxOMSSyslog_2.4.zip; release/nxOMSSyslog_2.4.zip; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/omsconfig/module_packages/nxOMSSyslog_2.5.zip; release/nxOMSSyslog_2.5.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSSudoCustomLog_2.7.zip; release/nxOMSSudoCustomLog_2.7.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSKeyMgmt_1.0.zip; release/nxOMSKeyMgmt_1.0.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/${{SHORT_NAME}}/keys/dscgpgkey.asc; LCM/keys/dscgpgkey.asc; 644; ${{RUN_AS_USER}}; root
@@ -305,7 +305,7 @@ chown -R ${{RUN_AS_USER}} /opt/microsoft/omsconfig/Scripts
 # Set up built-in resource modules for OMS DSC
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nx_1.0.zip 0"
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSPerfCounter_2.2.zip 0"
-su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSSyslog_2.4.zip 0"
+su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSSyslog_2.5.zip 0"
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSSudoCustomLog_2.7.zip 0"
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSKeyMgmt_1.0.zip 0"
 su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxFileInventory_1.3.zip 0"


### PR DESCRIPTION
Redhat 5, SLES 11 are the only ones shipping syslog-ng be default.

This bug is causing syslog-ng to exit, it was triggered because customer manually removed rsyslog and installed syslog-ng on their Redhat 7.4 VMs.

In order to test this, you have to install syslog-ng on any redhat 6 or 7