### PR TITLE
update npmd_agent_x64 binary to 2.9 version for NPM DSC module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -530,7 +530,7 @@ nxFileInventory:
 
 nxOMSAgentNPMConfig:
 	rm -rf output/staging; \
-	VERSION="2.8"; \
+	VERSION="2.9"; \
 	PROVIDERS="nxOMSAgentNPMConfig"; \
 	STAGINGDIR="output/staging/$@/DSCResources"; \
 	cat Providers/Modules/$@.psd1 | sed "s@<MODULE_VERSION>@$${VERSION}@" > intermediate/Modules/$@.psd1; \


### PR DESCRIPTION
This PR is to update all latest changes of npmd_agent binary those are committed till 07th May.

Following is the latest PR: https://msazure.visualstudio.com/One/_git/Mgmt-LogAnalytics-NPMD/pullrequest/2899963