### PR TITLE
Handle sigterm for OMS_MetaConfigHelper.py script

### DIFF
--- a/LCM/scripts/OMS_MetaConfigHelper.py
+++ b/LCM/scripts/OMS_MetaConfigHelper.py
@@ -32,7 +32,7 @@ proc = None
 # function to handle ternimation signals received from omsagent.
 # Child process are created by with a new group id.
 # We issue termination signal together to all childprocesses with group id.
-def sigterm_handler(_signo, _stack_frame):
+def signal_handler(signalNumber, frame):
     printVerboseMessage("OMS_MetaconfigHelper.py script received SIGTERM signal.")
 
     if proc is not None:
@@ -151,7 +151,7 @@ Variables = dict()
 Defines = []
 
 # register the SIGTERM handler
-signal.signal(signal.SIGTERM, sigterm_handler)
+signal.signal(signal.SIGTERM, signal_handler)
 
 # Parse command line arguments
 args = []

--- a/LCM/scripts/SetDscLocalConfigurationManager.py
+++ b/LCM/scripts/SetDscLocalConfigurationManager.py
@@ -7,6 +7,7 @@ from traceback            import format_exc
 from fcntl                import flock, LOCK_EX, LOCK_UN, LOCK_NB
 from OmsConfigHostHelpers import write_omsconfig_host_telemetry, write_omsconfig_host_switch_event, write_omsconfig_host_log, stop_old_host_instances
 from time                 import sleep
+import signal
 
 pathToCurrentScript = realpath(__file__)
 pathToCommonScriptsFolder = dirname(pathToCurrentScript)
@@ -18,6 +19,7 @@ operationStatusUtilityPath = join(pathToCommonScriptsFolder, 'OperationStatusUti
 operationStatusUtility = load_source('operationStatusUtility', operationStatusUtilityPath)
 
 operation = 'SetLCM'
+proc = None
 
 def usage():
     print("Usage:")
@@ -50,6 +52,7 @@ def apply_meta_config(args):
         exit(1)
 
     fileHandle = open(args[2], 'r')
+    global proc
     try:
         fileContent = fileHandle.read()
         outtokens = []
@@ -123,9 +126,9 @@ def apply_meta_config(args):
                         sleep(60)
 
                 if dschostlock_acquired:
-                    p = Popen(parameters, stdout=PIPE, stderr=PIPE)
-                    exit_code = p.wait()
-                    stdout, stderr = p.communicate()
+                    proc = Popen(parameters, stdout=PIPE, stderr=PIPE)
+                    exit_code = proc.wait()
+                    stdout, stderr = proc.communicate()
                     print(stdout)
                 else:
                     print("dsc host lock already acuired by a different process")
@@ -137,9 +140,9 @@ def apply_meta_config(args):
                     # Close dsc host lock file handle
                     dschostlock_filehandle.close()
         else:
-            p = Popen(parameters, stdout=PIPE, stderr=PIPE)
-            exit_code = p.wait()
-            stdout, stderr = p.communicate()
+            proc = Popen(parameters, stdout=PIPE, stderr=PIPE)
+            exit_code = proc.wait()
+            stdout, stderr = proc.communicate()
 
         print(stdout)
 
@@ -148,6 +151,24 @@ def apply_meta_config(args):
 
     finally:
         fileHandle.close()
+
+# function to handle ternimation signals received from omsagent.
+# we kill the child dsc_host process if it is invoked and exit current script.
+def sigterm_handler(_signo, _stack_frame):
+    global proc
+    write_omsconfig_host_log("SIGTERM signal received. Trying to kill any child process...", pathToCurrentScript)
+
+    if proc is not None:
+        write_omsconfig_host_log("Terminating child process (ID = " + str(proc.pid) + ") by sending SIGTERM signal.", pathToCurrentScript)
+        proc.terminate()
+    else:
+        write_omsconfig_host_log("There is no child process running. It has either completed execution or has not been started.", pathToCurrentScript)
+    
+    write_omsconfig_host_log("Script exiting...", pathToCurrentScript)
+    exit(1)
+
+# register the SIGTERM handler
+signal.signal(signal.SIGTERM, sigterm_handler)
 
 if __name__ == "__main__":
     main(argv)

--- a/LCM/scripts/SetDscLocalConfigurationManager.py
+++ b/LCM/scripts/SetDscLocalConfigurationManager.py
@@ -154,7 +154,7 @@ def apply_meta_config(args):
 
 # function to handle ternimation signals received from omsagent.
 # we kill the child dsc_host process if it is invoked and exit current script.
-def sigterm_handler(_signo, _stack_frame):
+def signal_handler(signalNumber, frame):
     global proc
     write_omsconfig_host_log("SIGTERM signal received. Trying to kill any child process...", pathToCurrentScript)
 
@@ -167,8 +167,7 @@ def sigterm_handler(_signo, _stack_frame):
     write_omsconfig_host_log("Script exiting...", pathToCurrentScript)
     exit(1)
 
-# register the SIGTERM handler
-signal.signal(signal.SIGTERM, sigterm_handler)
-
 if __name__ == "__main__":
+    # register the SIGTERM handler
+    signal.signal(signal.SIGTERM, signal_handler)
     main(argv)


### PR DESCRIPTION
Omsagent will regenerate MetConfig.mof if there is a change in DSC endpoint as part of its topology requests. Below is the process chain here:
- agent_maintenance_script.rb popen3 call to OMS_MetaConfigHelper.py
- OMS_MetaConfigHelper popen call to SetDscLocalConfigurationManager.py
- SetDscLocalConfigurationManager.py popen call to dsc_host (further complicated by 10 x 60s wait to acquire the dsc_host lock)

Since the call to generate the metaconfig is complex/not reliable we call it with timeout + kill logic in this PR (https://github.com/microsoft/OMS-Agent-for-Linux/pull/1160). As part of this timeout + kill logic, in some edge cases this child chain will not be cleaned e.g. we could end up with OMS_MetaConfigHelper killed but remaining orphans. 

We handle Sigterms sent by the omsagent and pass it down and ensure that the process chain is always cleaned.