### PR TITLE
Update NPM version file when new agent binaries are added successfully

### DIFF
--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSAgentNPMConfig.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSAgentNPMConfig.py
@@ -319,20 +319,21 @@ def UpdateAgentBinary(newVersion):
         retval &= DeleteAllFiles(src, AGENT_BINARY_PATH)
         retval &= CopyAllFiles(src, AGENT_BINARY_PATH)
 
+    #Update version number after deleting and copying new agent files
+    if retval == True:
+        WriteFile(AGENT_RESOURCE_VERSION_PATH, newVersion)
+
     # set capabilities to binary
     src_files = os.listdir(src)
     for file_name in src_files:
         if AGENT_BINARY_NAME in file_name:
             full_file_name = os.path.join(AGENT_BINARY_PATH, file_name)
             break
-    retval &= NPM_ACTION.binary_setcap(full_file_name)
+    NPM_ACTION.binary_setcap(full_file_name)
 
     # Notify ruby plugin
     #retval &= NotifyServer(Commands.RestartNPM)
 
-    #Update version number
-    if retval == True:
-        WriteFile(AGENT_RESOURCE_VERSION_PATH, newVersion)
     return retval
 
 def UpdatePluginFiles():

--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSAgentNPMConfig.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSAgentNPMConfig.py
@@ -318,6 +318,7 @@ def UpdateAgentBinary(newVersion):
         src = RESOURCE_MODULE_PATH.__add__(DSC_X86_AGENT_PATH)
         retval &= DeleteAllFiles(src, AGENT_BINARY_PATH)
         retval &= CopyAllFiles(src, AGENT_BINARY_PATH)
+        LOG_ACTION.log(LogType.Error, 'npmd agent binary do not support 32-bit.')
 
     #Update version number after deleting and copying new agent files
     if retval == True:

--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSAgentNPMConfig.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSAgentNPMConfig.py
@@ -330,7 +330,7 @@ def UpdateAgentBinary(newVersion):
         if AGENT_BINARY_NAME in file_name:
             full_file_name = os.path.join(AGENT_BINARY_PATH, file_name)
             break
-    NPM_ACTION.binary_setcap(full_file_name)
+    retval &= NPM_ACTION.binary_setcap(full_file_name)
 
     # Notify ruby plugin
     #retval &= NotifyServer(Commands.RestartNPM)

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSAgentNPMConfig.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSAgentNPMConfig.py
@@ -316,6 +316,7 @@ def UpdateAgentBinary(newVersion):
         src = RESOURCE_MODULE_PATH.__add__(DSC_X86_AGENT_PATH)
         retval &= DeleteAllFiles(src, AGENT_BINARY_PATH)
         retval &= CopyAllFiles(src, AGENT_BINARY_PATH)
+        LOG_ACTION.log(LogType.Error, 'npmd agent binary do not support 32-bit.')
 
     #Update version number after deleting and copying new agent files
     if retval == True:

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSAgentNPMConfig.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSAgentNPMConfig.py
@@ -328,7 +328,7 @@ def UpdateAgentBinary(newVersion):
         if AGENT_BINARY_NAME in file_name:
             full_file_name = os.path.join(AGENT_BINARY_PATH, file_name)
             break
-    NPM_ACTION.binary_setcap(full_file_name)
+    retval &= NPM_ACTION.binary_setcap(full_file_name)
 
     # Notify ruby plugin
     #retval &= NotifyServer(Commands.RestartNPM)

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSAgentNPMConfig.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSAgentNPMConfig.py
@@ -317,20 +317,21 @@ def UpdateAgentBinary(newVersion):
         retval &= DeleteAllFiles(src, AGENT_BINARY_PATH)
         retval &= CopyAllFiles(src, AGENT_BINARY_PATH)
 
+    #Update version number after deleting and copying new agent files
+    if retval == True:
+        WriteFile(AGENT_RESOURCE_VERSION_PATH, newVersion)
+
     # set capabilities to binary
     src_files = os.listdir(src)
     for file_name in src_files:
         if AGENT_BINARY_NAME in file_name:
             full_file_name = os.path.join(AGENT_BINARY_PATH, file_name)
             break
-    retval &= NPM_ACTION.binary_setcap(full_file_name)
+    NPM_ACTION.binary_setcap(full_file_name)
 
     # Notify ruby plugin
     #retval &= NotifyServer(Commands.RestartNPM)
 
-    #Update version number
-    if retval == True:
-        WriteFile(AGENT_RESOURCE_VERSION_PATH, newVersion)
     return retval
 
 def UpdatePluginFiles():

--- a/Providers/Scripts/3.x/Scripts/nxOMSAgentNPMConfig.py
+++ b/Providers/Scripts/3.x/Scripts/nxOMSAgentNPMConfig.py
@@ -318,20 +318,21 @@ def UpdateAgentBinary(newVersion):
         retval &= DeleteAllFiles(src, AGENT_BINARY_PATH)
         retval &= CopyAllFiles(src, AGENT_BINARY_PATH)
 
+    #Update version number after deleting and copying new agent files
+    if retval == True:
+        WriteFile(AGENT_RESOURCE_VERSION_PATH, newVersion)
+
     # set capabilities to binary
     src_files = os.listdir(src)
     for file_name in src_files:
         if AGENT_BINARY_NAME in file_name:
             full_file_name = os.path.join(AGENT_BINARY_PATH, file_name)
             break
-    retval &= NPM_ACTION.binary_setcap(full_file_name)
+    NPM_ACTION.binary_setcap(full_file_name)
 
     # Notify ruby plugin
     #retval &= NotifyServer(Commands.RestartNPM)
 
-    #Update version number
-    if retval == True:
-        WriteFile(AGENT_RESOURCE_VERSION_PATH, newVersion)
     return retval
 
 def UpdatePluginFiles():

--- a/Providers/Scripts/3.x/Scripts/nxOMSAgentNPMConfig.py
+++ b/Providers/Scripts/3.x/Scripts/nxOMSAgentNPMConfig.py
@@ -317,6 +317,7 @@ def UpdateAgentBinary(newVersion):
         src = RESOURCE_MODULE_PATH.__add__(DSC_X86_AGENT_PATH)
         retval &= DeleteAllFiles(src, AGENT_BINARY_PATH)
         retval &= CopyAllFiles(src, AGENT_BINARY_PATH)
+        LOG_ACTION.log(LogType.Error, 'npmd agent binary do not support 32-bit.')
 
     #Update version number after deleting and copying new agent files
     if retval == True:

--- a/Providers/Scripts/3.x/Scripts/nxOMSAgentNPMConfig.py
+++ b/Providers/Scripts/3.x/Scripts/nxOMSAgentNPMConfig.py
@@ -329,7 +329,7 @@ def UpdateAgentBinary(newVersion):
         if AGENT_BINARY_NAME in file_name:
             full_file_name = os.path.join(AGENT_BINARY_PATH, file_name)
             break
-    NPM_ACTION.binary_setcap(full_file_name)
+    retval &= NPM_ACTION.binary_setcap(full_file_name)
 
     # Notify ruby plugin
     #retval &= NotifyServer(Commands.RestartNPM)


### PR DESCRIPTION
1. Update npm_version file with new version number once new binary files are successfully added.
2. No need to check whether OS is able to run "setcap" command to set raw socket capability and only then update the npm_version file.
3. checking the "setcap" command is run successfully or not is optional now.