### PR TITLE
Add UploadDirectly flag in ConnectionMonitorPathResult

### DIFF
--- a/Providers/Modules/NPM/Plugin/plugin/in_npmd_server.rb
+++ b/Providers/Modules/NPM/Plugin/plugin/in_npmd_server.rb
@@ -318,6 +318,9 @@ module Fluent
                                     # Append EPM, CM and ER data
                                     elsif _subtypeList.include?item["SubType"]
                                         Logger::logInfo "#{item["SubType"]} is uploaded"
+                                        #Append UploadDirectly Flag to true for ConnectionMonitorPath as this flag will be used at NPM service
+                                        if item["SubType"] == "ConnectionMonitorPath"
+                                            item["UploadDirectly"] = "true"
                                         _validUploadDataItems << item if is_valid_dataitem(item)
                                     else
                                         log_error "Invalid Subtype data received"

--- a/Providers/Modules/NPM/Plugin/plugin/npmd_config_lib.rb
+++ b/Providers/Modules/NPM/Plugin/plugin/npmd_config_lib.rb
@@ -1107,7 +1107,8 @@ module NPMContract
                                                     "Protocol",
                                                     "PathTestResult",
                                                     "AdditionalData",
-                                                    "IngestionWorkspaceResourceId"]
+                                                    "IngestionWorkspaceResourceId",
+                                                    "UploadDirectly"]
 
     def self.IsValidDataitem(item, itemType)
         _contract=[]


### PR DESCRIPTION
This PR is to add a flag "UploadDirectly" in ConnectionMonitorPathResult so that NPM service uses this flag to understand whether data is already prepared at NPMDAgent level or NPM service needs to construct them from data available.