### PR TITLE
Jinsha python3 merged (#715)

### DIFF
--- a/LCM/dsc/engine/ConsistencyInvoker/ConsistencyInvoker.c
+++ b/LCM/dsc/engine/ConsistencyInvoker/ConsistencyInvoker.c
@@ -14,22 +14,92 @@
    THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+#include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #define PYTHON_COMMAND "python"
+#define PYTHON2_COMMAND "python2"
+#define PYTHON3_COMMAND "python3"
 #define PYTHON_SCRIPT_NAME "PerformRequiredConfigurationChecks.py"
+
+char* getPythonProvider();
 
 int main(int argc, char *argv[])
 {
-    int fullCommandLength = strlen(PYTHON_COMMAND) + 1 + strlen(DSC_SCRIPT_PATH) + 1 + strlen(PYTHON_SCRIPT_NAME) + 1;
+    char * pythonCommand = PYTHON2_COMMAND;
+    
+    char* dscScriptPath = malloc(1);
+    dscScriptPath = 0;
+    dscScriptPath = realloc(dscScriptPath, strlen(DSC_SCRIPT_PATH) + 1 );
+    dscScriptPath = strcat(dscScriptPath, DSC_SCRIPT_PATH);
+    
+    //if oms config check to be added
+    if(strstr(dscScriptPath, "omsconfig")!= NULL)
+    {
+        pythonCommand = getPythonProvider();
+
+        if(strcmp(pythonCommand, PYTHON3_COMMAND) == 0)
+        {
+            dscScriptPath = realloc(dscScriptPath, strlen(dscScriptPath) + strlen("/python3") + 1 );
+            dscScriptPath = strcat(dscScriptPath, "/python3");
+        }
+    }
+
+
+    int fullCommandLength = strlen(pythonCommand) + 1 + strlen(dscScriptPath) + 1 + strlen(PYTHON_SCRIPT_NAME) + 1;
     char fullCommand[fullCommandLength];
 
-    strcpy(fullCommand, PYTHON_COMMAND);
+    strcpy(fullCommand, pythonCommand);
     strcat(fullCommand, " ");
-    strcat(fullCommand, DSC_SCRIPT_PATH);
+    strcat(fullCommand, dscScriptPath);
     strcat(fullCommand, "/");
     strcat(fullCommand, PYTHON_SCRIPT_NAME);
 
     int returnValue = system(fullCommand);
     return returnValue;
+}
+
+
+// I may need to move this method in some file which is accessible to all other files in the project.
+char* getPythonProvider()
+{
+    int buffer_length = 128;
+    char buffer[buffer_length]; 
+    char* result = malloc(1);
+    *result = 0; 
+
+    FILE* pipe = popen("python2 --version 2>&1", "r");   
+    if(!pipe) {
+        printf("Cant start command.");
+    }
+    while(fgets(buffer, 128, pipe) != NULL) {
+        result = realloc(result, (result ? strlen(result) : 0) + buffer_length );
+        strcat(result,buffer);
+    }
+
+    // If python2 --version does not contain 'not found' return python2
+    if(strstr(result, "not found") == NULL) {
+    	return PYTHON2_COMMAND;
+    }
+
+    // Look for python3
+    result = malloc(1);
+    *result = 0;
+    pipe = popen("python3 --version 2>&1", "r");
+    if(!pipe) {
+    	printf("Cant start command.");
+    }
+    while(fgets(buffer, 128, pipe) != NULL) {
+        result = realloc(result, (result ? strlen(result) : 0) + buffer_length );
+        strcat(result,buffer);
+    }
+
+    // If python3 --version does not contain 'not found' return python3
+    if(strstr(result, "not found") == NULL) {
+	    return PYTHON3_COMMAND;
+    }
+
+    return PYTHON_COMMAND;
+
 }

--- a/LCM/dsc/engine/ca/CAInfrastructure/WebPullClient.c
+++ b/LCM/dsc/engine/ca/CAInfrastructure/WebPullClient.c
@@ -3,7 +3,7 @@
 
    Copyright (c) Microsoft Corporation
 
-   All rights reserved. 
+   All rights reserved.
 
    MIT License
 
@@ -29,6 +29,9 @@
 #include <openssl/err.h>
 #include <curl/curl.h>
 #include <base/conf.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdbool.h>
 
 #include "WebPullClient.h"
 
@@ -56,7 +59,7 @@ struct ModuleTable {
     ModuleTableEntry* first;
 };
 
-static MI_Result GetModuleNameVersionTable(MI_Char* mofFileLocation, 
+static MI_Result GetModuleNameVersionTable(MI_Char* mofFileLocation,
                                            ModuleTable* table,
                                            _Outptr_result_maybenull_ MI_Instance **extendedError);
 
@@ -66,13 +69,13 @@ struct ReadChunk
     size_t last_char;
 };
 
-struct Chunk 
+struct Chunk
 {
     size_t size;
     char * data;
 };
 
-struct HeaderChunk 
+struct HeaderChunk
 {
     size_t size;
     char ** headerKeys;
@@ -106,7 +109,7 @@ static void CleanupHeaderChunk(struct HeaderChunk * chunk)
     free(chunk->headerValues);
     chunk->headerKeys = NULL;
     chunk->headerValues = NULL;
-    
+
 }
 
 struct SSLOptions g_sslOptions;
@@ -122,7 +125,7 @@ static MI_Result GetSSLOptions(_Outptr_result_maybenull_ MI_Instance **extendedE
     g_sslOptions.cipherList[0] = '\0';
     g_sslOptions.CABundle[0] = '\0';
     g_sslOptions.Proxy[0] = '\0';
-    
+
     conf = Conf_Open(OMI_CONF_FILE_PATH);
     if (!conf)
     {
@@ -153,7 +156,7 @@ static MI_Result GetSSLOptions(_Outptr_result_maybenull_ MI_Instance **extendedE
             }
             else if (strcasecmp(value, "false") == 0)
             {
-                g_sslOptions.DoNotCheckCertificate = MI_FALSE;           
+                g_sslOptions.DoNotCheckCertificate = MI_FALSE;
             }
             else
             {
@@ -169,7 +172,7 @@ static MI_Result GetSSLOptions(_Outptr_result_maybenull_ MI_Instance **extendedE
             }
             else if (strcasecmp(value, "false") == 0)
             {
-                g_sslOptions.NoSSLv3 = MI_FALSE;         
+                g_sslOptions.NoSSLv3 = MI_FALSE;
             }
             else
             {
@@ -261,12 +264,12 @@ static MI_Result GetSSLOptions(_Outptr_result_maybenull_ MI_Instance **extendedE
 static size_t HeaderCallback(void *contents, size_t size, size_t nmemb, void *userp)
 {
   size_t realsize = size * nmemb;
-  struct HeaderChunk *chunk = (struct HeaderChunk *)userp; 
+  struct HeaderChunk *chunk = (struct HeaderChunk *)userp;
   char* colonPointer = NULL;
   long key_length = 0;
   long value_length = 0;
   char *charContents = (char*)calloc(realsize, 1);
-  
+
   // We have to do a silly memcpy here because there's no safe version of "strstr", used below.
   memcpy(charContents, contents, realsize);
 
@@ -294,7 +297,7 @@ static size_t HeaderCallback(void *contents, size_t size, size_t nmemb, void *us
 
   chunk->headerKeys[chunk->size] = malloc( key_length + 1 );
   chunk->headerValues[chunk->size] = malloc( value_length + 1);
-  
+
   memcpy(chunk->headerKeys[chunk->size], charContents, key_length);
   chunk->headerKeys[chunk->size][key_length] = '\0';
   memcpy(chunk->headerValues[chunk->size], colonPointer + 2, value_length);
@@ -304,23 +307,23 @@ static size_t HeaderCallback(void *contents, size_t size, size_t nmemb, void *us
   free(charContents);
   return realsize;
 }
- 
+
 static size_t WriteCallback(void *contents, size_t size, size_t nmemb, void *userp)
 {
   size_t realsize = size * nmemb;
   struct Chunk *mem = (struct Chunk *)userp;
- 
+
   mem->data = realloc(mem->data, mem->size + realsize + 1);
   memcpy(&(mem->data[mem->size]), contents, realsize);
   mem->size += realsize;
   mem->data[mem->size] = 0;
- 
+
   return realsize;
 }
 
 
 MI_Char *GetSystemUuid();
-MI_Boolean EscapeValue (_In_reads_z_(size) char *tokenValue, int startValue, int size, 
+MI_Boolean EscapeValue (_In_reads_z_(size) char *tokenValue, int startValue, int size,
                     _Inout_ int *currentTokenStartValue,
                     _Inout_ int *currentTokenEndValue,
                     _Inout_ int *nextTokenValue);
@@ -415,7 +418,7 @@ static ModuleTableEntry** ModuleTableContainsKey(ModuleTable* table, MI_Char* mo
     {
         return NULL;
     }
-    
+
     current = &table->first;
     while (*current != NULL)
     {
@@ -459,12 +462,12 @@ MI_Boolean ValidateChecksum(_In_z_ MI_Char *checksum, _In_z_ const MI_Char* path
     size_t bytesRead;
     SHA256_CTX Ctx;
     char const alphabet[] = "0123456789ABCDEF";
-    unsigned char hashedValue[SHA256TRANSFORM_DIGEST_LEN];    
+    unsigned char hashedValue[SHA256TRANSFORM_DIGEST_LEN];
     int iCount = 0;
     FILE * fp = NULL;
     if( checksum == NULL)
         return MI_FALSE;
-    
+
     fp = File_OpenT(path, MI_T("r"));
     if( fp == NULL )
         return MI_FALSE;
@@ -485,9 +488,9 @@ MI_Boolean ValidateChecksum(_In_z_ MI_Char *checksum, _In_z_ const MI_Char* path
         }
     }
     while( bytesRead >= BUFFER_SIZE_1KB );
-    
+
     SHA256_Final(hashedValue, &Ctx);
-    
+
     File_Close(fp);
     // validate the checksum.
     // Use the buffer for memory
@@ -497,19 +500,19 @@ MI_Boolean ValidateChecksum(_In_z_ MI_Char *checksum, _In_z_ const MI_Char* path
     {
         computedHash[2*iCount] = alphabet[ hashedValue[iCount]/16];
         computedHash[2*iCount+1] = alphabet[ hashedValue[iCount]%16];
-    }    
+    }
 
     if( Tcscasecmp(checksum, (const MI_Char*)computedHash) != 0 )
         return MI_FALSE;
 
     return MI_TRUE;
-    
+
 }
 
 MI_INLINE MI_Boolean IsValidUuid(_In_z_ MI_Char* systemUuid)
 {
     MI_Uint32 len = 0;
-    MI_Uint32 xCount = 0;     
+    MI_Uint32 xCount = 0;
     if( systemUuid == NULL)
     {
         return MI_FALSE;
@@ -517,7 +520,7 @@ MI_INLINE MI_Boolean IsValidUuid(_In_z_ MI_Char* systemUuid)
     len = (MI_Uint32)Tcslen(systemUuid);
     if( len != 36 )
         return MI_FALSE;
-    //pattern 8-13-19-24 and all characters are hexadecimal. 
+    //pattern 8-13-19-24 and all characters are hexadecimal.
     for(xCount = 0; xCount <8; xCount++)
     {
         if(!isxdigit((unsigned char)systemUuid[xCount]))
@@ -575,18 +578,18 @@ MI_Boolean ConnectionAllowed(_In_ MI_InstanceA *customParam, _In_z_ const MI_Cha
     //only https is allowed.
     if( Tcsncasecmp(serverName, MI_T("https"), 5) == 0 )
         return MI_TRUE;
-    
+
     return MI_FALSE;
 }
-MI_Result GetMetaConfigParameters(_In_ MI_Instance *metaConfig, 
+MI_Result GetMetaConfigParameters(_In_ MI_Instance *metaConfig,
                                   _In_ MI_Char* partialConfigName,
                                   _Outptr_opt_result_maybenull_    MI_Instance **credential,
                                   _Inout_    MI_InstanceA *customParam,
                                   _Outptr_result_maybenull_z_ MI_Char **configurationID,
                                   _Outptr_result_maybenull_z_ MI_Char **certificateID,
-                                  _Inout_updates_(URL_SIZE) MI_Char *url, 
-                                  _Inout_updates_(SUBURL_SIZE) MI_Char *subUrl, 
-                                  _Out_ MI_Uint32 *port, 
+                                  _Inout_updates_(URL_SIZE) MI_Char *url,
+                                  _Inout_updates_(SUBURL_SIZE) MI_Char *subUrl,
+                                  _Out_ MI_Uint32 *port,
                                   _Out_ MI_Boolean *bIsHttps,
                                   _Out_ MI_Uint32* getActionStatusCode,
                                   _Outptr_result_maybenull_ MI_Instance **extendedError)
@@ -626,7 +629,7 @@ MI_Result GetMetaConfigParameters(_In_ MI_Instance *metaConfig,
     {
         *getActionStatusCode = InvalidConfigurationIdInMetaConfig;
         r = GetCimMIError(MI_RESULT_SERVER_LIMITS_EXCEEDED, extendedError, ID_ENGINEHELPER_MEMORY_ERROR);
-        return r;              
+        return r;
     }
     memcpy(*configurationID, value.string, Tcslen(value.string)* sizeof(MI_Char));
     /* Validate the Uuid.*/
@@ -635,18 +638,18 @@ MI_Result GetMetaConfigParameters(_In_ MI_Instance *metaConfig,
     {
         *getActionStatusCode = InvalidConfigurationIdFormat;
         r = GetCimMIError1Param(MI_RESULT_FAILED, extendedError, ID_PULL_INVALIDCONFIGURATIONIDFORMAT, *configurationID);
-        DSC_free(*configurationID);             
-        return r;            
+        DSC_free(*configurationID);
+        return r;
     }
 */
-    
+
     // 2. Get Credential.
     r = MI_Instance_GetElement(metaConfig, MetaConfig_Credential, &value, NULL, &flags, NULL);
     if( r == MI_RESULT_OK && !(flags & MI_FLAG_NULL))
     {
         *credential = value.instance;
-    }     
-    
+    }
+
 
 
     // If partialConfigName is defined, get the ConfigurationDownloadManagers, else get the DownloadManagerCustomData
@@ -691,11 +694,11 @@ MI_Result GetMetaConfigParameters(_In_ MI_Instance *metaConfig,
 
         for (xCount = 0; xCount < value.instancea.size; ++xCount)
         {
-            MI_Instance_GetElement(value.instancea.data[xCount], OMI_MetaConfigurationResource_ResourceId, &value2, &miType, &flags, NULL);   
+            MI_Instance_GetElement(value.instancea.data[xCount], OMI_MetaConfigurationResource_ResourceId, &value2, &miType, &flags, NULL);
             if ( Tcscasecmp(value2.string, configurationSource) == 0 )
             {
                 // Found the WebDownloadManager with the proper resource ID.
-                MI_Instance_GetElement(value.instancea.data[xCount], MI_T("ServerURL"), &value2, &miType, &flags, NULL);   
+                MI_Instance_GetElement(value.instancea.data[xCount], MI_T("ServerURL"), &value2, &miType, &flags, NULL);
                 if (r != MI_RESULT_OK || (flags & MI_FLAG_NULL))
                 {
                     return GetCimMIError1Param(MI_RESULT_NO_SUCH_PROPERTY, extendedError, ID_PULL_NOSERVERURL, value3.string);
@@ -703,13 +706,13 @@ MI_Result GetMetaConfigParameters(_In_ MI_Instance *metaConfig,
 
                 memcpy(serverURL, value2.string, (Tcslen(value2.string) + 1) * sizeof(MI_Char));
 
-                MI_Instance_GetElement(value.instancea.data[xCount], MI_T("CertificateID"), &value2, &miType, &flags, NULL);   
+                MI_Instance_GetElement(value.instancea.data[xCount], MI_T("CertificateID"), &value2, &miType, &flags, NULL);
                 if (r == MI_RESULT_OK && !(flags & MI_FLAG_NULL))
                 {
-                    memcpy(*certificateID, value2.string, Tcslen(value2.string) * sizeof(MI_Char));  
+                    memcpy(*certificateID, value2.string, Tcslen(value2.string) * sizeof(MI_Char));
                 }
 
-                MI_Instance_GetElement(value.instancea.data[xCount], MI_T("AllowUnsecureConnection"), &value2, &miType, &flags, NULL);   
+                MI_Instance_GetElement(value.instancea.data[xCount], MI_T("AllowUnsecureConnection"), &value2, &miType, &flags, NULL);
                 if (r == MI_RESULT_OK && !(flags & MI_FLAG_NULL))
                 {
                     allowUnsecureConnection = value2.boolean;
@@ -720,7 +723,7 @@ MI_Result GetMetaConfigParameters(_In_ MI_Instance *metaConfig,
                 {
                     *getActionStatusCode = InvalidDownloadManagerCustomDataInMetaConfig;
                     r = GetCimMIError1Param( MI_RESULT_INVALID_PARAMETER, extendedError, ID_PULL_UNSECURECONNECTIONNOTALLOWED, serverURL);
-                    return r;     
+                    return r;
                 }
                 // Found the WebDownloadManager, stop searching.
                 break;
@@ -737,7 +740,7 @@ MI_Result GetMetaConfigParameters(_In_ MI_Instance *metaConfig,
             customParam->data = value.instancea.data;
         }
 
-        
+
         // 4. Get certificate ID.
         for( xCount =0; xCount < customParam->size; xCount++)
         {
@@ -757,13 +760,13 @@ MI_Result GetMetaConfigParameters(_In_ MI_Instance *metaConfig,
                         if( *configurationID )
                             DSC_free(*configurationID);
                         *configurationID = NULL;
-                        return r;              
+                        return r;
                     }
-                    memcpy(*certificateID, value.string, Tcslen(value.string)* sizeof(MI_Char));  
+                    memcpy(*certificateID, value.string, Tcslen(value.string)* sizeof(MI_Char));
                     break;
                 }
             }
-        }         
+        }
     }
 
     if (*serverURL == '\0')
@@ -787,20 +790,20 @@ MI_Result GetMetaConfigParameters(_In_ MI_Instance *metaConfig,
                     {
                         // Found ServerUrl in value.string
                         memcpy(serverURL, value.string, (Tcslen(value.string) + 1) * sizeof(MI_Char));
-                        
+
                         //Check if connection is secure and if unsecure user explicitly asks for it.
                         if( !ConnectionAllowed(&customData, serverURL) )
                         {
                             *getActionStatusCode = InvalidDownloadManagerCustomDataInMetaConfig;
                             r = GetCimMIError1Param( MI_RESULT_INVALID_PARAMETER, extendedError, ID_PULL_UNSECURECONNECTIONNOTALLOWED, serverURL);
                             return r;
-                        }   
-                        
+                        }
+
                         break;
                     }
                 }
             }
-        }      
+        }
         else
         {
             // There's no DownloadManagerCustomData, AND there's no partial configuration.  We should be able to find WebDownloadManager, and only one!
@@ -810,31 +813,31 @@ MI_Result GetMetaConfigParameters(_In_ MI_Instance *metaConfig,
                 // Unable to get the config download managers
                 return GetCimMIError(MI_RESULT_NO_SUCH_PROPERTY, extendedError, ID_PULL_NOCONFIGDOWNLOADMANAGERS);
             }
-         
+
             if (value.instancea.size > 1)
             {
                 // Too many download managers defined, please set up partial configuration for this.
                 return GetCimMIError(MI_RESULT_FAILED, extendedError, ID_PULL_TOOMANYCONFIGDOWNLOADMANAGERS);
             }
 
-            MI_Instance_GetElement(value.instancea.data[0], OMI_MetaConfigurationResource_ResourceId, &value3, NULL, &flags, NULL);   
+            MI_Instance_GetElement(value.instancea.data[0], OMI_MetaConfigurationResource_ResourceId, &value3, NULL, &flags, NULL);
 
             // Found the WebDownloadManager with the proper resource ID.
-            MI_Instance_GetElement(value.instancea.data[0], MI_T("ServerURL"), &value2, NULL, &flags, NULL);   
+            MI_Instance_GetElement(value.instancea.data[0], MI_T("ServerURL"), &value2, NULL, &flags, NULL);
             if (r != MI_RESULT_OK || (flags & MI_FLAG_NULL))
             {
                 return GetCimMIError1Param(MI_RESULT_NO_SUCH_PROPERTY, extendedError, ID_PULL_NOSERVERURL, value3.string);
             }
-            
+
             memcpy(serverURL, value2.string, (Tcslen(value2.string) + 1) * sizeof(MI_Char));
 
-            MI_Instance_GetElement(value.instancea.data[0], MI_T("CertificateID"), &value2, NULL, &flags, NULL);   
+            MI_Instance_GetElement(value.instancea.data[0], MI_T("CertificateID"), &value2, NULL, &flags, NULL);
             if (r == MI_RESULT_OK && !(flags & MI_FLAG_NULL))
             {
-                memcpy(*certificateID, value2.string, Tcslen(value2.string) * sizeof(MI_Char));  
+                memcpy(*certificateID, value2.string, Tcslen(value2.string) * sizeof(MI_Char));
             }
-            
-            MI_Instance_GetElement(value.instancea.data[0], MI_T("AllowUnsecureConnection"), &value2, NULL, &flags, NULL);   
+
+            MI_Instance_GetElement(value.instancea.data[0], MI_T("AllowUnsecureConnection"), &value2, NULL, &flags, NULL);
             if (r == MI_RESULT_OK && !(flags & MI_FLAG_NULL))
             {
                 allowUnsecureConnection = value2.boolean;
@@ -844,13 +847,13 @@ MI_Result GetMetaConfigParameters(_In_ MI_Instance *metaConfig,
 
     if (*serverURL != '\0')
     {
-        if( sscanf(serverURL, MI_T("http://%99[^:]:%d/%199[^\n]"), url, port, subUrl) == 3 || 
+        if( sscanf(serverURL, MI_T("http://%99[^:]:%d/%199[^\n]"), url, port, subUrl) == 3 ||
             sscanf(serverURL, MI_T("http://%99[^/]/%199[^\n]"), url, subUrl) == 2 )
         {
             //success
         }
         //format is: http://server:port/suburl or http://server/suburl
-        else if( sscanf(serverURL, MI_T("https://%99[^:]:%d/%199[^\n]"), url, port, subUrl) == 3 || 
+        else if( sscanf(serverURL, MI_T("https://%99[^:]:%d/%199[^\n]"), url, port, subUrl) == 3 ||
                  sscanf(serverURL, MI_T("https://%99[^/]/%199[^\n]"), url, subUrl) == 2 )
         {
             //success
@@ -865,14 +868,14 @@ MI_Result GetMetaConfigParameters(_In_ MI_Instance *metaConfig,
     {
         // Not found
         *getActionStatusCode = InvalidDownloadManagerCustomDataInMetaConfig;
-        return GetCimMIError(r, extendedError, ID_ENGINEHELPER_MEMORY_ERROR);   
+        return GetCimMIError(r, extendedError, ID_ENGINEHELPER_MEMORY_ERROR);
     }
-    
+
     return MI_RESULT_OK;
-   
+
 }
 
-MI_Char * GetGetActionBodyContent(_In_z_ const MI_Char *checksum, MI_Boolean nodeCompliant, 
+MI_Char * GetGetActionBodyContent(_In_z_ const MI_Char *checksum, MI_Boolean nodeCompliant,
                                 _In_z_ const MI_Char *checksumAlgorithm, MI_Uint32 statusCode)
 {
     const MI_Char *checksumName = MI_T("Checksum");
@@ -885,7 +888,7 @@ MI_Char * GetGetActionBodyContent(_In_z_ const MI_Char *checksum, MI_Boolean nod
     MI_Char statusCodeValue[MAX_STATUSCODE_SIZE];
     size_t length;
     MI_Char *content = NULL;
-    
+
     if( nodeCompliant == MI_TRUE)
     {
         complianceStatus = MI_T("TRUE");
@@ -897,7 +900,7 @@ MI_Char * GetGetActionBodyContent(_In_z_ const MI_Char *checksum, MI_Boolean nod
     Stprintf(statusCodeValue, MAX_STATUSCODE_SIZE, MI_T("%d"), statusCode);
 
     length = 50 + Tcslen(clientStatusName) + Tcslen(checksumName) + Tcslen(algorithmName) + Tcslen(checksum) + Tcslen(checksumAlgorithm);
-    
+
     content = (MI_Char *)DSC_malloc(length * sizeof(MI_Char), NitsHere());
     if( content == NULL )
     {
@@ -914,7 +917,7 @@ MI_Char * GetGetActionBodyContent(_In_z_ const MI_Char *checksum, MI_Boolean nod
 int EscapeString(_In_reads_z_(size) char *tokenValue, int startValue, int size)
 {
     int xCount = startValue;
-    char *start = tokenValue;    
+    char *start = tokenValue;
     while( xCount < size)
     {
         if( *(start+xCount) == '"')
@@ -923,16 +926,16 @@ int EscapeString(_In_reads_z_(size) char *tokenValue, int startValue, int size)
         }
         if( (*(start+xCount) == '\\') && (xCount+1 < size) && (*(start+xCount+1) == '"'))
         xCount++;
-    
+
         xCount++;
-    }    
+    }
     return -1;
 }
 
 int EscapeArray (_In_reads_z_(size) char *tokenValue, int startValue, int size)
 {
     int xCount = startValue;
-    char *start = tokenValue; 
+    char *start = tokenValue;
     int currentTokenStartValue = 0;
     int currentTokenEndValue = 0;
     int nextTokenValue = 0;
@@ -953,16 +956,16 @@ int EscapeArray (_In_reads_z_(size) char *tokenValue, int startValue, int size)
             }
             xCount = nextTokenValue;
         }
-    }    
+    }
     return -1;
 }
 
 int EscapeObject (_In_reads_z_(size) char *tokenValue, int startValue, int size)
 {
     int xCount = startValue;
-    char *start = tokenValue; 
+    char *start = tokenValue;
     int currentTokenStartValue = 0;
-    int currentTokenEndValue = 0;    
+    int currentTokenEndValue = 0;
     int nextTokenValue = 0;
     // escape until we get '}'. it will be in format {string:value};
     while( xCount < size)
@@ -979,18 +982,18 @@ int EscapeObject (_In_reads_z_(size) char *tokenValue, int startValue, int size)
             {
                 return -1;
             }
-            xCount = nextTokenValue;            
+            xCount = nextTokenValue;
         }
         xCount++;
-    }    
+    }
     return -1;
 }
 
 int EscapeNumber (_In_reads_z_(size) char *tokenValue, int startValue, int size)
 {
     int xCount = startValue;
-    char *start = tokenValue;  
-    // escape until we get ":",",","}",}]". 
+    char *start = tokenValue;
+    // escape until we get ":",",","}",}]".
     while( xCount < size)
     {
         if( *(start+xCount) == ',' ||
@@ -1000,17 +1003,17 @@ int EscapeNumber (_In_reads_z_(size) char *tokenValue, int startValue, int size)
           return xCount-1;
         }
         xCount++;
-    }    
+    }
     return -1;
 }
 
-MI_Boolean EscapeValue (_In_reads_z_(size) char *tokenValue, int startValue, int size, 
+MI_Boolean EscapeValue (_In_reads_z_(size) char *tokenValue, int startValue, int size,
                     _Inout_ int *currentTokenStartValue,
                     _Inout_ int *currentTokenEndValue,
                     _Inout_ int *nextTokenValue)
 {
     int xCount = startValue;
-    char *start = tokenValue;     
+    char *start = tokenValue;
     if( xCount < size)
         {
         if( *(start+xCount) == '"' ) // it is a string
@@ -1028,44 +1031,44 @@ MI_Boolean EscapeValue (_In_reads_z_(size) char *tokenValue, int startValue, int
         }
         else if( *(start+xCount) == '{' ) // it is an object
         {
-            *currentTokenStartValue = xCount +1;        
+            *currentTokenStartValue = xCount +1;
             *currentTokenEndValue = EscapeObject(tokenValue, *currentTokenStartValue, size);
             *nextTokenValue = *currentTokenEndValue + 2;
-        }    
+        }
         else if( Strcasecmp(start+xCount, "true")) // it is value true
         {
-            *currentTokenStartValue = xCount;        
+            *currentTokenStartValue = xCount;
             *currentTokenEndValue = xCount + 3;
             *nextTokenValue = *currentTokenEndValue + 1;
-        }    
+        }
         else if( Strcasecmp(start+xCount, "false")) // it is value false
         {
-            *currentTokenStartValue = xCount;        
+            *currentTokenStartValue = xCount;
             *currentTokenEndValue = xCount + 4;
             *nextTokenValue = *currentTokenEndValue + 1;
-        }        
+        }
         else if( Strcasecmp(start+xCount, "null")) // it is value true
         {
-            *currentTokenStartValue = xCount;        
+            *currentTokenStartValue = xCount;
             *currentTokenEndValue = xCount + 3;
             *nextTokenValue = *currentTokenEndValue + 1;
-        }  
+        }
         else // it is a number
         {
-            *currentTokenStartValue = xCount;    
+            *currentTokenStartValue = xCount;
             *currentTokenEndValue = EscapeNumber(tokenValue, *currentTokenStartValue, size);
             *nextTokenValue = *currentTokenEndValue + 2;
-        }   
+        }
         if (*currentTokenEndValue == -1 || *currentTokenStartValue == -1)
-            return MI_FALSE;     
-        return MI_TRUE;        
+            return MI_FALSE;
+        return MI_TRUE;
     }
     return MI_FALSE;
 }
 
 
 
-MI_Boolean GetNextToken(_In_reads_z_(size) char *tokenValue, int startValue, int size, 
+MI_Boolean GetNextToken(_In_reads_z_(size) char *tokenValue, int startValue, int size,
                     _Inout_ int *currentTokenStart,
                     _Inout_ int *currentTokenEnd,
                     _Inout_ int *currentTokenStartValue,
@@ -1083,13 +1086,13 @@ MI_Boolean GetNextToken(_In_reads_z_(size) char *tokenValue, int startValue, int
         //TokenEnd
         *currentTokenEnd = EscapeString(tokenValue, *currentTokenStart, size);
         if (*currentTokenEnd == -1)
-            return MI_FALSE; 
-        
+            return MI_FALSE;
+
           break;
         }
         if( (*(start+xCount) == '\\') && (xCount+1 < size) && (*(start+xCount+1) == '"'))
         xCount++;
-    
+
         xCount++;
     }
     if( xCount >= size )
@@ -1102,9 +1105,9 @@ MI_Boolean GetNextToken(_In_reads_z_(size) char *tokenValue, int startValue, int
 
     if(!EscapeValue(tokenValue, xCount, size, currentTokenStartValue , currentTokenEndValue, nextTokenValue))
         return MI_FALSE;
-    
-    return MI_TRUE;    
-  
+
+    return MI_TRUE;
+
 }
 
 
@@ -1125,7 +1128,7 @@ MI_Boolean GetGetActionData( _In_reads_z_(size) char *start,
     char* ptr2_end = NULL;
     *serverAssignedConfigurations = (OverAllGetActionResponse *) DSC_malloc(sizeof(OverAllGetActionResponse), NitsHere());
     *serverResponse = NULL;
-    
+
     ptr1 = strstr(start, "NodeStatus\":");
     if (ptr1 == NULL)
     {
@@ -1143,7 +1146,7 @@ MI_Boolean GetGetActionData( _In_reads_z_(size) char *start,
     *serverResponse = (char*) DSC_malloc(ptr1_end - ptr1 + 1, NitsHere());
     memcpy(*serverResponse, ptr1, ptr1_end - ptr1);
     (*serverResponse)[ptr1_end - ptr1] = '\0';
-    
+
 
     if (ptr2 != NULL)
     {
@@ -1185,7 +1188,7 @@ MI_Boolean ValidateContentTypeHeader(_Inout_updates_z_(size)  MI_Char *buffer, M
                 return MI_TRUE;
             }
             return MI_FALSE;
-        }        
+        }
         if( (firstOccurancePointer - start >= size-1) ||  firstOccurancePointer < start)
         {
             return MI_FALSE;
@@ -1214,12 +1217,12 @@ MI_Char *GetSystemUuid()
     {
         File_Close(fp);
         return NULL;
-    }  
+    }
     // Caller will validate the contents.
     fread(systemUUid , 1, JOB_UUID_LENGTH, fp);
-            File_Close(fp);        
+            File_Close(fp);
     return systemUUid;
-        }      
+        }
 
 MI_Result SetGeneralCurlOptions(CURL* curl,
 				_Outptr_result_maybenull_ MI_Instance **extendedError)
@@ -1234,7 +1237,7 @@ MI_Result SetGeneralCurlOptions(CURL* curl,
         Setting operation timeout to 10 minutes.
     */
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, 600);
-    
+
     if (g_sslOptions.DoNotCheckCertificate == MI_TRUE)
     {
         curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
@@ -1263,9 +1266,9 @@ MI_Result SetGeneralCurlOptions(CURL* curl,
     }
 
     return MI_RESULT_OK;
-}  
+}
 
-MI_Result  IssueGetActionRequest( _In_z_ const MI_Char *configurationID, 
+MI_Result  IssueGetActionRequest( _In_z_ const MI_Char *configurationID,
                                   _In_z_ const MI_Char *certificateID,
                                   _In_z_ const MI_Char *checkSum,
                                   _In_ MI_Boolean complianceStatus,
@@ -1296,7 +1299,7 @@ MI_Result  IssueGetActionRequest( _In_z_ const MI_Char *configurationID,
 
     requestParam.serverOperation = OPERATION_GETACTION;
     if( checkSum != NULL)
-        checkSumFinalValue = checkSum;  
+        checkSumFinalValue = checkSum;
 
     *result = NULL;
 
@@ -1307,7 +1310,7 @@ MI_Result  IssueGetActionRequest( _In_z_ const MI_Char *configurationID,
     }
 
     DSC_EventWriteWebDownloadManagerDoActionServerUrl(configurationID, url);
-    
+
     // Get body for GetAction request
     bodyContent = GetGetActionBodyContent(checkSumFinalValue, complianceStatus, AllowedChecksumAlgorithm, lastGetActionStatusCode);
 
@@ -1315,7 +1318,7 @@ MI_Result  IssueGetActionRequest( _In_z_ const MI_Char *configurationID,
     {
         *getActionStatusCode = DownloadManagerInitializationFailure;
         return GetCimMIError(r, extendedError, ID_ENGINEHELPER_MEMORY_ERROR);
-    }    
+    }
 
     curl = curl_easy_init();
     if (!curl)
@@ -1340,7 +1343,7 @@ MI_Result  IssueGetActionRequest( _In_z_ const MI_Char *configurationID,
 	curl_easy_cleanup(curl);
 	return r;
     }
-    
+
     curl_easy_setopt(curl, CURLOPT_URL, actionUrl);
 
     headerChunk.data = (char *)malloc(1);
@@ -1368,7 +1371,7 @@ MI_Result  IssueGetActionRequest( _In_z_ const MI_Char *configurationID,
         return GetCimMIError(MI_RESULT_FAILED, extendedError, ID_PULL_CERTOPTS_NOT_SUPPORTED);
     }
     res = curl_easy_setopt(curl, CURLOPT_SSLKEY, OAAS_KEYPATH);
-    
+
     if (g_sslOptions.cipherList[0] != '\0')
     {
         res = curl_easy_setopt(curl, CURLOPT_SSL_CIPHER_LIST, g_sslOptions.cipherList);
@@ -1419,19 +1422,19 @@ MI_Result  IssueGetActionRequest( _In_z_ const MI_Char *configurationID,
         *getActionStatusCode = GetDscActionCommandFailure;
         free(headerChunk.data);
         free(dataChunk.data);
-        return GetCimMIError1Param(r, extendedError, ID_PULL_GETACTIONFAILED, webPulginName); 
-    }    
+        return GetCimMIError1Param(r, extendedError, ID_PULL_GETACTIONFAILED, webPulginName);
+    }
 
     GetGetActionData(dataChunk.data, dataChunk.size, &getActionStatus, serverAssignedConfigurations);
-    
+
     free(headerChunk.data);
     free(dataChunk.data);
 
     if( getActionStatus == NULL)
     {
         *getActionStatusCode = GetDscActionCommandFailure;
-        return GetCimMIError1Param(MI_RESULT_FAILED, extendedError, ID_PULL_GETACTIONFAILED, webPulginName);         
-    }    
+        return GetCimMIError1Param(MI_RESULT_FAILED, extendedError, ID_PULL_GETACTIONFAILED, webPulginName);
+    }
     if (! (Strcasecmp( getActionStatus, GetActionResultOk) == 0 ||
         Strcasecmp( getActionStatus, GetActionResultGetConfiguration) == 0 ) )
     {
@@ -1443,15 +1446,15 @@ MI_Result  IssueGetActionRequest( _In_z_ const MI_Char *configurationID,
     }
 
     *result = getActionStatus;
-    *getActionStatusCode = Success;       
+    *getActionStatusCode = Success;
     DSC_EventWriteWebDownloadManagerDoActionGetCall(configurationID, requestParam.u.action.getActionStatus);
-    
+
     return MI_RESULT_OK;
 }
 
 MI_Result  IssueGetConfigurationRequest( _In_z_ const MI_Char *configurationID,
                                          _In_z_ const MI_Char *certificateID,
-                                         _In_z_ const MI_Char *directoryPath, 
+                                         _In_z_ const MI_Char *directoryPath,
                                          _Outptr_result_maybenull_z_  MI_Char** result,
                                          _Out_ MI_Uint32* getActionStatusCode,
                                          _In_reads_z_(URL_SIZE) const MI_Char *url,
@@ -1482,8 +1485,8 @@ MI_Result  IssueGetConfigurationRequest( _In_z_ const MI_Char *configurationID,
     {
         *getActionStatusCode = GetConfigurationCommandFailure;
         return GetCimMIError(r, extendedError, ID_ENGINEHELPER_MEMORY_ERROR);
-    }    
-    DSC_EventWriteGetDscDocumentWebDownloadManagerServerUrl(configurationID, url);    
+    }
+    DSC_EventWriteGetDscDocumentWebDownloadManagerServerUrl(configurationID, url);
     Stprintf(outputResult,3, MI_T("OK"));
 
     curl = curl_easy_init();
@@ -1507,7 +1510,7 @@ MI_Result  IssueGetConfigurationRequest( _In_z_ const MI_Char *configurationID,
         curl_easy_cleanup(curl);
         return r;
     }
-    
+
     curl_easy_setopt(curl, CURLOPT_URL, configurationUrl);
 
     InitHeaderChunk(&headerChunk);
@@ -1533,7 +1536,7 @@ MI_Result  IssueGetConfigurationRequest( _In_z_ const MI_Char *configurationID,
     }
     curl_easy_setopt(curl, CURLOPT_SSLKEY, OAAS_KEYPATH);
 
-    
+
     if (g_sslOptions.cipherList[0] != '\0')
     {
         res = curl_easy_setopt(curl, CURLOPT_SSL_CIPHER_LIST, g_sslOptions.cipherList);
@@ -1573,7 +1576,7 @@ MI_Result  IssueGetConfigurationRequest( _In_z_ const MI_Char *configurationID,
         curl_easy_cleanup(curl);
 
         return GetCimMIError2Params(MI_RESULT_FAILED, extendedError, ID_PULL_CURLPERFORMFAILED, url, curl_easy_strerror(res));
-    }      
+    }
 
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &responseCode);
     curl_easy_cleanup(curl);
@@ -1597,7 +1600,7 @@ MI_Result  IssueGetConfigurationRequest( _In_z_ const MI_Char *configurationID,
         {
             break;
         }
-        
+
         if ( Tcscasecmp(headerChunk.headerKeys[i], "Checksum") == 0 )
         {
             checksumResponse = headerChunk.headerValues[i];
@@ -1612,7 +1615,7 @@ MI_Result  IssueGetConfigurationRequest( _In_z_ const MI_Char *configurationID,
         *getActionStatusCode = InvalidChecksumAlgorithm;
         return GetCimMIError(MI_RESULT_FAILED, extendedError, ID_PULL_INVALIDRESPONSEFROMSERVER);
     }
-    
+
     if( Tcscasecmp(checksumAlgorithmResponse, AllowedChecksumAlgorithm) != 0 )
     {
         *getActionStatusCode = InvalidChecksumAlgorithm;
@@ -1625,22 +1628,22 @@ MI_Result  IssueGetConfigurationRequest( _In_z_ const MI_Char *configurationID,
         if(fp == NULL)
         {
             *getActionStatusCode = GetConfigurationCommandFailure;
-            return GetCimMIError1Param(MI_RESULT_FAILED, extendedError, 
+            return GetCimMIError1Param(MI_RESULT_FAILED, extendedError,
                                        ID_PULL_CONFIGURATIONSAVEFAILED, directoryPath);
         }
         fwrite( dataChunk.data, 1, dataChunk.size, fp);
         File_Close(fp);
     }
-    
+
     if( !ValidateChecksum(checksumResponse, directoryPath) )
     {
         DSC_EventWriteWebDownloadManagerGetDocChecksumValidation(NULL, NULL);
         *getActionStatusCode = ConfigurationChecksumValidationFailure;
         return GetCimMIError(MI_RESULT_FAILED, extendedError, ID_PULL_CHECKSUMMISMATCH);
     }
-    
+
     DSC_EventWriteLCMPullConfigurationChecksumValidationResult(configurationID, (MI_Uint32)MI_RESULT_OK);
-    
+
     //Create checksumFile
     {
         MI_Char checksumFileName[MAX_URL_LENGTH];
@@ -1656,7 +1659,7 @@ MI_Result  IssueGetConfigurationRequest( _In_z_ const MI_Char *configurationID,
         {
             *getActionStatusCode = GetConfigurationCommandFailure;
             DSC_free(outputResult);
-            return GetCimMIError1Param(MI_RESULT_FAILED, extendedError, ID_PULLGETCONFIGURATION_CHECKSUMSAVEFAILED, checksumFileName);            
+            return GetCimMIError1Param(MI_RESULT_FAILED, extendedError, ID_PULLGETCONFIGURATION_CHECKSUMSAVEFAILED, checksumFileName);
         }
     }
 
@@ -1669,10 +1672,10 @@ MI_Result  IssueGetConfigurationRequest( _In_z_ const MI_Char *configurationID,
     return MI_RESULT_OK;
 }
 
-MI_Result GetUrlParam(_In_ MI_InstanceA *customData, 
-    _Inout_updates_(URL_SIZE) MI_Char *url, 
-    _Inout_updates_(SUBURL_SIZE) MI_Char *subUrl, 
-    _Out_ MI_Uint32 *port, 
+MI_Result GetUrlParam(_In_ MI_InstanceA *customData,
+    _Inout_updates_(URL_SIZE) MI_Char *url,
+    _Inout_updates_(SUBURL_SIZE) MI_Char *subUrl,
+    _Out_ MI_Uint32 *port,
     _Out_ MI_Boolean *bIsHttps,
     _Out_ MI_Uint32* getActionStatusCode,
     _Outptr_result_maybenull_ MI_Instance **extendedError)
@@ -1700,16 +1703,16 @@ MI_Result GetUrlParam(_In_ MI_InstanceA *customData,
                 {
                     *getActionStatusCode = InvalidDownloadManagerCustomDataInMetaConfig;
                     r = GetCimMIError1Param( MI_RESULT_INVALID_PARAMETER, extendedError, ID_PULL_UNSECURECONNECTIONNOTALLOWED, value.string);
-                    return r;   
+                    return r;
                 }
-                
-                if( sscanf(value.string, MI_T("http://%99[^:]:%d/%199[^\n]"), url, port, subUrl) == 3 || 
+
+                if( sscanf(value.string, MI_T("http://%99[^:]:%d/%199[^\n]"), url, port, subUrl) == 3 ||
                     sscanf(value.string, MI_T("http://%99[^/]/%199[^\n]"), url, subUrl) == 2 )
                 {
                     //success
                 }
                 //format is: http://server:port/suburl or http://server/suburl
-                else if( sscanf(value.string, MI_T("https://%99[^:]:%d/%199[^\n]"), url, port, subUrl) == 3 || 
+                else if( sscanf(value.string, MI_T("https://%99[^:]:%d/%199[^\n]"), url, port, subUrl) == 3 ||
                     sscanf(value.string, MI_T("https://%99[^/]/%199[^\n]"), url, subUrl) == 2 )
                 {
                     //success
@@ -1723,12 +1726,12 @@ MI_Result GetUrlParam(_In_ MI_InstanceA *customData,
     if(  xCount >= customData->size ) // Not found
     {
         *getActionStatusCode = InvalidDownloadManagerCustomDataInMetaConfig;
-        return GetCimMIError(r, extendedError, ID_ENGINEHELPER_MEMORY_ERROR);   
+        return GetCimMIError(r, extendedError, ID_ENGINEHELPER_MEMORY_ERROR);
     }
     return MI_RESULT_OK;
 }
 
-MI_Result GetRequestParam(_In_ MI_Instance *metaConfig, 
+MI_Result GetRequestParam(_In_ MI_Instance *metaConfig,
                           _In_ MI_Char * partialConfigName,
                           _Inout_updates_(URL_SIZE) MI_Char *url,
                           _Inout_updates_(SUBURL_SIZE) MI_Char *subUrl,
@@ -1753,9 +1756,9 @@ MI_Result CreateTmpDirectoryPath(_Outptr_result_maybenull_z_  MI_Char** director
     MI_Char *path;
    if( TempnamT(&path) )
        return MI_RESULT_FAILED;
-   
+
    if( path != NULL)
-   { 
+   {
        int result = MkdirT(path, S_IRWXU);
        if( result == 0 )
        {
@@ -1776,7 +1779,7 @@ MI_Result CreateTmpDirectoryPath(_Outptr_result_maybenull_z_  MI_Char** director
    return MI_RESULT_FAILED;
 }
 
-MI_Result  IssueGetModuleRequest( _In_z_ const MI_Char *configurationID, 
+MI_Result  IssueGetModuleRequest( _In_z_ const MI_Char *configurationID,
                                   _In_z_ const MI_Char *moduleName,
                                   _In_z_ const MI_Char *moduleVersion,
                                   _In_z_ const MI_Char *certificateID,
@@ -1812,7 +1815,7 @@ MI_Result  IssueGetModuleRequest( _In_z_ const MI_Char *configurationID,
     }
     DSC_EventWriteGetDscDocumentWebDownloadManagerServerUrl(configurationID, url);
     Stprintf(outputResult,3, MI_T("OK"));
-    
+
     curl = curl_easy_init();
     if (!curl)
     {
@@ -1836,11 +1839,11 @@ MI_Result  IssueGetModuleRequest( _In_z_ const MI_Char *configurationID,
 	curl_easy_cleanup(curl);
 	return r;
     }
-        
+
     InitHeaderChunk(&headerChunk);
     dataChunk.data = (char *)malloc(1);
     dataChunk.size = 0;
-    
+
     curl_easy_setopt(curl, CURLOPT_URL, configurationUrl);
 
     list = curl_slist_append(list, "ProtocolVersion: 2.0");
@@ -1937,18 +1940,18 @@ MI_Result  IssueGetModuleRequest( _In_z_ const MI_Char *configurationID,
     }
 
     if( Tcscasecmp(checksumAlgorithmResponse, AllowedChecksumAlgorithm) != 0 )
-    {      
+    {
         *getActionStatusCode = InvalidChecksumAlgorithm;
         return GetCimMIError(MI_RESULT_FAILED, extendedError, ID_PULL_INVALIDCHECKSUMALGORITHM);
     }
-    
+
     if( dataChunk.size > 0 )
     {
         FILE *fp = File_OpenT(filePath, MI_T("a"));
         if(fp == NULL)
         {
             *getActionStatusCode = GetConfigurationCommandFailure;
-            return GetCimMIError1Param(MI_RESULT_FAILED, extendedError, 
+            return GetCimMIError1Param(MI_RESULT_FAILED, extendedError,
                                        ID_PULL_CONFIGURATIONSAVEFAILED, filePath);
         }
         fwrite( dataChunk.data, 1, dataChunk.size, fp);
@@ -1963,9 +1966,9 @@ MI_Result  IssueGetModuleRequest( _In_z_ const MI_Char *configurationID,
     }
 
 
-    
+
     DSC_EventWriteLCMPullConfigurationChecksumValidationResult(configurationID, (MI_Uint32)MI_RESULT_OK);
-  
+
     //Create checksumFile
     {
         MI_Char checksumFileName[MAX_URL_LENGTH];
@@ -1981,7 +1984,7 @@ MI_Result  IssueGetModuleRequest( _In_z_ const MI_Char *configurationID,
         {
             *getActionStatusCode = GetConfigurationCommandFailure;
             DSC_free(outputResult);
-            return GetCimMIError1Param(MI_RESULT_FAILED, extendedError, ID_PULLGETCONFIGURATION_CHECKSUMSAVEFAILED, checksumFileName);            
+            return GetCimMIError1Param(MI_RESULT_FAILED, extendedError, ID_PULLGETCONFIGURATION_CHECKSUMSAVEFAILED, checksumFileName);
         }
     }
 
@@ -1995,11 +1998,11 @@ MI_Result  IssueGetModuleRequest( _In_z_ const MI_Char *configurationID,
 }
 
 MI_Result MI_CALL Pull_GetModules(_Out_ MI_Uint32 * numModulesInstalled,
-                                  const MI_Char *configurationID, 
+                                  const MI_Char *configurationID,
                                   const MI_Char *certificateID,
                                   MI_Char* directoryPath,
                                   MI_Char* fileName,
-                                  MI_Char** result,                               
+                                  MI_Char** result,
                                   MI_Uint32* getActionStatusCode,
                                   MI_Boolean bAllowedModuleOverride,
                                   _In_reads_z_(URL_SIZE) const MI_Char *url,
@@ -2050,8 +2053,8 @@ MI_Result MI_CALL Pull_GetModules(_Out_ MI_Uint32 * numModulesInstalled,
     while (current != NULL)
     {
         Snprintf(zipPath, MAX_URL_LENGTH, "%s/%s_%s.zip", directoryPath, current->moduleName, current->moduleVersionClassTuple->moduleVersion);
-        r = IssueGetModuleRequest(configurationID, 
-                                  current->moduleName, 
+        r = IssueGetModuleRequest(configurationID,
+                                  current->moduleName,
                                   current->moduleVersionClassTuple->moduleVersion,
                                   certificateID,
                                   zipPath,
@@ -2068,12 +2071,45 @@ MI_Result MI_CALL Pull_GetModules(_Out_ MI_Uint32 * numModulesInstalled,
             CleanupModuleTable(moduleTable);
             return r;
         }
+        // Determine python version
+        char data[BUFSIZ];
+        int isPython2 = 1;
+        DSC_LOG_INFO("Assuming python2 in WebPullClient\n");
 
-        Snprintf(stringBuffer, MAX_URL_LENGTH, "%s %s %s", DSC_SCRIPT_PATH "/InstallModule.py", zipPath, verifyFlag);
+	// Look for python2
+        FILE * pipe = popen("python2 --version 2>&1", "r");
+        fgets(data, BUFSIZ, pipe);
+	if (!strstr(data, "not found"))
+	{
+		DSC_LOG_INFO("Found python2 in WebPullClient.\n");
+          	isPython2 = 1;
+      	}
+	else
+	{
+		// If python2 does not exist, look for python3
+		memset(&data[0], 0, sizeof(data));
+        	pipe = popen("python3 --version 2>&1", "r");
+        	fgets(data, BUFSIZ, pipe);
+		if (!strstr(data, "not found")) {
+			DSC_LOG_INFO("Found python3 in WebPullClient.\n");
+          		isPython2 = 0;
+      		}
+	}
+
+      	if (isPython2 == 1)
+      	{
+        	DSC_LOG_INFO("Calling InstallModule with python2");
+      		Snprintf(stringBuffer, MAX_URL_LENGTH, "%s %s %s", DSC_SCRIPT_PATH "/InstallModule.py", zipPath, verifyFlag);
+      	}
+      	else
+      	{
+		DSC_LOG_INFO("Calling InstallModule with python3");
+		Snprintf(stringBuffer, MAX_URL_LENGTH, "%s %s %s %s", "/usr/bin/python3 " DSC_SCRIPT_PATH "/python3/InstallModule.py", zipPath, verifyFlag, " 2>&1");
+      	}
         DSC_LOG_INFO("executing '%T'\n", stringBuffer);
         retval = system(stringBuffer);
         DSC_LOG_INFO("Executed '%T', returned %d\n", stringBuffer, retval);
-        
+
         if (retval != 0)
         {
             if (retval == -1 && errno == ECHILD)
@@ -2083,8 +2119,18 @@ MI_Result MI_CALL Pull_GetModules(_Out_ MI_Uint32 * numModulesInstalled,
             else
             {
                 // Attempt to remove the module as a last resort.  If it fails too, a reinstall may be necessary.
-                Snprintf(stringBuffer, MAX_URL_LENGTH, "%s %s", DSC_SCRIPT_PATH "/RemoveModule.py", current->moduleName);
-                retval = system(stringBuffer); 
+                if (isPython2 == 1)
+                {
+                    DSC_LOG_INFO("Calling RemoveModule with python2");
+                    Snprintf(stringBuffer, MAX_URL_LENGTH, "%s %s", DSC_SCRIPT_PATH "/RemoveModule.py", current->moduleName);
+                }
+                else
+                {
+                    DSC_LOG_INFO("Calling RemoveModule with python3");
+                    Snprintf(stringBuffer, MAX_URL_LENGTH, "%s %s %s", "/usr/bin/python3 " DSC_SCRIPT_PATH "/python3/RemoveModule.py", current->moduleName, " 2>&1");
+                }
+
+                retval = system(stringBuffer);
                 DSC_LOG_INFO("Executed '%T', returned %d\n", stringBuffer, retval);
                 if ( retval == 0 || (retval == -1 && errno == ECHILD) )
                 {
@@ -2152,7 +2198,7 @@ MI_Result MI_CALL Pull_GetConfigurationWebDownloadManager(_In_ LCMProviderContex
         *getActionStatusCode = InvalidDownloadManagerCustomDataInMetaConfig;
         r = GetCimMIError( MI_RESULT_INVALID_PARAMETER, extendedError, ID_PULL_INVALIDURLINCUSTOMDATA);
         return r;
-    }    
+    }
     r = CreateTmpDirectoryPath(directoryName, &fileName);
     if( r != MI_RESULT_OK)
     {
@@ -2166,19 +2212,19 @@ MI_Result MI_CALL Pull_GetConfigurationWebDownloadManager(_In_ LCMProviderContex
     if( r != MI_RESULT_OK)
     {
         DSC_free(configurationID);
-        DSC_free(fileName);  
+        DSC_free(fileName);
         return r;
     }
 
-    DSC_EventWriteLCMPullGetConfigAttempt( webPulginName, configurationID);    
+    DSC_EventWriteLCMPullGetConfigAttempt( webPulginName, configurationID);
     // Issue Get Action Request
-    r = IssueGetConfigurationRequest( configurationID,  certificateID, fileName, result, 
+    r = IssueGetConfigurationRequest( configurationID,  certificateID, fileName, result,
                                       getActionStatusCode, url, port, subUrl, bIsHttps, assignedConfiguration, extendedError);
-      
+
     if( r != MI_RESULT_OK)
     {
         DSC_free(configurationID);
-        DSC_free(fileName);  
+        DSC_free(fileName);
         return r;
     }
 
@@ -2198,12 +2244,12 @@ MI_Result MI_CALL Pull_GetConfigurationWebDownloadManager(_In_ LCMProviderContex
 
     DSC_free(configurationID);
     *mofFileName = fileName;
-    DSC_EventWriteLCMPullGetConfigSuccess(webPulginName);    
+    DSC_EventWriteLCMPullGetConfigSuccess(webPulginName);
     return MI_RESULT_OK;
 }
 
 
-                                 
+
 MI_Result MI_CALL Pull_GetActionWebDownloadManager(_In_ LCMProviderContext *lcmContext,
                                                    _In_ MI_Instance *metaConfig,
                                                    _In_opt_z_ MI_Char *partialConfigName,
@@ -2223,7 +2269,7 @@ MI_Result MI_CALL Pull_GetActionWebDownloadManager(_In_ LCMProviderContext *lcmC
     MI_Uint32 port = DEFAULT_SERVERPORT;
     MI_Boolean bIsHttps = MI_FALSE;
     MI_Char *tmpChecksum = NULL;
-    
+
     if( metaConfig == NULL)
     {
         return MI_RESULT_INVALID_PARAMETER;
@@ -2250,7 +2296,7 @@ MI_Result MI_CALL Pull_GetActionWebDownloadManager(_In_ LCMProviderContext *lcmC
         r = GetCimMIError( MI_RESULT_INVALID_PARAMETER, extendedError, ID_PULL_INVALIDURLINCUSTOMDATA);
         DSC_free(tmpChecksum);
         return r;
-    }    
+    }
 
     // Get our supported SSL options if there are any
     r = GetSSLOptions(extendedError);
@@ -2261,7 +2307,7 @@ MI_Result MI_CALL Pull_GetActionWebDownloadManager(_In_ LCMProviderContext *lcmC
         return r;
     }
 
-    DSC_EventWriteLCMPullGetActionAttempt( webPulginName, configurationID, tmpChecksum, complianceStatus);    
+    DSC_EventWriteLCMPullGetActionAttempt( webPulginName, configurationID, tmpChecksum, complianceStatus);
     // Issue Get Action Request
     r = IssueGetActionRequest( configurationID, certificateID, tmpChecksum, complianceStatus, lastGetActionStatusCode, result, getActionStatusCode, url, port, subUrl, bIsHttps, serverAssignedConfigurations, extendedError);
 
@@ -2270,9 +2316,9 @@ MI_Result MI_CALL Pull_GetActionWebDownloadManager(_In_ LCMProviderContext *lcmC
     if( r != MI_RESULT_OK)
     {
         return r;
-    }     
-    DSC_EventWriteLCMPullGetActionSuccess(*result, webPulginName);    
-    
+    }
+    DSC_EventWriteLCMPullGetActionSuccess(*result, webPulginName);
+
     return MI_RESULT_OK;
 }
 
@@ -2326,7 +2372,7 @@ static int IsModuleInstalled(MI_Char* moduleName, MI_Char* moduleVersion)
     FILE * fp = NULL;
 
     Snprintf(buffer, MAX_URL_LENGTH, DSC_MODULES_PATH "/%s/VERSION", moduleName);
-    
+
     fp = File_OpenT(buffer, MI_T("r"));
     if( fp == NULL )
     {
@@ -2349,12 +2395,12 @@ static int IsModuleInstalled(MI_Char* moduleName, MI_Char* moduleVersion)
         // Invalid version size.  It shouldn't be this long!
         return 0;
     }
-    
+
     // Since we're going to be tokenizing moduleVersion, we should make a copy of it.
     tmpLength = Tcslen(moduleVersion) + 1;
     memcpy(buffer2, moduleVersion, tmpLength);
 
-    // If the installed version (buffer) is less than the parsed moduleVersion, we need the latest version.    
+    // If the installed version (buffer) is less than the parsed moduleVersion, we need the latest version.
     if (CompareVersions(buffer, buffer2) < 0)
     {
         return 0;
@@ -2390,7 +2436,7 @@ static MI_Result FilterUsingCachedModules(ModuleTable* table)
     return MI_RESULT_OK;
 }
 
-static MI_Result GetModuleNameVersionTable(MI_Char* mofFileLocation, 
+static MI_Result GetModuleNameVersionTable(MI_Char* mofFileLocation,
                                            ModuleTable* table,
                                            _Outptr_result_maybenull_ MI_Instance **extendedError)
 {
@@ -2410,17 +2456,17 @@ static MI_Result GetModuleNameVersionTable(MI_Char* mofFileLocation,
     ModuleTableEntry* current;
     ModuleTableEntry** foundEntry;
     ModuleClassList** foundClassEntry;
-    
+
     miApp = (MI_Application *) DSC_malloc( sizeof(MI_Application), NitsHere());
     memset(miApp,  0, sizeof(MI_Application));
-    r = DSC_MI_Application_Initialize(0, NULL, NULL, miApp);   
+    r = DSC_MI_Application_Initialize(0, NULL, NULL, miApp);
     if( r != MI_RESULT_OK)
     {
         DSC_free(miApp);
         return GetCimMIError1Param(MI_RESULT_FAILED, extendedError, ID_PULL_INITIALIZEMODULETABLEFAILED, "App Init failed");
-    }      
-    
-    memset(&deserializer, 0, sizeof(MI_Deserializer));    
+    }
+
+    memset(&deserializer, 0, sizeof(MI_Deserializer));
     memset(&options, 0, sizeof(MI_OperationOptions));
 
     r = DSC_MI_Application_NewOperationOptions(miApp, MI_FALSE, &options);
@@ -2453,7 +2499,7 @@ static MI_Result GetModuleNameVersionTable(MI_Char* mofFileLocation,
         MI_Application_Close(miApp);
         DSC_free(miApp);
         return r;
-    }   
+    }
     miClassArray.size = 0;
     miClassArray.data = NULL;
 
@@ -2491,7 +2537,7 @@ static MI_Result GetModuleNameVersionTable(MI_Char* mofFileLocation,
 
             if ( IsModuleVersionValidFormat(moduleVersion.string) == 1 )
             {
-                
+
                 // foundEntry will be a pointer to the "next" or "first" pointer that points to the ModuleTableEntry we want
                 foundEntry = ModuleTableContainsKey(table, moduleName.string);
                 if ( *foundEntry != NULL )
@@ -2534,7 +2580,7 @@ static MI_Result GetModuleNameVersionTable(MI_Char* mofFileLocation,
 
                     current->moduleVersionClassTuple->first = (ModuleClassList*) DSC_malloc(sizeof(ModuleClassList), NitsHere());
                     current->moduleVersionClassTuple->first->next = NULL;
-                    
+
                     // Copy class name
                     tmpLength = Tcslen(miInstanceArray->data[i]->classDecl->name) + 1;
                     current->moduleVersionClassTuple->first->moduleClass = (MI_Char*)DSC_malloc(sizeof(MI_Char) * tmpLength, NitsHere());
@@ -2576,7 +2622,7 @@ size_t read_callback(char *buffer, size_t size, size_t nitems, void *instream)
     {
         return 0;
     }
-    
+
     len = strlen(&readChunk->data[readChunk->last_char]);
 
     if (len <= (size * nitems))
@@ -2618,23 +2664,23 @@ MI_Result Pull_Register(MI_Char* serverURL,
     {
         return r;
     }
-    
+
     curl = curl_easy_init();
     if (!curl)
     {
         return GetCimMIError(MI_RESULT_FAILED, extendedError, ID_PULL_CURLFAILEDTOINITIALIZE);
     }
-    
+
     Snprintf(actionUrl, MAX_URL_LENGTH, "%s/Nodes(AgentId='%s')", serverURL, agentId);
     curl_easy_setopt(curl, CURLOPT_URL, actionUrl);
-    
+
     headerChunk.data = (char *)malloc(1);
     headerChunk.size = 0;
     dataChunk.data = (char *)malloc(1);
     dataChunk.size = 0;
     readChunk.data = requestBody;
     readChunk.last_char = 0;
-    
+
     list = curl_slist_append(list, x_ms_header);
     list = curl_slist_append(list, auth_header);
     list = curl_slist_append(list, "Accept: application/json");
@@ -2720,14 +2766,14 @@ MI_Result Pull_Register(MI_Char* serverURL,
 
 extern MI_Char* RunCommand(const MI_Char* command);
 
-MI_Result MI_CALL Pull_SendStatusReport(_In_ LCMProviderContext *lcmContext, 
+MI_Result MI_CALL Pull_SendStatusReport(_In_ LCMProviderContext *lcmContext,
                                                       _In_ MI_Instance *metaConfig,
                                                       _In_ MI_Instance *statusReport,
                                                       _In_ MI_Uint32 isStatusReport,
                                                       _Out_ MI_Uint32* getActionStatusCode,
                                                       _Outptr_result_maybenull_ MI_Instance **extendedError)
 {
-    
+
     MI_Result r = MI_RESULT_OK;
     const char *emptyString = "";
     MI_Char actionUrl[MAX_URL_LENGTH];
@@ -2735,7 +2781,7 @@ MI_Result MI_CALL Pull_SendStatusReport(_In_ LCMProviderContext *lcmContext,
 
     char * getActionStatus = NULL;
     long responseCode = 0;
-    
+
     CURL *curl = NULL;
     CURLcode res = CURLE_OK;
     struct Chunk headerChunk;
@@ -2805,13 +2851,13 @@ MI_Result MI_CALL Pull_SendStatusReport(_In_ LCMProviderContext *lcmContext,
                              g_rnids->ModuleVersion, g_rnids->RebootRequested, g_rnids->ResourceId, g_rnids->ConfigurationName, g_rnids->InDesiredState);
                     Destroy_StatusReport_RNIDS(g_rnids);
                     g_rnids = NULL;
-                    
+
                 }
             }
         }
 
         reportText = RunCommand(dataBuffer);
-        
+
         curl = curl_easy_init();
         if (!curl)
         {
@@ -2828,12 +2874,12 @@ MI_Result MI_CALL Pull_SendStatusReport(_In_ LCMProviderContext *lcmContext,
 
         Snprintf(actionUrl, MAX_URL_LENGTH, "%s/Nodes(AgentId='%s')/SendReport", serverURL.string, agentId.string);
         curl_easy_setopt(curl, CURLOPT_URL, actionUrl);
-        
+
         headerChunk.data = (char *)malloc(1);
         headerChunk.size = 0;
         dataChunk.data = (char *)malloc(1);
         dataChunk.size = 0;
-        
+
         curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
         curl_easy_setopt(curl, CURLOPT_HTTPHEADER, list);
         curl_easy_setopt(curl, CURLOPT_POSTFIELDS, reportText);
@@ -2849,7 +2895,7 @@ MI_Result MI_CALL Pull_SendStatusReport(_In_ LCMProviderContext *lcmContext,
             return GetCimMIError(MI_RESULT_FAILED, extendedError, ID_PULL_CERTOPTS_NOT_SUPPORTED);
         }
         curl_easy_setopt(curl, CURLOPT_SSLKEY, OAAS_KEYPATH);
-        
+
         res = curl_easy_perform(curl);
 
         if (res != CURLE_OK)
@@ -2863,9 +2909,9 @@ MI_Result MI_CALL Pull_SendStatusReport(_In_ LCMProviderContext *lcmContext,
             free(dataChunk.data);
             continue;
         }
-        
+
         curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &responseCode);
-        
+
         if (responseCode != 200 && responseCode != 201 && responseCode != 204)
         {
             // Error on register
@@ -2883,11 +2929,11 @@ MI_Result MI_CALL Pull_SendStatusReport(_In_ LCMProviderContext *lcmContext,
         bAtLeastOneReportSuccess = 1;
 
         curl_easy_cleanup(curl);
-        
+
         DSC_free(reportText);
         free(headerChunk.data);
         free(dataChunk.data);
-        
+
     }
 
     curl_slist_free_all(list);

--- a/LCM/scripts/calcPythonPath.sh
+++ b/LCM/scripts/calcPythonPath.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+if [ "$#" -ne 0 ]
+then
+	# Checking which python version is available 
+	# python3
+	if [[ -z $(python2 --version 2>&1 | grep 'not found') ]]
+	then
+		#echo "python exists"; 
+		pythonVer="python2"
+	elif [[ -z $(python3 --version 2>&1 | grep 'not found') ]]
+	then
+		#echo "python3 exists"; 
+		pythonVer="python3"
+	else 
+		echo "You do not have python on this machine"
+		exit 1
+	fi
+
+	# Detemine file location
+	echo "You provided the following argument(s): $@"
+	if [ "$pythonVer" == "python2" ] 
+	then
+		filePath="/opt/microsoft/omsconfig/Scripts/"
+	else
+		filePath="/opt/microsoft/omsconfig/Scripts/python3/"
+	fi
+
+	# Construct command from arguments
+	for args in "$@"; do
+		filePath+=$args
+		filePath+=" "
+	done
+	echo "The path provided is: "
+	echo $(ls $filePath)
+	
+	# Construct command
+	echo "sudo su omsagent -c '$pythonVer $filePath'"
+	sudo su omsagent -c "$pythonVer $filePath"
+else
+	echo "No parameters were passed."
+fi
+

--- a/LCM/scripts/python3/GetDscConfiguration.py
+++ b/LCM/scripts/python3/GetDscConfiguration.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+import fileinput
+import sys
+import subprocess
+import json
+import time
+import datetime
+import os
+import os.path
+from OmsConfigHostHelpers import write_omsconfig_host_telemetry, write_omsconfig_host_switch_event, write_omsconfig_host_log, stop_old_host_instances
+from imp                import load_source
+from os.path            import dirname, isfile, join, realpath
+from fcntl              import flock, LOCK_EX, LOCK_UN, LOCK_NB
+
+pathToCurrentScript = realpath(__file__)
+pathToCommonScriptsFolder = dirname(pathToCurrentScript)
+
+helperLibPath = join(pathToCommonScriptsFolder, 'helperlib.py')
+helperlib = load_source('helperlib', helperLibPath)
+
+omi_bindir = "<CONFIG_BINDIR>"
+omicli_path = omi_bindir + "/omicli"
+dsc_host_base_path = helperlib.DSC_HOST_BASE_PATH
+dsc_host_path = join(dsc_host_base_path, 'bin/dsc_host')
+dsc_host_output_path = join(dsc_host_base_path, 'output')
+dsc_host_lock_path = join(dsc_host_base_path, 'dsc_host_lock')
+dsc_host_switch_path = join(dsc_host_base_path, 'dsc_host_ready')
+
+if ("omsconfig" in helperlib.DSC_SCRIPT_PATH):
+    write_omsconfig_host_switch_event(pathToCurrentScript, isfile(dsc_host_switch_path))
+
+if ("omsconfig" in helperlib.DSC_SCRIPT_PATH) and (isfile(dsc_host_switch_path)):
+    use_omsconfig_host = True
+else:
+    use_omsconfig_host = False
+
+parameters = []
+
+if use_omsconfig_host:
+    parameters.append(dsc_host_path)
+    parameters.append(dsc_host_output_path)
+    parameters.append("GetConfiguration")
+else:
+    parameters.append(omicli_path)
+    parameters.append("iv")
+    parameters.append("<DSC_NAMESPACE>")
+    parameters.append("{")
+    parameters.append("MSFT_DSCLocalConfigurationManager")
+    parameters.append("}")
+    parameters.append("GetConfiguration")
+
+stdout = ''
+stderr = ''
+
+if use_omsconfig_host:
+    try:
+        dschostlock_filehandle = None
+        stop_old_host_instances(dsc_host_lock_path)
+
+        # Open the dsc host lock file. This also creates a file if it does not exist
+        dschostlock_filehandle = open(dsc_host_lock_path, 'w')
+        print("Opened the dsc host lock file at the path '" + dsc_host_lock_path + "'")
+        
+        dschostlock_acquired = False
+
+        # Acquire dsc host file lock
+        for retry in range(10):
+            try:
+                flock(dschostlock_filehandle, LOCK_EX | LOCK_NB)
+                dschostlock_acquired = True
+                break
+            except IOError:
+                write_omsconfig_host_log('dsc_host lock file not acquired. retry (#' + str(retry) + ') after 60 seconds...', pathToCurrentScript)
+                sleep(60)
+
+        if dschostlock_acquired:
+            p = subprocess.Popen(parameters, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            stdout, stderr = p.communicate()
+            stdout = stdout.decode() if isinstance(stdout, bytes) else stdout
+            print(stdout)
+        else:
+            print("dsc host lock already acuired by a different process")
+    finally:
+        if (dschostlock_filehandle):
+            # Release dsc host file lock
+            flock(dschostlock_filehandle, LOCK_UN)
+
+            # Close dsc host lock file handle
+            dschostlock_filehandle.close()
+else:
+    p = subprocess.Popen(parameters, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = p.communicate()
+
+
+stdout = stdout.decode() if isinstance(stdout, bytes) else stdout
+stderr = stderr.decode() if isinstance(stderr, bytes) else stderr
+print(stdout)
+print(stderr)
+
+

--- a/LCM/scripts/python3/GetDscLocalConfigurationManager.py
+++ b/LCM/scripts/python3/GetDscLocalConfigurationManager.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+import fileinput
+import sys
+import subprocess
+import json
+import time
+import datetime
+import os
+import os.path
+from OmsConfigHostHelpers import write_omsconfig_host_telemetry, write_omsconfig_host_switch_event, write_omsconfig_host_log, stop_old_host_instances
+from imp                import load_source
+from os.path            import dirname, isfile, join, realpath
+from fcntl              import flock, LOCK_EX, LOCK_UN, LOCK_NB
+
+pathToCurrentScript = realpath(__file__)
+pathToCommonScriptsFolder = dirname(pathToCurrentScript)
+
+helperLibPath = join(pathToCommonScriptsFolder, 'helperlib.py')
+helperlib = load_source('helperlib', helperLibPath)
+
+omi_bindir = "<CONFIG_BINDIR>"
+omicli_path = omi_bindir + "/omicli"
+dsc_host_base_path = helperlib.DSC_HOST_BASE_PATH
+dsc_host_path = join(dsc_host_base_path, 'bin/dsc_host')
+dsc_host_output_path = join(dsc_host_base_path, 'output')
+dsc_host_lock_path = join(dsc_host_base_path, 'dsc_host_lock')
+dsc_host_switch_path = join(dsc_host_base_path, 'dsc_host_ready')
+
+if ("omsconfig" in helperlib.DSC_SCRIPT_PATH):
+    write_omsconfig_host_switch_event(pathToCurrentScript, isfile(dsc_host_switch_path))
+
+if ("omsconfig" in helperlib.DSC_SCRIPT_PATH) and (isfile(dsc_host_switch_path)):
+    use_omsconfig_host = True
+else:
+    use_omsconfig_host = False
+
+parameters = []
+
+if use_omsconfig_host:
+    parameters.append(dsc_host_path)
+    parameters.append(dsc_host_output_path)
+    parameters.append("GetMetaConfiguration")
+else:
+    parameters.append(omicli_path)
+    parameters.append("iv")
+    parameters.append("<DSC_NAMESPACE>")
+    parameters.append("{")
+    parameters.append("MSFT_DSCLocalConfigurationManager")
+    parameters.append("}")
+    parameters.append("GetMetaConfiguration")
+
+stdout = ''
+stderr = ''
+
+if use_omsconfig_host:
+    try:
+        dschostlock_filehandle = None
+        stop_old_host_instances(dsc_host_lock_path)
+
+        # Open the dsc host lock file. This also creates a file if it does not exist
+        dschostlock_filehandle = open(dsc_host_lock_path, 'w')
+        print("Opened the dsc host lock file at the path '" + dsc_host_lock_path + "'")
+        
+        dschostlock_acquired = False
+
+        # Acquire dsc host file lock
+        for retry in range(10):
+            try:
+                flock(dschostlock_filehandle, LOCK_EX | LOCK_NB)
+                dschostlock_acquired = True
+                break
+            except IOError:
+                write_omsconfig_host_log('dsc_host lock file not acquired. retry (#' + str(retry) + ') after 60 seconds...', pathToCurrentScript)
+                sleep(60)
+
+        if dschostlock_acquired:
+            p = subprocess.Popen(parameters, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            stdout, stderr = p.communicate()
+            stdout = stdout.decode() if isinstance(stdout, bytes) else stdout
+            print(stdout)
+        else:
+            print("dsc host lock already acuired by a different process")
+    finally:
+        if (dschostlock_filehandle):
+            # Release dsc host file lock
+            flock(dschostlock_filehandle, LOCK_UN)
+
+            # Close dsc host lock file handle
+            dschostlock_filehandle.close()
+else:
+    p = subprocess.Popen(parameters, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = p.communicate()
+
+stdout = stdout.decode() if isinstance(stdout, bytes) else stdout
+stderr = stderr.decode() if isinstance(stderr, bytes) else stderr
+print(stdout)
+print(stderr)
+
+

--- a/LCM/scripts/python3/ImportGPGKey.sh
+++ b/LCM/scripts/python3/ImportGPGKey.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+if [ -z "$1" ]; then
+    echo "Usage:"
+    echo "   $0 PUBLIC_GPG_KEY"
+    exit 1
+fi
+
+if [ -z "$2" ]; then
+    KEYRING_NAME="keyring.gpg"
+else
+    KEYRING_NAME=$2
+fi
+
+DSC_ETC_DIR=<CONFIG_SYSCONFDIR>/<CONFIG_SYSCONFDIR_DSC>
+HOME=$DSC_ETC_DIR gpg --no-default-keyring  --keyring $DSC_ETC_DIR/$KEYRING_NAME --import $1
+RETVAL=$?
+
+if [ "<CONFIG_SYSCONFDIR_DSC>" = "omsagent" ]; then
+    if [ `id -u` = 0 ] ; then
+        chown omsagent $DSC_ETC_DIR/$KEYRING_NAME
+    fi
+fi
+
+exit $RETVAL

--- a/LCM/scripts/python3/InstallModule.py
+++ b/LCM/scripts/python3/InstallModule.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 import imp
 import os
 import stat
@@ -31,11 +31,15 @@ def usage():
     sys.exit(1)
 
 def exitWithError(message, errorCode = 1):
+    if (isinstance(message, bytes)):
+        message = message.decode()
     errorMessage = "ERROR from InstallModule.py: " + message
     print(errorMessage)
     sys.exit(errorCode)
 
 def printVerboseMessage(message):
+    if (isinstance(message, bytes)):
+        message = message.decode()
     verboseMessage = "VERBOSE from InstallModule.py: " + message
     print(verboseMessage)
 
@@ -65,7 +69,8 @@ def getPlatformArchitectureFolderName():
 
 
 def regenerateDscPythonScriptInitFiles():
-    regenerateInitFilesResult = subprocess.call("(python /opt/microsoft/omsconfig/Scripts/RegenerateInitFiles.py)", shell=True)
+    regenerateInitFilesResult = subprocess.call("(python3 /opt/microsoft/omsconfig/Scripts/python3/RegenerateInitFiles.py)", shell=True)
+    print("The result code is", regenerateInitFilesResult)
     if regenerateInitFilesResult != 0:
         exitWithError("Failed to regenerate the DSC __init__.py files with the result code", regenerateInitFilesResult)
 
@@ -210,7 +215,8 @@ def main(args):
     moduleResources = os.listdir(moduleDscResourcesDestinationPath)
 
     # Note: Python 2.4 and 3 recognize different formats for octal
-    strMode = "0777"
+    strMode = "0o777"
+   
 
     octMode = int(strMode, base=8)
 

--- a/LCM/scripts/python3/OMS_MetaConfigHelper.py
+++ b/LCM/scripts/python3/OMS_MetaConfigHelper.py
@@ -1,9 +1,8 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 import os
 import sys
 import imp
 import subprocess
-import signal
 from os.path import basename, dirname, join, realpath, split
 from imp                import load_source
 from os.path            import dirname, isfile, join, realpath
@@ -27,26 +26,17 @@ fullPathDSCLogger = os.path.join(pathToCommonScriptsFolder, 'nxDSCLog.py')
 nxDSCLog = imp.load_source('nxDSCLog', fullPathDSCLogger)
 logger = nxDSCLog.ConsoleAndFileLogger()
 sys.stdout = logger
-proc = None
-
-# function to handle ternimation signals received from omsagent.
-# Child process are created by with a new group id.
-# We issue termination signal together to all childprocesses with group id.
-def signal_handler(signalNumber, frame):
-    printVerboseMessage("OMS_MetaconfigHelper.py script received SIGTERM signal.")
-
-    if proc is not None:
-        printVerboseMessage("Terminating child process by sending SIGTERM signal.")
-        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
-    else:
-        printVerboseMessage("There is no child process running. It is either completed execution or has not been invoked.")
 
 def exitWithError(message, errorCode = 1):
+    if (isinstance(message, bytes)):
+        message = message.decode()
     errorMessage = "ERROR from OMS_MetaConfigHelper.py: " + message
     print(errorMessage)
     sys.exit(errorCode)
 
 def printVerboseMessage(message):
+    if (isinstance(message, bytes)):
+        message = message.decode()
     verboseMessage = "VERBOSE from OMS_MetaConfigHelper.py: " + message
     print(verboseMessage)
 
@@ -150,9 +140,6 @@ def source_file(filename):
 Variables = dict()
 Defines = []
 
-# register the SIGTERM handler
-signal.signal(signal.SIGTERM, signal_handler)
-
 # Parse command line arguments
 args = []
 optlist = []
@@ -240,16 +227,17 @@ finally:
 os.system("chown omsagent " + metamof_path)
 
 if os.geteuid() == 0:
-    commandToRun = "su - omsagent -c '/opt/microsoft/omsconfig/Scripts/SetDscLocalConfigurationManager.py -configurationmof " + metamof_path + "'"
+    commandToRun = "su - omsagent -c '/opt/microsoft/omsconfig/Scripts/python3/SetDscLocalConfigurationManager.py -configurationmof " + metamof_path + "'"
 else:
-    commandToRun = "/opt/microsoft/omsconfig/Scripts/SetDscLocalConfigurationManager.py -configurationmof " + metamof_path
+    commandToRun = "/opt/microsoft/omsconfig/Scripts/python3/SetDscLocalConfigurationManager.py -configurationmof " + metamof_path
 
 # Apply the metaconfig using SetDscLocalConfiguration
-proc = subprocess.Popen(commandToRun, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, close_fds=True, preexec_fn=os.setsid)
+proc = subprocess.Popen(commandToRun, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, close_fds=True)
 exit_code = proc.wait()
 
 stdout, stderr = proc.communicate()
-printVerboseMessage("Output from: " + commandToRun + ": " + str(stdout))
+stdout = stdout.decode() if isinstance(stdout, bytes) else stdout
+printVerboseMessage("Output from3: " + commandToRun + ": " + str(stdout))
 
 set_metaconfig_success_string = ""
 if "omsconfig" in helperlib.DSC_SCRIPT_PATH:
@@ -257,14 +245,14 @@ if "omsconfig" in helperlib.DSC_SCRIPT_PATH:
 else:
     set_metaconfig_success_string = "ReturnValue=0"
 
-if ((exit_code == 0) and (stderr.decode(encoding = 'UTF-8') == '') and (set_metaconfig_success_string in str(stdout))):
+if ((exit_code == 0) and (stderr == '' or (sys.version_info >= (3, 0) and stderr.decode(encoding = 'UTF-8') == '')) and (set_metaconfig_success_string in str(stdout))):
     printVerboseMessage('Successfully configured omsconfig.')
 else:
     if exit_code == 0:
         exit_code = 1
 
     if (stderr != ''):
-        exitWithError(("Error on running command: " + commandToRun + " Error Message: " + stderr), exit_code)
+        exitWithError(("Error on running command: " + commandToRun + " Error Message: " + stderr.decode()), exit_code)
     elif ((sys.version_info >= (3, 0) and stderr.decode(encoding = 'UTF-8') != '')):
         exitWithError(("Error on running command: " + commandToRun + " Error Message: " + stderr.decode(encoding = 'UTF-8')), exit_code)
     else:

--- a/LCM/scripts/python3/OmsConfigHostHelpers.py
+++ b/LCM/scripts/python3/OmsConfigHostHelpers.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+import json
+import time
+import datetime
+import os
+import math
+import signal
+
+def write_omsconfig_host_telemetry(message, pathToCurrentScript='', level = 'INFO'):
+    omsagent_telemetry_path = '/var/opt/microsoft/omsconfig/status'
+    dsc_host_telemetry_path = os.path.join(omsagent_telemetry_path, 'omsconfighost')
+
+    if not os.path.exists(omsagent_telemetry_path):
+        os.makedirs(omsagent_telemetry_path)
+
+    if os.path.isfile(dsc_host_telemetry_path):
+        with open(dsc_host_telemetry_path) as host_telemetry_file:
+            try:
+                host_telemetry_json = json.load(host_telemetry_file)
+            except:
+                host_telemetry_json = {}
+                host_telemetry_json['operation'] = 'omsconfighost'
+                host_telemetry_json['message'] = ''
+                host_telemetry_json['success'] = 1
+    else:
+        os.mknod(dsc_host_telemetry_path)
+        host_telemetry_json = {}
+        host_telemetry_json['operation'] = 'omsconfighost'
+        host_telemetry_json['message'] = ''
+        host_telemetry_json['success'] = 1
+
+    msg_template = '<OMSCONFIGLOG>[%s] [%d] [%s] [%d] [%s:%d] %s</OMSCONFIGLOG>'
+    timestamp = datetime.datetime.fromtimestamp(time.time()).strftime('%Y/%m/%d %H:%M:%S')
+    msg_buffer = msg_template % (timestamp, os.getpid(), level, 0, pathToCurrentScript, 0, json.dumps(message))
+
+    host_telemetry_json['message'] += msg_buffer
+
+    with open(dsc_host_telemetry_path, 'w+') as host_telemetry_file:
+        json.dump(host_telemetry_json, host_telemetry_file)
+
+def get_agent_id():
+    agentid_path = "/etc/opt/omi/conf/omsconfig/agentid"
+    if os.path.isfile(agentid_path):
+        with open(agentid_path, "r") as agentid_file:
+            agent_id = agentid_file.read(36) # read 36 characters from the file
+            return agent_id
+    return "00000000-0000-0000-0000-000000000000"
+
+def write_omsconfig_host_switch_event(pathToCurrentScript, dsc_host_switch_exists):
+    if dsc_host_switch_exists:
+        message = 'Using dsc_host'
+    else:
+        message = 'Falling back to OMI'
+    telemetry_message = '[%s] %s' % (get_agent_id(), message)
+    write_omsconfig_host_telemetry(telemetry_message, pathToCurrentScript)
+
+def write_omsconfig_host_log(message, pathToCurrentScript, level = 'INFO'):
+    log_entry_template = '[%s] [%d] [%s] [%d] [%s:%d] %s\n'
+    timestamp = datetime.datetime.fromtimestamp(time.time()).strftime('%Y/%m/%d %H:%M:%S')
+    log_entry = log_entry_template % (timestamp, os.getpid(), level, 0, pathToCurrentScript, 0, message)
+
+    omsconfig_log_folder = '/var/opt/microsoft/omsconfig'
+    if not os.path.exists(omsconfig_log_folder):
+        os.makedirs(omsconfig_log_folder)
+
+    print(log_entry)
+
+    omsconfig_log_path = os.path.join(omsconfig_log_folder, 'omsconfig.log')
+    with open(omsconfig_log_path, 'a+') as omsconfig_log_file:
+        omsconfig_log_file.write(log_entry)
+
+    omsconfig_detailed_log_path = os.path.join(omsconfig_log_folder, 'omsconfigdetailed.log')
+    with open(omsconfig_detailed_log_path, 'a+') as omsconfig_detailed_log_file:
+        omsconfig_detailed_log_file.write(log_entry)
+    
+    if (level == 'ERROR') or (level == 'WARNING') or (level == 'FATAL'):
+        write_omsconfig_host_telemetry(message, pathToCurrentScript, level)
+
+def stop_old_host_instances(dsc_host_lock_path):
+    dsc_host_pid_path = '/opt/dsc/bin/dsc_host.pid'
+
+    last_host_pid = 0
+
+    if os.path.isfile(dsc_host_pid_path):
+        with open(dsc_host_pid_path) as dsc_host_pid_file:
+            try:
+                last_host_pid = dsc_host_pid_file.read()
+            except:
+                pass
+    
+    if last_host_pid == 0:
+        return
+    
+    # Timestamps are measured in seconds since epoch
+    host_pid_last_modified_time = os.path.getmtime(dsc_host_pid_path)
+    current_time = math.floor(time.time())
+    timestamp_diff = current_time - host_pid_last_modified_time
+
+    if (timestamp_diff < 0):
+        return
+    
+    # If file was last modified more than 3 hours ago, we will kill the process
+    if (timestamp_diff > 3600 * 3):
+        try:
+            write_omsconfig_host_log('Killing dsc_host with pid = ' + str(last_host_pid) + ' since it is older than 3 hours.', 'stop_old_host_instances', 'WARNING')
+            os.kill(last_host_pid, signal.SIGTERM)
+            if (os.path.exists(dsc_host_lock_path)):
+                os.remove(dsc_host_lock_path)
+            write_omsconfig_host_log('Killed dsc_host with pid = ' + str(last_host_pid) + ' since it was taking longer than 3 hours.', 'stop_old_host_instances', 'WARNING')
+        except:
+            pass

--- a/LCM/scripts/python3/OperationStatusUtility.py
+++ b/LCM/scripts/python3/OperationStatusUtility.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 from datetime   import datetime
 from errno      import EINVAL
 from imp        import load_source
@@ -26,8 +26,8 @@ def get_current_timestamp():
 
 def get_permission_in_oct(threeDigitString):
     # Note: Python 2.4 and 3 recognize different formats for octal
-    strMode = "0" + threeDigitString
-
+    strMode = "0o" + threeDigitString
+    
     octMode = int(strMode, base = 8)
     return octMode
 

--- a/LCM/scripts/python3/PerformInventory.py
+++ b/LCM/scripts/python3/PerformInventory.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+from fcntl                import flock, LOCK_EX, LOCK_UN, LOCK_NB
+from imp                  import load_source
+from os                   import listdir, system
+from os.path              import dirname, isfile, join, realpath
+from shutil               import move
+from subprocess           import Popen, PIPE
+from sys                  import argv, exc_info, exit, stdout, version_info
+from traceback            import format_exc
+from xml.dom.minidom      import parse
+from OmsConfigHostHelpers import write_omsconfig_host_telemetry, write_omsconfig_host_switch_event, write_omsconfig_host_log, stop_old_host_instances
+from time                 import sleep
+
+pathToCurrentScript = realpath(__file__)
+pathToCommonScriptsFolder = dirname(pathToCurrentScript)
+
+helperLibPath = join(pathToCommonScriptsFolder, 'helperlib.py')
+helperlib = load_source('helperlib', helperLibPath)
+
+operationStatusUtilityPath = join(pathToCommonScriptsFolder, 'OperationStatusUtility.py')
+operationStatusUtility = load_source('operationStatusUtility', operationStatusUtilityPath)
+
+operation = 'PerformInventory'
+
+# Redirect output to our log file
+fullPathDSCLogger = join(pathToCommonScriptsFolder, 'nxDSCLog.py')
+nxDSCLog = load_source('nxDSCLog', fullPathDSCLogger)
+logger = nxDSCLog.ConsoleAndFileLogger()
+stdout = logger
+
+def usage():
+    write_omsconfig_host_log('Incorrect parameters to PerformInventory.py: ' + str(argv), pathToCurrentScript, 'WARNING')
+    print("""Usage: PerformInventory.py [OPTIONS]
+OPTIONS (case insensitive):
+ --InMOF PATH_TO_INVENTORY.MOF
+ --OutXML PATH_TO_OUTPUT_REPORT.XML
+ --help
+""")
+
+def exitWithError(message, errorCode = 1):
+    if (isinstance(message, bytes)):
+        message = message.decode()
+    timestamp = operationStatusUtility.get_current_timestamp()
+    errorMessage = timestamp + ": ERROR from PerformInventory.py: " + message
+    print(errorMessage)
+    exit(errorCode)
+
+def printVerboseMessage(message):
+    if (isinstance(message, bytes)):
+        message = message.decode()
+    timestamp = operationStatusUtility.get_current_timestamp()
+    verboseMessage = str(timestamp) + ": VERBOSE from PerformInventory.py: " + str(message)
+    print(verboseMessage)
+
+def main(args):
+    try:
+        perform_inventory(args)
+    except SystemExit:
+        exit(exc_info()[1])
+    except Exception:
+        # Python 2.4-2.7 and 2.6-3 recognize different formats for exceptions. This methods works in all versions.
+        formattedExceptionMessage = format_exc()
+        write_omsconfig_host_log('Python exception raised from PerformInventory.py: ' + formattedExceptionMessage, pathToCurrentScript, 'ERROR')
+        raise
+
+def perform_inventory(args):
+    Variables = dict()
+
+    # Parse command line arguments
+    optlist = []
+
+    command_line_length = len(args)
+    argIndex = 0
+    inArgument = False
+    currentArgument = ""
+    arg = ""
+
+    while argIndex < command_line_length:
+        arg = args[argIndex]
+        if argIndex == 0:
+            # skip the program name
+            argIndex += 1
+            continue
+
+        if inArgument:
+            Variables[currentArgument] = arg
+            inArgument = False
+        else:
+            if arg[0:2] == "--":
+                inArgument = True
+                currentArgument = arg[2:].lower()
+            else:
+                # The rest are not options
+                args = args[argIndex:]
+                break
+        argIndex += 1
+
+    if inArgument:
+        Variables[currentArgument] = arg
+
+    AcceptableOptions = ["inmof", "outxml", "help"]
+
+    if "help" in Variables:
+        usage()
+        exit(0)
+
+    optionsValid = True
+    for arg in Variables.keys():
+        if arg.lower() not in AcceptableOptions:
+            optionsValid = False
+            exitWithError("Error: %s is not a valid option" % arg)
+
+    if optionsValid == False:
+        usage()
+        exit(1)
+
+    dsc_sysconfdir = join(helperlib.CONFIG_SYSCONFDIR, helperlib.CONFIG_SYSCONFDIR_DSC)
+    dsc_reportdir = join(dsc_sysconfdir, 'InventoryReports')
+    omicli_path = join(helperlib.CONFIG_BINDIR, 'omicli')
+    dsc_host_base_path = helperlib.DSC_HOST_BASE_PATH
+    dsc_host_path = join(dsc_host_base_path, 'bin/dsc_host')
+    dsc_host_output_path = join(dsc_host_base_path, 'output')
+    dsc_host_lock_path = join(dsc_host_base_path, 'dsc_host_lock')
+    dsc_host_switch_path = join(dsc_host_base_path, 'dsc_host_ready')
+    dsc_configuration_path = join(dsc_sysconfdir, 'configuration')
+    temp_report_path = join(dsc_configuration_path, 'Inventory.xml.temp')
+    report_path = join(dsc_configuration_path, 'Inventory.xml')
+    inventorylock_path = join(dsc_sysconfdir, 'inventory_lock')
+
+    if ("omsconfig" in helperlib.DSC_SCRIPT_PATH):
+        write_omsconfig_host_switch_event(pathToCurrentScript, isfile(dsc_host_switch_path))
+
+    if ("omsconfig" in helperlib.DSC_SCRIPT_PATH) and (isfile(dsc_host_switch_path)):
+        use_omsconfig_host = True
+    else:
+        use_omsconfig_host = False
+
+    if "outxml" in Variables:
+        report_path = Variables["outxml"]
+
+    parameters = []
+
+    if use_omsconfig_host:
+        parameters.append(dsc_host_path)
+        parameters.append(dsc_host_output_path)
+
+        if "inmof" in Variables:
+            parameters.append("PerformInventoryOOB")
+            parameters.append(Variables["inmof"])
+        else:
+            parameters.append("PerformInventory")
+    else:
+        parameters.append(omicli_path)
+        parameters.append("iv")
+        parameters.append(helperlib.DSC_NAMESPACE)
+        parameters.append("{")
+        parameters.append("MSFT_DSCLocalConfigurationManager")
+        parameters.append("}")
+
+        if "inmof" in Variables:
+            parameters.append("PerformInventoryOOB")
+            parameters.append("{")
+            parameters.append("InventoryMOFPath")
+            parameters.append(Variables["inmof"])
+            parameters.append("}")
+        else:
+            parameters.append("PerformInventory")
+
+    # Ensure inventory lock file permission is set correctly before opening
+    operationStatusUtility.ensure_file_permissions(inventorylock_path, '644')
+
+    # Open the inventory lock file. This also creates a file if it does not exist.
+    inventorylock_filehandle = open(inventorylock_path, 'w')
+    printVerboseMessage("Opened the inventory lock file at the path '" + inventorylock_path + "'")
+    retval = 0
+    inventorylock_acquired = True
+    dschostlock_filehandle = None
+    inmof_file = ''
+    if "inmof" in Variables:
+        inmof_file = Variables["inmof"]
+
+    try:
+        # Acquire inventory file lock
+        try:
+            flock(inventorylock_filehandle, LOCK_EX | LOCK_NB)
+            write_omsconfig_host_log('Inventory lock is acquired by : ' + inmof_file, pathToCurrentScript)
+        except IOError:
+            inventorylock_acquired = False
+            write_omsconfig_host_log('Failed to acquire inventory lock.', pathToCurrentScript, 'WARNING')
+
+        if inventorylock_acquired:
+            dschostlock_acquired = False
+            
+            if use_omsconfig_host:
+                if isfile(dsc_host_lock_path):
+                    stop_old_host_instances(dsc_host_lock_path)
+                    # Open the dsc host lock file. This also creates a file if it does not exist.
+                    dschostlock_filehandle = open(dsc_host_lock_path, 'w')
+                    printVerboseMessage("Opened the dsc host lock file at the path '" + dsc_host_lock_path + "'")
+
+                    # Acquire dsc host file lock
+                    for retry in range(10):
+                        try:
+                            flock(dschostlock_filehandle, LOCK_EX | LOCK_NB)
+                            dschostlock_acquired = True
+                            write_omsconfig_host_log('dsc_host lock file is acquired by : ' + inmof_file, pathToCurrentScript)
+                            break
+                        except IOError:
+                            write_omsconfig_host_log('dsc_host lock file not acquired. retry (#' + str(retry) + ') after 60 seconds...', pathToCurrentScript)
+                            sleep(60)
+                else:
+                    write_omsconfig_host_log('dsc_host lock file does not exist. Skipping this operation until next consistency hits.', pathToCurrentScript, 'WARNING')
+
+            if dschostlock_acquired or (not use_omsconfig_host):
+                try:
+                    system("rm -f " + dsc_reportdir + "/*")
+
+                    process = Popen(parameters, stdout = PIPE, stderr = PIPE)
+                    stdout, stderr = process.communicate()
+                    retval = process.returncode
+
+                    stdout = stdout.decode() if isinstance(stdout, bytes) else stdout
+                    stderr = stderr.decode() if isinstance(stderr, bytes) else stderr
+                    printVerboseMessage(stdout)
+
+                    if (retval > 0):
+                        write_omsconfig_host_log('dsc_host failed with code = ' + str(retval), pathToCurrentScript)
+                        exit(retval)
+
+                    # Combine reports together
+                    reportFiles = listdir(dsc_reportdir)
+
+                    final_xml_report = '<INSTANCE CLASSNAME="Inventory"><PROPERTY.ARRAY NAME="Instances" TYPE="string" EmbeddedObject="object"><VALUE.ARRAY>'
+                    values = []
+                    for reportFileName in reportFiles:
+                        reportFilePath = join(dsc_reportdir, reportFileName)
+
+                        if not isfile(reportFilePath):
+                            continue
+                        report = parse(reportFilePath)
+                        for valueNode in report.getElementsByTagName('VALUE'):
+                            values.append(valueNode.toxml())
+
+                    final_xml_report = final_xml_report + "".join(values) + "</VALUE.ARRAY></PROPERTY.ARRAY></INSTANCE>"
+
+                    # Ensure temporary inventory report file permission is set correctly before opening
+                    operationStatusUtility.ensure_file_permissions(temp_report_path, '644')
+
+                    tempReportFileHandle = open(temp_report_path, 'w')
+                    try:
+                        tempReportFileHandle.write(final_xml_report)
+                    finally:
+                        if (tempReportFileHandle):
+                            tempReportFileHandle.close()
+
+                    # Ensure temporary inventory report file permission is set correctly after opening
+                    operationStatusUtility.ensure_file_permissions(temp_report_path, '644')
+
+                    system("rm -f " + dsc_reportdir + "/*")
+                    move(temp_report_path, report_path)
+
+                    # Ensure inventory report file permission is set correctly
+                    operationStatusUtility.ensure_file_permissions(report_path, '644')
+                finally:
+                    if (dschostlock_filehandle):
+                        # Release inventory file lock
+                        flock(inventorylock_filehandle, LOCK_UN)
+
+                        # Release dsc host file lock
+                        if isfile(dsc_host_lock_path) and use_omsconfig_host:
+                            try:
+                                flock(dschostlock_filehandle, LOCK_UN)
+                            except:
+                                pass
+    finally:
+        if (inventorylock_filehandle):
+            # Close inventory lock file handle
+            inventorylock_filehandle.close()
+        
+        if (dschostlock_filehandle):
+            # Close dsc host lock file handle
+            if use_omsconfig_host:
+                try:
+                    dschostlock_filehandle.close()
+                except:
+                    pass
+
+    # Ensure inventory lock file permission is set correctly after opening
+    operationStatusUtility.ensure_file_permissions(inventorylock_path, '644')
+
+    # Ensure dsc host lock file permission is set correctly after opening
+    if use_omsconfig_host:
+        operationStatusUtility.ensure_file_permissions(dsc_host_lock_path, '644')
+
+    exit(retval)
+
+if __name__ == "__main__":
+    main(argv)

--- a/LCM/scripts/python3/PerformRequiredConfigurationChecks.py
+++ b/LCM/scripts/python3/PerformRequiredConfigurationChecks.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+from imp        import load_source
+from os.path    import dirname, join, realpath, isfile
+from subprocess import PIPE, Popen
+from sys        import exc_info, exit, version_info
+from traceback  import format_exc
+from fcntl      import flock, LOCK_EX, LOCK_UN, LOCK_NB
+from OmsConfigHostHelpers import write_omsconfig_host_telemetry, write_omsconfig_host_switch_event, write_omsconfig_host_log, stop_old_host_instances
+from time       import sleep
+
+pathToCurrentScript = realpath(__file__)
+pathToCommonScriptsFolder = dirname(pathToCurrentScript)
+
+helperLibPath = join(pathToCommonScriptsFolder, 'helperlib.py')
+helperlib = load_source('helperlib', helperLibPath)
+
+operationStatusUtilityPath = join(pathToCommonScriptsFolder, 'OperationStatusUtility.py')
+operationStatusUtility = load_source('operationStatusUtility', operationStatusUtilityPath)
+
+operation = 'PerformConsistency'
+
+def main():
+    try:
+        run_perform_required_configuration_checks()
+    except SystemExit:
+        exit(exc_info()[1])
+    except Exception:
+        # Python 2.4-2.7 and 2.6-3 recognize different formats for exceptions. This methods works in all versions.
+        formattedExceptionMessage = format_exc()
+        write_omsconfig_host_log('Python exception raised from PerformRequiredConfigurationChecks.py: ' + formattedExceptionMessage, pathToCurrentScript, 'ERROR')
+        raise
+
+def run_perform_required_configuration_checks():
+
+    dsc_sysconfdir = join(helperlib.CONFIG_SYSCONFDIR, helperlib.CONFIG_SYSCONFDIR_DSC)
+    omicli_path = join(helperlib.CONFIG_BINDIR, 'omicli')
+    dsc_host_base_path = helperlib.DSC_HOST_BASE_PATH
+    dsc_host_path = join(dsc_host_base_path, 'bin/dsc_host')
+    dsc_host_output_path = join(dsc_host_base_path, 'output')
+    dsc_host_lock_path = join(dsc_host_base_path, 'dsc_host_lock')
+    dsc_host_switch_path = join(dsc_host_base_path, 'dsc_host_ready')
+
+    if ("omsconfig" in helperlib.DSC_SCRIPT_PATH):
+        write_omsconfig_host_switch_event(pathToCurrentScript, isfile(dsc_host_switch_path))
+
+    if ("omsconfig" in helperlib.DSC_SCRIPT_PATH) and (isfile(dsc_host_switch_path)):
+        use_omsconfig_host = True
+    else:
+        use_omsconfig_host = False
+
+    parameters = []
+    if use_omsconfig_host:
+        parameters.append(dsc_host_path)
+        parameters.append(dsc_host_output_path)
+        parameters.append("PerformRequiredConfigurationChecks")
+        parameters.append("1")
+    else:
+        parameters.append(omicli_path)
+        parameters.append("iv")
+        parameters.append(helperlib.DSC_NAMESPACE)
+        parameters.append("{")
+        parameters.append("MSFT_DSCLocalConfigurationManager")
+        parameters.append("}")
+        parameters.append("PerformRequiredConfigurationChecks")
+        parameters.append("{")
+        parameters.append("Flags")
+        parameters.append("1")
+        parameters.append("}")
+
+    stdout = ''
+    stderr = ''
+
+    if use_omsconfig_host:
+        try:
+            # Open the dsc host lock file. This also creates a file if it does not exist
+            dschostlock_filehandle = None
+            dschostlock_filehandle = open(dsc_host_lock_path, 'w')
+            print("Opened the dsc host lock file at the path '" + dsc_host_lock_path + "'")
+            
+            dschostlock_acquired = False
+
+            # Acquire dsc host file lock
+            for retry in range(60):
+                try:
+                    flock(dschostlock_filehandle, LOCK_EX | LOCK_NB)
+                    write_omsconfig_host_log('dsc_host lock file is acquired by : PerformRequiredConfigurationChecks', pathToCurrentScript)
+                    dschostlock_acquired = True
+                    break
+                except IOError:
+                    write_omsconfig_host_log('dsc_host lock file not acquired. retry (#' + str(retry) + ') after 60 seconds...', pathToCurrentScript)
+                    sleep(15)
+                    stop_old_host_instances(dsc_host_lock_path)
+                
+            if dschostlock_acquired:
+                p = Popen(parameters, stdout=PIPE, stderr=PIPE)
+                stdout, stderr = p.communicate()
+                stdout = stdout.decode() if isinstance(stdout, bytes) else stdout
+                print(stdout)
+            else:
+                print("dsc host lock already acuired by a different process")
+        finally:
+            if (dschostlock_filehandle):
+                # Release dsc host file lock
+                flock(dschostlock_filehandle, LOCK_UN)
+
+                # Close dsc host lock file handle
+                dschostlock_filehandle.close()
+    else:
+        p = Popen(parameters, stdout=PIPE, stderr=PIPE)
+        stdout, stderr = p.communicate()
+    stdout = stdout.decode() if isinstance(stdout, bytes) else stdout
+    print(stdout)
+
+if __name__ == "__main__":
+    main()

--- a/LCM/scripts/python3/RegenerateInitFiles.py
+++ b/LCM/scripts/python3/RegenerateInitFiles.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+import glob
+import os.path
+
+omi_libdir = "<DSC_SCRIPT_PATH>"
+
+script_dirs=[omi_libdir + "/2.4x-2.5x/Scripts",
+             omi_libdir + "/2.6x-2.7x/Scripts",
+             omi_libdir + "/3.x/Scripts"]
+
+for current_dir in script_dirs:
+    out_init = "__all__="
+    py_files = glob.glob(current_dir + "/*.py")
+    py_files_basename = []
+    for current_file in py_files:
+        current_basename = os.path.basename(current_file)
+
+        if len(current_basename) < 3:
+            print("Found odd file name at: " + current_file + ", ignoring it.")
+            continue
+        if current_basename == "__init__.py":
+            continue
+
+        py_files_basename.append(current_basename[:-3])
+
+    out_init = out_init + str(py_files_basename)
+    open(current_dir + "/__init__.py", "w").write(out_init)
+        

--- a/LCM/scripts/python3/Register.py
+++ b/LCM/scripts/python3/Register.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+import sys
+import os
+import os.path
+import tempfile
+import shutil
+
+def usage():
+   print("""Usage: Register.py [OPTIONS]
+OPTIONS (case insensitive):
+ --RegistrationKey KEY
+ --ServerURL URL
+ --ConfigurationName NAME
+ --RefreshFrequencyMins NUM                                          default=30
+ --ConfigurationModeFrequencyMins NUM                                default=15
+ --ConfigurationMode (ApplyAndMonitor, ApplyAndAutoCorrect, ApplyOnly, MonitorOnly) default=ApplyAndMonitor
+ --RefreshMode (Pull|Push)                                           default=Pull
+ --Help
+""")
+
+# Apply a DSC meta configuration based on a template
+Variables = dict()
+
+# Parse command line arguments
+args = []
+optlist = []
+
+command_line_length = len(sys.argv)
+i = 0
+inArgument = False
+currentArgument = ""
+arg = ""
+while i < command_line_length:
+   arg = sys.argv[i]
+   if i == 0:
+      # skip the program name
+      i += 1
+      continue
+
+   if inArgument:
+      Variables[currentArgument] = arg
+      inArgument = False
+   else:
+      if arg[0:2] == "--":
+         inArgument = True
+         currentArgument = arg[2:].lower()
+      else:
+         # The rest are not options
+         args = sys.argv[i:]
+         break
+   i += 1
+   
+if inArgument:
+   Variables[currentArgument] = arg
+
+AcceptableOptions = ["registrationkey", "serverurl", "configurationname", "refreshfrequencymins", "configurationmodefrequencymins", "configurationmode", "refreshmode", "help", "regeneratecert"]
+
+if "help" in Variables:
+   usage()
+   sys.exit(0)
+
+optionsValid = True
+for arg in Variables.keys():
+   if arg.lower() not in AcceptableOptions:
+      optionsValid = False
+      print("Error: %s is not a valid option" % arg)
+
+if len(Variables.keys()) == 0:
+   if len(args) == 2:
+      # Assume first parameter is RegistrationKey and second parameter is ServerURL in this case
+      Variables["registrationkey"] = args[0]
+      Variables["serverurl"] = args[1]
+   else:
+      print("Error: Unexpected (" + str(len(args)) + ") number of non-option arguments.  Without options specified, we expect arguments to be RegistrationKey followed by ServerURL.")
+      optionsValid = False
+   
+if optionsValid == False:
+   usage()
+   sys.exit(1)
+
+ServerURL = ""
+RegistrationKey = ""
+ConfigurationName = ""
+
+# If RefreshMode == Pull (which is default), then RegistrationKey and ServerURL are required.
+RefreshMode = "Pull"
+if "refreshmode" in Variables:
+   RefreshMode = Variables["refreshmode"]
+
+if RefreshMode == "Pull":
+   if "registrationkey" not in Variables:
+      print("Error: RegistrationKey must be specified for Pull mode")
+      usage()
+      sys.exit(1)
+   if "serverurl" not in Variables:
+      print("Error: ServerURL must be specified for Pull mode")
+      usage()
+      sys.exit(1)
+   ServerURL = Variables["serverurl"]
+   RegistrationKey = Variables["registrationkey"]
+   if "configurationname" in Variables:
+      ConfigurationName = Variables["configurationname"]
+
+ConfigurationMode = "ApplyAndMonitor"
+if "configurationmode" in Variables:
+   ConfigurationMode = Variables["configurationmode"]
+
+RefreshFrequencyMins = "30"
+if "refreshfrequencymins" in Variables:
+   RefreshFrequencyMins = Variables["refreshfrequencymins"]
+   
+ConfigurationModeFrequencyMins = "15"
+if "configurationmodefrequencymins" in Variables:
+   ConfigurationModeFrequencyMins = Variables["configurationmodefrequencymins"]
+
+RegenerateCert = False
+if "regeneratecert" in Variables:
+   RegenerateCert = True
+
+metaConfig = ""
+if RefreshMode == "Push":
+   metaConfig = """
+     instance of MSFT_DSCMetaConfiguration as $MSFT_DSCMetaConfiguration1ref
+     {
+     DownloadManagerName = "WebDownloadManager";
+     RefreshMode = "<REFRESHMODE>";
+     ConfigurationMode = "<CONFIGURATIONMODE>";
+     
+     };
+     
+     instance of OMI_ConfigurationDocument
+     {
+     Version="1.0.0";
+     };
+     """
+else:
+   metaConfig="""
+     instance of MSFT_WebDownloadManager as $MSFT_WebDownloadManager1ref
+     {
+     ResourceID = "[ConfigurationRepositoryWeb]AzureAutomationDSC";
+     SourceInfo = "C:\\\\OaaS-RegistrationMetaConfig2.ps1::20::9::ConfigurationRepositoryWeb";
+     RegistrationKey = "<REGKEY>"; 
+     ServerURL = "<SERVERURL>";
+     ConfigurationNames = {"<CONFIGURATIONNAME>"};
+     };
+     
+     instance of MSFT_WebResourceManager as $MSFT_WebResourceManager1ref
+     {
+     SourceInfo = "C:\\\\OaaS-RegistrationMetaConfig2.ps1::27::9::ResourceRepositoryWeb";
+     ResourceID = "[ResourceRepositoryWeb]AzureAutomationDSC";
+     RegistrationKey = "<REGKEY>"; 
+     ServerURL = "<SERVERURL>";
+     };
+     
+     instance of MSFT_WebReportManager as $MSFT_WebReportManager1ref
+     {
+     SourceInfo = "C:\\\\OaaS-RegistrationMetaConfig2.ps1::34::9::ReportServerWeb";
+     ResourceID = "[ReportServerWeb]AzureAutomationDSC";
+     RegistrationKey = "<REGKEY>"; 
+     ServerURL = "<SERVERURL>";
+     };
+     
+     instance of MSFT_DSCMetaConfiguration as $MSFT_DSCMetaConfiguration1ref
+     {
+     RefreshMode = "<REFRESHMODE>";
+     AllowModuleOverwrite = False;
+     RefreshFrequencyMins = <REFRESHFREQUENCYMINS>;
+     RebootNodeIfNeeded = False;
+     ConfigurationModeFrequencyMins = <CONFIGURATIONMODEFREQUENCYMINS>;
+     ConfigurationMode = "<CONFIGURATIONMODE>";
+     
+     ResourceModuleManagers = {
+     $MSFT_WebResourceManager1ref  
+     };
+     ReportManagers = {
+     $MSFT_WebReportManager1ref  
+     };
+     ConfigurationDownloadManagers = {
+     $MSFT_WebDownloadManager1ref  
+     };
+     };
+     
+     instance of OMI_ConfigurationDocument
+     {
+     Version="2.0.0";
+     MinimumCompatibleVersion = "2.0.0";
+     CompatibleVersionAdditionalProperties= { "MSFT_DSCMetaConfiguration:StatusRetentionTimeInDays" };
+     Author="azureautomation";
+     Name="RegistrationMetaConfig";
+     };
+"""
+metaConfig = metaConfig.replace("<REFRESHMODE>", RefreshMode)
+metaConfig = metaConfig.replace("<REFRESHFREQUENCYMINS>", RefreshFrequencyMins)
+metaConfig = metaConfig.replace("<CONFIGURATIONMODEFREQUENCYMINS>", ConfigurationModeFrequencyMins)
+metaConfig = metaConfig.replace("<CONFIGURATIONMODE>", ConfigurationMode)
+metaConfig = metaConfig.replace("<SERVERURL>", ServerURL)
+metaConfig = metaConfig.replace("<REGKEY>", RegistrationKey)
+metaConfig = metaConfig.replace("<CONFIGURATIONNAME>", ConfigurationName)
+
+# Write to file and run SendMetaConfigurationApply.py
+tempdir = tempfile.mkdtemp()
+meta_path = tempdir + "/metaconf.mof"
+f = open(meta_path, "w")
+f.write(metaConfig)
+f.close()
+
+# Generate new cert if specified
+if RegenerateCert == True:
+   OAAS_CERTPATH="<OAAS_CERTPATH>"
+   OAAS_KEYPATH="<OAAS_KEYPATH>"
+   OAAS_THUMBPRINT="<OAAS_THUMBPRINT>"
+   os.system("touch " + OAAS_KEYPATH + "; chmod 0600 " + OAAS_KEYPATH);
+   os.system("touch " + OAAS_KEYPATH + "_old; chmod 0600 " + OAAS_KEYPATH + "_old");
+   os.system("openssl req -subj '/CN=DSC-OaaS' -new -newkey rsa:2048 -days 365 -nodes -x509 -keyout " + OAAS_KEYPATH + "_old -out " + OAAS_CERTPATH + " && openssl rsa -in " +  OAAS_KEYPATH + "_old -out " + OAAS_KEYPATH + " && rm -f " +  OAAS_KEYPATH + "_old");
+   os.system("openssl x509 -noout -in " + OAAS_CERTPATH + " -fingerprint | sed 's/^.*=//' > " + OAAS_THUMBPRINT);
+
+os.system("<DSC_SCRIPT_PATH>/SetDscLocalConfigurationManager.py -configurationmof " + meta_path)
+
+shutil.rmtree(tempdir)

--- a/LCM/scripts/python3/RegisterHelper.sh
+++ b/LCM/scripts/python3/RegisterHelper.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+NodeName=`hostname`
+
+IPAddress=`ip addr | grep 'inet' | awk '{print $2}' | sed 's/\/.*//' | tr "\n" ";" | cut -c 1-254`;
+
+RegistrationKey="$3"
+
+if [ -n "$4" ]; then
+    ConfigurationName="\"ConfigurationNames\":[\"$4\"],"
+else
+    ConfigurationName=""
+fi
+
+FriendlyName="DSC-OaaS Client Authentication"
+Issuer=`openssl x509 -text -in <OAAS_CERTPATH> | grep Issuer: | head -n 1 | awk '{print $2}'`
+NotAfter_pre=`openssl x509 -dates -in <OAAS_CERTPATH> | grep notAfter | sed 's/^.*=//'`
+NotAfter=`date --date="${NotAfter_pre}" +%Y-%m-%dT%T.%7N%:z`
+NotBefore_pre=`openssl x509 -dates -in <OAAS_CERTPATH> | grep notBefore | sed 's/^.*=//'`
+NotBefore=`date --date="${NotBefore_pre}" +%Y-%m-%dT%T.%7N%:z`
+Subject=`openssl x509 -text -in <OAAS_CERTPATH> | grep Subject: | head -n 1 | awk '{print $2}'`
+PublicKey=`openssl x509 -in <OAAS_CERTPATH> -pubkey -noout | awk 'NR>2 { print line } { line=$0 }' | tr -d "\n"`
+Thumbprint=`openssl x509 -noout -in <OAAS_CERTPATH> -fingerprint | sed 's/^.*=//' | tr -d :`
+
+if [ -n "$2" ]; then
+    RegistrationMessageType="$2"
+else
+    RegistrationMessageType="ConfigurationRepository"
+fi
+
+x_ms_date=`date --utc +%Y-%m-%dT%T.%7NZ | tr -d "\n"`
+
+requestBody="{\"AgentInformation\":{\"LCMVersion\":\"2.0\",\"NodeName\":\"$NodeName\",\"IPAddress\":\"$IPAddress\"},$ConfigurationName\"RegistrationInformation\":{\"CertificateInformation\":{\"FriendlyName\":\"$FriendlyName\",\"Issuer\":\"$Issuer\",\"NotAfter\":\"$NotAfter\",\"NotBefore\":\"$NotBefore\",\"Subject\":\"$Subject\",\"PublicKey\":\"$PublicKey\",\"Thumbprint\":\"$Thumbprint\",\"Version\":3},\"RegistrationMessageType\":\"$RegistrationMessageType\"}}"
+
+contentHash=`echo -n "$requestBody" | openssl dgst -binary -sha256 | openssl enc -base64 | tr -d "\n"`
+
+stringToSign=`printf "${contentHash}\n${x_ms_date}"`
+
+signature=`echo -n "$stringToSign" | openssl dgst -binary -sha256 -hmac "$RegistrationKey" | openssl enc -base64 | tr -d "\n"`
+
+if [ "$1" = "body" ]; then
+    printf "$requestBody"
+elif [ "$1" = "header" ]; then
+    echo "x-ms-date: $x_ms_date"
+    echo "Authorization: Shared $signature"
+else
+    echo "x-ms-date: $x_ms_date"
+    echo "Authorization: Shared $signature"
+    printf "$requestBody"
+fi
+

--- a/LCM/scripts/python3/RemoveModule.py
+++ b/LCM/scripts/python3/RemoveModule.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+import sys
+import os
+import subprocess
+import shutil
+import platform
+import imp
+from os.path import dirname, join, realpath
+
+pathToCurrentScript = realpath(__file__)
+pathToCommonScriptsFolder = dirname(pathToCurrentScript)
+helperLibPath = join(pathToCommonScriptsFolder, 'helperlib.py')
+helperlib = imp.load_source('helperlib', helperLibPath)
+fullPathDSCLogger = os.path.join(pathToCommonScriptsFolder, 'nxDSCLog.py')
+nxDSCLog = imp.load_source('nxDSCLog', fullPathDSCLogger)
+logger = nxDSCLog.ConsoleAndFileLogger()
+sys.stdout = logger
+
+def usage():
+    print("Usage:")
+    print("  RemoveModule.py NAME")
+    sys.exit(1)
+
+def exitWithError(message, errorCode = 1):
+    if (isinstance(message, bytes)):
+        message = message.decode()
+    errorMessage = "ERROR from RemoveModule.py: " + message
+    print(errorMessage)
+    sys.exit(errorCode)
+
+def printVerboseMessage(message):
+    if (isinstance(message, bytes)):
+        message = message.decode()
+    verboseMessage = "VERBOSE from RemoveModule.py: " + message
+    print(verboseMessage)
+
+def getPlatformArchitectureFolderName():
+    platformArchitecture = platform.architecture()
+    if len(platformArchitecture) != 2:
+        exitWithError("The python function platform.architecture() failed to return a valid tuple. Cannot detect if this system has an x64 or an x86 architecture.")
+
+    if (platformArchitecture[0] == "64bit"):
+        platformArchitectureFolderName = "x64"
+    else:
+        platformArchitectureFolderName = "x86"
+
+    return platformArchitectureFolderName
+
+def regenerateDscPythonScriptInitFiles():
+    regenerateInitFilesScriptPath = join(helperlib.DSC_SCRIPT_PATH, 'python3/RegenerateInitFiles.py')
+    regenerateInitFilesResult = subprocess.call(regenerateInitFilesScriptPath)
+    if regenerateInitFilesResult != 0:
+        exitWithError("Failed to regenerate the DSC __init__.py files with the result code " + regenerateInitFilesResult)
+
+def main(args):
+    '''
+    Removes all the resources in the named module from DSC and OMI.
+    '''
+
+    # Parameter validation
+    if len(args) != 1:
+        usage()
+
+    moduleName = args[0]
+    modulePath = join(helperlib.DSC_MODULES_PATH, moduleName)
+    
+    if os.path.isdir(modulePath):
+        printVerboseMessage("Found installed module " + moduleName + " at the path " + modulePath + ". Removing module.")
+    else:
+        exitWithError("Unable to find installed module " + moduleName + " at the path " + modulePath)
+
+    # TODO: Move this module-specifc section out of this generic script.
+    # Special section for nxOMSAutomationWorker module.
+    # The Linux Hybrid worker and manager needs to be killed before the module is removed.
+    # Also a good idea to remove the state and working directories.
+    if moduleName == "nxOMSAutomationWorker":
+        # Invoke deregister when it becomes available.
+        # Kill all processes running under the nxOMSAutomationWorker user.
+        # In some cases, there might be no processes to kill, and the return code of the following command might be non-zero.
+        # We make a best attempt to terminate the processes and don't care about its return code.
+        nxOMSAutomationWorkerUserName = "nxautomation"
+        subprocess.call(["sudo", "pkill", "-u", nxOMSAutomationWorkerUserName, ".*"])
+
+        # Remove the state directory for nxOMSAutomationWorker
+        nxOMSAutomationWorkerStateFolderPath = "/var/opt/microsoft/omsagent/state/automationworker"
+        shutil.rmtree(nxOMSAutomationWorkerStateFolderPath, ignore_errors=True)
+
+        # Remove the working directory for nxOMSAutomationWorker
+        nxOMSAutomationWorkerWorkingFolderPath = "/var/opt/microsoft/omsagent/run/automationworker"
+        shutil.rmtree(nxOMSAutomationWorkerWorkingFolderPath, ignore_errors=True)
+
+    # Populate common DSC paths
+    dscMainFolderPath = join(helperlib.CONFIG_SYSCONFDIR, helperlib.CONFIG_SYSCONFDIR_DSC)
+    dscConfigurationFolderPath = join (dscMainFolderPath, 'configuration')
+    dscConfigurationRegistrationFolderPath = join(dscConfigurationFolderPath, 'registration')
+    dscConfigurationSchemaFolderPath = join(dscConfigurationFolderPath, 'schema')
+
+    # Populate common OMI namespace path
+    omiNamespaceFolderName = helperlib.DSC_NAMESPACE.replace('/', '-')
+    omiRegistrationFolderPath = join(helperlib.CONFIG_SYSCONFDIR, 'omiregister')
+    omiNamespaceFolderPath = join(omiRegistrationFolderPath, omiNamespaceFolderName)
+
+    # Populate common platform architecture
+    resourceArchitectureFolderName = getPlatformArchitectureFolderName()
+
+    # Remove all the resources in the module from DSC and OMI
+    moduleResourcePath = join(modulePath, 'DSCResources')
+    moduleResources = os.listdir(moduleResourcePath)
+
+    for resource in moduleResources:
+        resourceFolderPath = join(moduleResourcePath, resource)
+
+        # Skip anything that is not a directory
+        if not os.path.isdir(resourceFolderPath):
+            continue
+
+        printVerboseMessage("Removing resource " + resource)
+
+        # Remove DSC schema for the resource
+        dscConfigurationSchemaFolderPath = join(dscConfigurationFolderPath, 'schema')
+        resourceDscSchemaFolderPath = join(dscConfigurationSchemaFolderPath, resource)
+
+        if os.path.isdir(resourceDscSchemaFolderPath):
+            shutil.rmtree(resourceDscSchemaFolderPath)
+        else:
+            printVerboseMessage("Unable to find DSC schema folder for resource " + resource + " at the path " + resourceDscSchemaFolderPath + ". Continuing with resource removal.")
+
+        # Remove DSC registration for the resource
+        resourceDscRegistrationFolderPath = join(dscConfigurationRegistrationFolderPath, resource)
+
+        if os.path.isdir(resourceDscRegistrationFolderPath):
+            shutil.rmtree(resourceDscRegistrationFolderPath)
+        else:
+            printVerboseMessage("Unable to find DSC registration folder for resource " + resource + " at the path " + resourceDscRegistrationFolderPath + ". Continuing with resource removal.")
+
+        # Remove the resource Python scripts from the DSC scripts directories
+        resourceLibraryFolderPath = join(resourceFolderPath, resourceArchitectureFolderName)
+        if not os.path.isdir(resourceLibraryFolderPath):
+            exitWithError("Unable to find the resource library folder for the " + resourceArchitectureFolderName + " architecture in the module at " + resourceLibraryFolderPath)
+
+        resourceScriptsFolderPath = join(resourceLibraryFolderPath, 'Scripts')
+        if not os.path.isdir(resourceLibraryFolderPath):
+            exitWithError("Unable to find the resource library scripts folder for the resource " + resource + " and platform architecture " + resourceArchitectureFolderName + " at the path " + resourceScriptsFolderPath + " in the extracted module.")
+
+
+        pythonVersionFileNames = ['2.4x-2.5x', '2.6x-2.7x', '3.x']
+
+        for pythonVersionFileName in pythonVersionFileNames:
+            resourceScriptsPythonVersionFolderPath = join(resourceScriptsFolderPath, pythonVersionFileName)
+            if not os.path.isdir(resourceScriptsPythonVersionFolderPath):
+                exitWithError("Unable to find the version-specific Python folder under the resource library scripts folder for the resource " + resource + " and platform architecture " + resourceArchitectureFolderName + " at the path " + resourceScriptsPythonVersionFolderPath + " in the extracted module.")
+
+            resourceScriptsPythonVersionScriptsFolderPath = join(resourceScriptsPythonVersionFolderPath, 'Scripts')
+            if not os.path.isdir(resourceScriptsPythonVersionScriptsFolderPath):
+                exitWithError("Unable to find the version-specific Python scripts folder under the resource library scripts folder for the resource " + resource + " and platform architecture " + resourceArchitectureFolderName + " at the path " + resourceScriptsPythonVersionScriptsFolderPath + " in the extracted module.")
+
+            resourceScriptFileNames = os.listdir(resourceScriptsPythonVersionScriptsFolderPath)
+
+            dscScriptsPythonVersionFolderPath = join(helperlib.DSC_SCRIPT_PATH, pythonVersionFileName)
+            dscScriptsPythonVersionScriptsFolderPath = join(dscScriptsPythonVersionFolderPath, 'Scripts')
+
+            for resourceScriptFileName in resourceScriptFileNames:
+                resourceScriptFilePath = join(dscScriptsPythonVersionScriptsFolderPath, resourceScriptFileName)
+                if os.path.isfile(resourceScriptFilePath):
+                    os.remove(resourceScriptFilePath)
+                else:
+                    printVerboseMessage("Unable to find resource script " + resourceScriptFileName + " under the DSC scripts folder at the path " + resourceScriptFilePath + ". Continuing with resource removal.")
+
+        # Remove OMI library file for the resource
+        resourceLibraryOriginalName = "lib" + resource + ".so"
+        
+        if helperlib.DSC_NAMESPACE == "root/Microsoft/DesiredStateConfiguration":
+            resourceLibraryFileName = resourceLibraryOriginalName
+        else:
+            resourceLibraryFileName = resourceLibraryOriginalName.replace('.so', "_" + omiNamespaceFolderName + ".so")
+
+        resourceLibraryFilePath = join(helperlib.CONFIG_LIBDIR, resourceLibraryFileName)
+
+        if os.path.isfile(resourceLibraryFilePath):
+            os.remove(resourceLibraryFilePath)
+        else:
+            printVerboseMessage("Unable to find OMI library file for resource " + resource + " at the path " + resourceLibraryFilePath + ". Continuing with resource removal.")
+        
+        # Remove OMSCONFIG library file for the resource
+        if "omsconfig" in helperlib.DSC_SCRIPT_PATH:
+            resourceSharedObjectDestinationPath = join("/opt/dsc/lib", resource)
+
+            if os.path.isdir(resourceSharedObjectDestinationPath):
+                shutil.rmtree(resourceSharedObjectDestinationPath)
+
+        # Remove OMI registration for the resource
+        resourceOmiRegistrationFileName = resource + ".reg"
+        resourceOmiRegistrationFilePath = join(omiNamespaceFolderPath, resourceOmiRegistrationFileName)
+        os.remove(resourceOmiRegistrationFilePath)
+
+    # Regenerate the DSC Python scripts init files
+    regenerateDscPythonScriptInitFiles()
+
+    # Remove the extracted module directory and everything in it   
+    shutil.rmtree(modulePath)
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/LCM/scripts/python3/RestoreConfiguration.py
+++ b/LCM/scripts/python3/RestoreConfiguration.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+import fileinput
+import sys
+import subprocess
+from imp                  import load_source
+from os.path              import dirname, isfile, join, realpath
+from fcntl                import flock, LOCK_EX, LOCK_UN, LOCK_NB
+from OmsConfigHostHelpers import write_omsconfig_host_telemetry, write_omsconfig_host_switch_event, write_omsconfig_host_log, stop_old_host_instances
+from time                 import sleep
+
+pathToCurrentScript = realpath(__file__)
+pathToCommonScriptsFolder = dirname(pathToCurrentScript)
+
+helperLibPath = join(pathToCommonScriptsFolder, 'helperlib.py')
+helperlib = load_source('helperlib', helperLibPath)
+
+omi_bindir = "<CONFIG_BINDIR>"
+omicli_path = omi_bindir + "/omicli"
+dsc_host_base_path = helperlib.DSC_HOST_BASE_PATH
+dsc_host_path = join(dsc_host_base_path, 'bin/dsc_host')
+dsc_host_output_path = join(dsc_host_base_path, 'output')
+dsc_host_lock_path = join(dsc_host_base_path, 'dsc_host_lock')
+dsc_host_switch_path = join(dsc_host_base_path, 'dsc_host_ready')
+
+if ("omsconfig" in helperlib.DSC_SCRIPT_PATH):
+    write_omsconfig_host_switch_event(pathToCurrentScript, isfile(dsc_host_switch_path))
+
+if ("omsconfig" in helperlib.DSC_SCRIPT_PATH) and (isfile(dsc_host_switch_path)):
+    use_omsconfig_host = True
+else:
+    use_omsconfig_host = False
+
+parameters = []
+if use_omsconfig_host:
+    parameters.append(dsc_host_path)
+    parameters.append(dsc_host_output_path)
+    parameters.append("RollBack")
+else:
+    parameters.append(omicli_path)
+    parameters.append("iv")
+    parameters.append("<DSC_NAMESPACE>")
+    parameters.append("{")
+    parameters.append("MSFT_DSCLocalConfigurationManager")
+    parameters.append("}")
+    parameters.append("RollBack")
+
+stdout = ''
+stderr = ''
+
+if use_omsconfig_host:
+    try:
+        stop_old_host_instances(dsc_host_lock_path)
+
+        # Open the dsc host lock file. This also creates a file if it does not exist
+        dschostlock_filehandle = open(dsc_host_lock_path, 'w')
+        print("Opened the dsc host lock file at the path '" + dsc_host_lock_path + "'")
+        
+        dschostlock_acquired = False
+
+        # Acquire dsc host file lock
+        for retry in range(10):
+            try:
+                flock(dschostlock_filehandle, LOCK_EX | LOCK_NB)
+                dschostlock_acquired = True
+                break
+            except IOError:
+                write_omsconfig_host_log('dsc_host lock file not acquired. retry (#' + str(retry) + ') after 60 seconds...', pathToCurrentScript)
+                sleep(60)
+
+        if dschostlock_acquired:
+            p = subprocess.Popen(parameters, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            stdout, stderr = p.communicate()
+            stdout = stdout.decode() if isinstance(stdout, bytes) else stdout
+            print(stdout)
+        else:
+            print("dsc host lock already acuired by a different process")
+    finally:
+        if (dschostlock_filehandle):
+            # Release dsc host file lock
+            flock(dschostlock_filehandle, LOCK_UN)
+
+            # Close dsc host lock file handle
+            dschostlock_filehandle.close()
+else:
+    p = subprocess.Popen(parameters, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = p.communicate()
+stdout = stdout.decode() if isinstance(stdout, bytes) else stdout
+stderr = stderr.decode() if isinstance(stderr, bytes) else stderr
+print(stdout)
+print(stderr)

--- a/LCM/scripts/python3/SetDscLocalConfigurationManager.py
+++ b/LCM/scripts/python3/SetDscLocalConfigurationManager.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+from imp                  import load_source
+from os.path              import dirname, isfile, join, realpath
+from subprocess           import PIPE, Popen
+from sys                  import argv, exc_info, exit, version_info
+from traceback            import format_exc
+from fcntl                import flock, LOCK_EX, LOCK_UN, LOCK_NB
+from OmsConfigHostHelpers import write_omsconfig_host_telemetry, write_omsconfig_host_switch_event, write_omsconfig_host_log, stop_old_host_instances
+from time                 import sleep
+import codecs 
+
+pathToCurrentScript = realpath(__file__)
+pathToCommonScriptsFolder = dirname(pathToCurrentScript)
+
+helperLibPath = join(pathToCommonScriptsFolder, 'helperlib.py')
+helperlib = load_source('helperlib', helperLibPath)
+
+operationStatusUtilityPath = join(pathToCommonScriptsFolder, 'OperationStatusUtility.py')
+operationStatusUtility = load_source('operationStatusUtility', operationStatusUtilityPath)
+
+operation = 'SetLCM'
+
+def usage():
+    print("Usage:")
+    print("    " + argv[0] + " -configurationmof FILE")
+    write_omsconfig_host_log('Incorrect parameters to SetDscLocalConfigurationManager.py: ' + str(argv), pathToCurrentScript, 'WARNING')
+    exit(1)
+
+def main(args):
+    try:
+        apply_meta_config(args)
+    except SystemExit:
+        exit(exc_info()[1])
+    except Exception:
+        # Python 2.4-2.7 and 2.6-3 recognize different formats for exceptions. This methods works in all versions.
+        formattedExceptionMessage = format_exc()
+        write_omsconfig_host_log('Python exception raised from SetDscLocalConfigurationManager.py: ' + formattedExceptionMessage, pathToCurrentScript, 'ERROR')
+        raise
+
+def apply_meta_config(args):
+    if len(args) != 3:
+        usage()
+
+
+
+    if args[1].lower() != '-configurationmof':
+        usage()
+
+    if (not isfile(args[2])):
+        errorMessage = 'The provided configurationmof file does not exist: ' + str(args[2])
+        print(errorMessage)
+        write_omsconfig_host_log('Incorrect parameters to SetDscLocalConfigurationManager.py: ' + errorMessage, pathToCurrentScript, 'ERROR')
+        exit(1)
+
+    fileHandle = open(args[2], 'rb')
+    try:
+        fileContent = fileHandle.read()
+        outtokens = []
+        for char in fileContent:
+            outtokens.append(str(ord(char)))
+
+        omicli_path = join(helperlib.CONFIG_BINDIR, 'omicli')
+        dsc_host_base_path = helperlib.DSC_HOST_BASE_PATH
+        dsc_host_path = join(dsc_host_base_path, 'bin/dsc_host')
+        dsc_host_output_path = join(dsc_host_base_path, 'output')
+        dsc_host_lock_path = join(dsc_host_base_path, 'dsc_host_lock')
+        dsc_host_switch_path = join(dsc_host_base_path, 'dsc_host_ready')
+
+        if ("omsconfig" in helperlib.DSC_SCRIPT_PATH):
+            write_omsconfig_host_switch_event(pathToCurrentScript, isfile(dsc_host_switch_path))
+
+        if ("omsconfig" in helperlib.DSC_SCRIPT_PATH) and (isfile(dsc_host_switch_path)):
+            use_omsconfig_host = True
+        else:
+            use_omsconfig_host = False
+
+        parameters = []
+
+        if use_omsconfig_host:
+            parameters.append(dsc_host_path)
+            parameters.append(dsc_host_output_path)
+            parameters.append("SendMetaConfigurationApply")
+            parameters.append(args[2])
+        else:
+            parameters.append(omicli_path)
+            parameters.append("iv")
+            parameters.append(helperlib.DSC_NAMESPACE)
+            parameters.append("{")
+            parameters.append("MSFT_DSCLocalConfigurationManager")
+            parameters.append("}")
+            parameters.append("SendMetaConfigurationApply")
+            parameters.append("{")
+            parameters.append("ConfigurationData")
+            parameters.append("[")
+            # Insert configurationmof data here
+            for token in outtokens:
+                parameters.append(token)
+            parameters.append("]")
+            parameters.append("}")
+
+        exit_code = 0
+        stdout = ''
+        stderr = ''
+
+        # Apply the metaconfig
+        if use_omsconfig_host:
+            try:
+                dschostlock_filehandle = None
+                stop_old_host_instances(dsc_host_lock_path)
+
+                # Open the dsc host lock file. This also creates a file if it does not exist
+                dschostlock_filehandle = open(dsc_host_lock_path, 'w')
+                print("Opened the dsc host lock file at the path '" + dsc_host_lock_path + "'")
+                
+                dschostlock_acquired = False
+
+                # Acquire dsc host file lock
+                for retry in range(10):
+                    try:
+                        flock(dschostlock_filehandle, LOCK_EX | LOCK_NB)
+                        write_omsconfig_host_log('dsc_host lock file is acquired by : SendMetaConfigurationApply', pathToCurrentScript)
+                        dschostlock_acquired = True
+                        break
+                    except IOError:
+                        write_omsconfig_host_log('dsc_host lock file not acquired. retry (#' + str(retry) + ') after 60 seconds...', pathToCurrentScript)
+                        sleep(60)
+
+                if dschostlock_acquired:
+                    p = Popen(parameters, stdout=PIPE, stderr=PIPE)
+                    exit_code = p.wait()
+                    stdout, stderr = p.communicate()
+                    stdout = stdout.decode() if isinstance(stdout, bytes) else stdout
+                    print(stdout)
+                else:
+                    print("dsc host lock already acuired by a different process")
+            finally:
+                if dschostlock_filehandle:
+                    # Release dsc host file lock
+                    flock(dschostlock_filehandle, LOCK_UN)
+
+                    # Close dsc host lock file handle
+                    dschostlock_filehandle.close()
+        else:
+            p = Popen(parameters, stdout=PIPE, stderr=PIPE)
+            exit_code = p.wait()
+            stdout, stderr = p.communicate()
+
+        stdout = stdout.decode() if isinstance(stdout, bytes) else stdout
+        print(stdout)
+
+        if ((exit_code != 0) or (stderr)):
+            exit(1)
+
+    finally:
+        fileHandle.close()
+
+if __name__ == "__main__":
+    main(argv)

--- a/LCM/scripts/python3/StartDscConfiguration.py
+++ b/LCM/scripts/python3/StartDscConfiguration.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+
+# Standard library imports
+from subprocess           import Popen, PIPE
+from sys                  import argv
+from imp                  import load_source
+from os.path              import dirname, isfile, join, realpath
+from fcntl                import flock, LOCK_EX, LOCK_UN, LOCK_NB
+from OmsConfigHostHelpers import write_omsconfig_host_telemetry, write_omsconfig_host_switch_event, write_omsconfig_host_log, stop_old_host_instances
+from time                 import sleep
+import subprocess
+import codecs 
+
+
+pathToCurrentScript = realpath(__file__)
+pathToCommonScriptsFolder = dirname(pathToCurrentScript)
+
+helperLibPath = join(pathToCommonScriptsFolder, 'helperlib.py')
+helperlib = load_source('helperlib', helperLibPath)
+
+try:
+    # Used by Python 2.7+
+    from argparse import ArgumentParser
+    useArgParse = True
+except:
+    # Used by Python 2.4-2.6
+    from optparse import OptionParser
+    useArgParse = False
+
+def main(argv):
+    """StartDscConfiguration"""
+
+    # Define method arguments and description
+    description = 'Starts the specified DSC configuration.'
+
+    parameters = {
+        'configurationmof' : {
+            'shortForm' : 'c',
+            'helpText' : 'The path to the configuration mof to start.',
+            'required' : True,
+            'action' : 'store'
+        },
+        'force' : {
+            'shortForm' : 'f',
+            'helpText' : 'Specifies that any current pending configuration should be forcibly removed before starting the new configuration.',
+            'required' : False,
+            'action' : 'store_true'
+        }
+    }
+
+    # Parse -configurationmof on its own for backwards compatibility
+    configmofArgument = None
+    if '-configurationmof' in argv:
+        configmofIndex = argv.index('-configurationmof')
+
+        try:
+            configmofArgument = argv[configmofIndex + 1]
+        except:
+            print('StartDscConfiguration.py: error: Please provide a valid path argument for -configurationmof')
+            exit(1)
+
+        # Set the configuration mof parameter to no longer be required so it doesn't error in the arugment parser
+        parameters['configurationmof']['required'] = False 
+
+        # Remove -configurationmof and its argument from the list so it doesn't error in the arugment parser
+        argv.pop(configmofIndex)
+        argv.pop(configmofIndex)
+
+    # Parse arguments
+    if (useArgParse):
+        # Used by Python 2.7+
+        parser = ArgumentParser(description = description)
+
+        for parameter in parameters.keys():
+            parameterInfo = parameters[parameter]
+            parser.add_argument('-' + parameterInfo['shortForm'], '--' + parameter, required = parameterInfo['required'], help = parameterInfo['helpText'], action = parameterInfo['action'])
+
+        parsedArguments = parser.parse_args(argv)
+    else:
+        # Used by Python 2.4-2.6
+        parser = OptionParser(description = description)
+
+        for parameter in parameters.keys():
+            parameterInfo = parameters[parameter]
+            parser.add_option('-' + parameterInfo['shortForm'], '--' + parameter, help = parameterInfo['helpText'], action = parameterInfo['action'])
+
+        (parsedArguments, extraArguments) = parser.parse_args(argv)
+
+        for parameter in parameters.keys():
+            if parameters[parameter]['required']:
+                if not getattr(parsedArguments, parameter):
+                    print ('StartDscConfiguration.py: error: argument -', parameters[parameter]['shortForm'], '/--', parameter, ' is required.')
+                    exit(1)
+
+    # Check that we don't have two configuration mofs defined
+    if configmofArgument and parsedArguments.configurationmof:
+        print('StartDscConfiguration.py: error: Two configuration mof arguments were found. Please provide only one.')
+        exit(1)
+    
+    if configmofArgument:
+        parsedArguments.configurationmof = configmofArgument
+
+    # Read the configuration mof
+    try:
+        configurationFile = codecs.open(parsedArguments.configurationmof, 'r', encoding= 'utf-16')
+    except:
+        configurationFile = codecs.open(parsedArguments.configurationmof, 'r', encoding = 'utf-16')
+
+    try:
+        configurationFileContent = configurationFile.read()
+    finally:
+        if (configurationFile):
+            configurationFile.close()
+
+    # Convert the file content to strings of integers representing unicode
+    configurationData = []
+    for char in configurationFileContent:
+        configurationData.append(str(ord(char)))
+
+    # # OMI CLI location
+    omiBinDir = "<CONFIG_BINDIR>"
+    omiCliPath = omiBinDir + "/omicli"
+    dsc_host_base_path = helperlib.DSC_HOST_BASE_PATH
+    dsc_host_path = join(dsc_host_base_path, 'bin/dsc_host')
+    dsc_host_output_path = join(dsc_host_base_path, 'output')
+    dsc_host_lock_path = join(dsc_host_base_path, 'dsc_host_lock')
+    dsc_host_switch_path = join(dsc_host_base_path, 'dsc_host_ready')
+
+    if ("omsconfig" in helperlib.DSC_SCRIPT_PATH):
+        write_omsconfig_host_switch_event(pathToCurrentScript, isfile(dsc_host_switch_path))
+
+    if ("omsconfig" in helperlib.DSC_SCRIPT_PATH) and (isfile(dsc_host_switch_path)):
+        use_omsconfig_host = True
+    else:
+        use_omsconfig_host = False
+
+    # Assemble parameters to pass to OMI CLI
+    host_parameters = []
+    if use_omsconfig_host:
+        host_parameters.append(dsc_host_path)
+        host_parameters.append(dsc_host_output_path)
+        host_parameters.append("SendConfigurationApply")
+        host_parameters.append(args[2])
+        # Insert force if specified
+        if parsedArguments.force:
+            host_parameters.append("force")
+    else:
+        host_parameters.append(omiCliPath)
+        host_parameters.append("iv")
+        host_parameters.append("<DSC_NAMESPACE>")
+        host_parameters.append("{")
+        host_parameters.append("MSFT_DSCLocalConfigurationManager")
+        host_parameters.append("}")
+        host_parameters.append("SendConfigurationApply")
+        host_parameters.append("{")
+        host_parameters.append("ConfigurationData")
+        host_parameters.append("[")
+
+        # Insert configurationmof data here
+        for token in configurationData:
+            host_parameters.append(token)
+        
+        host_parameters.append("]")
+
+        # Insert force if specified
+        if parsedArguments.force:
+            host_parameters.append("force")
+            host_parameters.append("true")
+
+        host_parameters.append("}")
+
+    stdout = ''
+    stderr = ''
+
+    if use_omsconfig_host:
+        try:
+            stop_old_host_instances(dsc_host_lock_path)
+
+            # Open the dsc host lock file. This also creates a file if it does not exist
+            dschostlock_filehandle = open(dsc_host_lock_path, 'w')
+            print("Opened the dsc host lock file at the path '" + dsc_host_lock_path + "'")
+            
+            dschostlock_acquired = False
+
+            # Acquire dsc host file lock
+            for retry in range(10):
+                try:
+                    flock(dschostlock_filehandle, LOCK_EX | LOCK_NB)
+                    dschostlock_acquired = True
+                    break
+                except IOError:
+                    write_omsconfig_host_log('dsc_host lock file not acquired. retry (#' + str(retry) + ') after 60 seconds...', pathToCurrentScript)
+                    sleep(60)
+
+            if dschostlock_acquired:
+                p = subprocess.Popen(parameters, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                stdout, stderr = p.communicate()
+                stdout = stdout.decode() if isinstance(stdout, bytes) else stdout
+                print(stdout)
+            else:
+                print("dsc host lock already acuired by a different process")
+        finally:
+            if (dschostlock_filehandle):
+                # Release dsc host file lock
+                flock(dschostlock_filehandle, LOCK_UN)
+
+                # Close dsc host lock file handle
+                dschostlock_filehandle.close()
+    else:
+        p = subprocess.Popen(parameters, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = p.communicate()
+
+    stdout = stdout.decode() if isinstance(stdout, bytes) else stdout
+    stderr = stderr.decode() if isinstance(stderr, bytes) else stderr
+    print(stdout)   
+    print(stderr)
+
+main(argv[1:])

--- a/LCM/scripts/python3/StatusReport.sh
+++ b/LCM/scripts/python3/StatusReport.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# $0 JobId (StartTime|EndTime) [ErrorMessage [SourceInfo ModuleName DurationInSeconds InstanceName StartDate ResourceName ModuleVersion RebootRequested ResourceId ConfigurationName InDesiredState]]
+
+curDate=`date +%Y-%m-%dT%T.%N%:z`
+ErrorMessage=""
+Errors=""
+RNIDS=""
+
+if [ "$2" = "EndTime" ]; then
+    if [ -n "$3" ]; then
+        ErrorMessage="\"{\\\"Locale\\\":\\\"en-US\\\",\\\"ErrorCode\\\":\\\"1\\\",\\\"ErrorMessage\\\":\\\"$3\\\",\\\"ResourceId\\\":\\\"DSCEngine\\\",\\\"ErrorSource\\\":\\\"DSCEngine\\\"}\""
+        Errors=",\\\"Error\\\":\\\"$3\\\""
+        if [ -n "${14}" ]; then
+            RNIDS="{\\\"SourceInfo\\\":\\\"$4\\\",\\\"ModuleName\\\":\\\"$5\\\",\\\"DurationInSeconds\\\":\\\"0\\\",\\\"InstanceName\\\":\\\"$7\\\",\\\"StartDate\\\":\\\"$curDate\\\",\\\"ResourceName\\\":\\\"$9\\\",\\\"ModuleVersion\\\":\\\"${10}\\\",\\\"RebootRequested\\\":\\\"${11}\\\",\\\"ResourceId\\\":\\\"${12}\\\",\\\"ConfigurationName\\\":\\\"${13}\\\",\\\"InDesiredState\\\":\\\"${14}\\\"}"
+        else
+            RNIDS="{\\\"SourceInfo\\\":\\\"(null)\\\",\\\"ModuleName\\\":\\\"PsDesiredStateConfiguration\\\",\\\"DurationInSeconds\\\":\\\"0\\\",\\\"InstanceName\\\":\\\"LCM\\\",\\\"StartDate\\\":\\\"$curDate\\\",\\\"ResourceName\\\":\\\"(null)\\\",\\\"ModuleVersion\\\":\\\"1.1\\\",\\\"RebootRequested\\\":\\\"False\\\",\\\"ResourceId\\\":\\\"[DSC]LCM\\\",\\\"ConfigurationName\\\":\\\"(null)\\\",\\\"InDesiredState\\\":\\\"False\\\"}"
+        fi
+        output="{\"JobId\":\"$1\",\"ConfigurationVersion\":\"2.0.0\",\"ReportFormatVersion\":\"2.0\",\"LCMVersion\":\"2.0\",\"EndTime\":\"$curDate\",\"Errors\":[$ErrorMessage],\"StatusData\":[\"{\\\"Locale\\\":\\\"en-US\\\",\\\"ResourcesNotInDesiredState\\\":[$RNIDS]$Errors}\"]}"
+    else
+        output="{\"JobId\":\"$1\",\"ConfigurationVersion\":\"2.0.0\",\"ReportFormatVersion\":\"2.0\",\"LCMVersion\":\"2.0\",\"EndTime\":\"$curDate\",\"Errors\":[$ErrorMessage],\"StatusData\":[\"{\\\"Locale\\\":\\\"en-US\\\"}\"]}"
+    fi
+else
+    IPAddress=`ip addr | grep 'inet' | awk '{print $2}' | sed 's/\/.*//' | tr "\n" ";" | cut -c 1-254`
+    NodeName=`hostname`
+    output="{\"JobId\":\"$1\",\"OperationType\":\"Consistency\",\"NodeName\":\"$NodeName\",\"IpAddress\":\"$IPAddress\",\"ReportFormatVersion\":\"2.0\",\"LCMVersion\":\"2.0\",\"StartTime\":\"$curDate\",\"Errors\":[],\"StatusData\":[\"{\\\"Locale\\\":\\\"en-US\\\"}\"]}"
+
+fi
+
+echo $output > <CONFIG_SYSCONFDIR>/<CONFIG_SYSCONFDIR_DSC>/last_statusreport
+echo $output

--- a/LCM/scripts/python3/TestDscConfiguration.py
+++ b/LCM/scripts/python3/TestDscConfiguration.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+import fileinput
+import sys
+import subprocess
+from OmsConfigHostHelpers import write_omsconfig_host_telemetry, write_omsconfig_host_switch_event, write_omsconfig_host_log, stop_old_host_instances
+from imp                  import load_source
+from os.path              import dirname, isfile, join, realpath
+from time                 import sleep
+from fcntl                import flock, LOCK_EX, LOCK_UN, LOCK_NB
+
+pathToCurrentScript = realpath(__file__)
+pathToCommonScriptsFolder = dirname(pathToCurrentScript)
+
+helperLibPath = join(pathToCommonScriptsFolder, 'helperlib.py')
+helperlib = load_source('helperlib', helperLibPath)
+
+omi_bindir = "<CONFIG_BINDIR>"
+omicli_path = omi_bindir + "/omicli"
+dsc_host_base_path = helperlib.DSC_HOST_BASE_PATH
+dsc_host_path = join(dsc_host_base_path, 'bin/dsc_host')
+dsc_host_output_path = join(dsc_host_base_path, 'output')
+dsc_host_lock_path = join(dsc_host_base_path, 'dsc_host_lock')
+dsc_host_switch_path = join(dsc_host_base_path, 'dsc_host_ready')
+
+if ("omsconfig" in helperlib.DSC_SCRIPT_PATH):
+    write_omsconfig_host_switch_event(pathToCurrentScript, isfile(dsc_host_switch_path))
+
+if ("omsconfig" in helperlib.DSC_SCRIPT_PATH) and (isfile(dsc_host_switch_path)):
+    use_omsconfig_host = True
+else:
+    use_omsconfig_host = False
+
+parameters = []
+if use_omsconfig_host:
+    parameters.append(dsc_host_path)
+    parameters.append(dsc_host_output_path)
+    parameters.append("TestConfiguration")
+else:
+    parameters.append(omicli_path)
+    parameters.append("iv")
+    parameters.append("<DSC_NAMESPACE>")
+    parameters.append("{")
+    parameters.append("MSFT_DSCLocalConfigurationManager")
+    parameters.append("}")
+    parameters.append("TestConfiguration")
+
+stdout = ''
+stderr = ''
+
+if use_omsconfig_host:
+    if isfile(dsc_host_lock_path):
+        try:
+            dschostlock_filehandle = None
+            stop_old_host_instances(dsc_host_lock_path)
+
+            # Open the dsc host lock file. This also creates a file if it does not exist
+            dschostlock_filehandle = open(dsc_host_lock_path, 'w')
+            print("Opened the dsc host lock file at the path '" + dsc_host_lock_path + "'")
+            
+            dschostlock_acquired = False
+
+            # Acquire dsc host file lock
+            for retry in range(10):
+                try:
+                    flock(dschostlock_filehandle, LOCK_EX | LOCK_NB)
+                    write_omsconfig_host_log('dsc_host lock file is acquired by : TestConfiguration', pathToCurrentScript)
+                    dschostlock_acquired = True
+                    break
+                except IOError:
+                    write_omsconfig_host_log('dsc_host lock file not acquired. retry (#' + str(retry) + ') after 60 seconds...', pathToCurrentScript)
+                    sleep(60)
+
+            if dschostlock_acquired:
+                p = subprocess.Popen(parameters, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                stdout, stderr = p.communicate()
+                exit_code = p.wait()
+                stdout = stdout.decode() if isinstance(stdout, bytes) else stdout
+                print(stdout)
+
+                if (exit_code > 0):
+                    write_omsconfig_host_log('dsc_host failed with code = ' + str(exit_code), pathToCurrentScript)
+                    exit(exit_code)
+            else:
+                print("dsc host lock already acuired by a different process")
+        finally:
+            if (dschostlock_filehandle):
+                # Release dsc host file lock
+                flock(dschostlock_filehandle, LOCK_UN)
+
+                # Close dsc host lock file handle
+                dschostlock_filehandle.close()
+    else:
+        write_omsconfig_host_log('dsc_host lock file does not exist. Skipping this operation until next consistency hits.', pathToCurrentScript, 'WARNING')
+else:
+    p = subprocess.Popen(parameters, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = p.communicate()
+
+stdout = stdout.decode() if isinstance(stdout, bytes) else stdout
+stderr = stderr.decode() if isinstance(stderr, bytes) else stderr
+print(stdout)
+print(stderr)
+
+

--- a/LCM/scripts/python3/omi_preexec.sh
+++ b/LCM/scripts/python3/omi_preexec.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+if [ ! -f /etc/opt/omi/conf/dsc/configuration/schema/MSFT_nxFileResource/MSFT_nxFileResource.schema.mof -o ! -f /opt/microsoft/dsc/Scripts/2.6x-2.7x/Scripts/nxFile.py -o ! -f /opt/omi/lib/libMSFT_nxFileResource.so ]; then
+    /opt/microsoft/dsc/Scripts/InstallModule.py /opt/microsoft/dsc/module_packages/nx_1.0.zip 0
+fi
+exit 0

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ endif
 all:
 	rm -rf release/*.rpm release/*.deb
 	mkdir -p intermediate/Scripts
+	mkdir -p intermediate/Scripts/python3
 	mkdir -p intermediate/Modules
 ifeq ($(BUILD_LOCAL),1)
 	$(MAKE) local
@@ -96,6 +97,7 @@ endif
 
 dsc098: lcm098 providers
 	mkdir -p intermediate/Scripts
+	mkdir -p intermediate/Scripts/python3
 	mkdir -p intermediate/Modules
 	.  omi-1.0.8/output_openssl_0.9.8/config.mak; \
 	for f in LCM/scripts/*.py LCM/scripts/*.sh Providers/Scripts/*.py Providers/Scripts/*.sh; do \
@@ -116,11 +118,30 @@ dsc098: lcm098 providers
 	  sed "s@<DSC_MODULES_PATH>@$(DSC_MODULES_PATH)@" > intermediate/Scripts/`basename $$f`; \
 	  chmod a+x intermediate/Scripts/`basename $$f`; \
 	done
+	for f in LCM/scripts/python3/*.py LCM/scripts/python3/*.sh; do \
+	  cat $$f | \
+	  sed "s@<CONFIG_BINDIR>@$$CONFIG_BINDIR@" | \
+	  sed "s@<CONFIG_LIBDIR>@$$CONFIG_LIBDIR@" | \
+	  sed "s@<CONFIG_LOCALSTATEDIR>@$$CONFIG_LOCALSTATEDIR@" | \
+	  sed "s@<CONFIG_SYSCONFDIR>@$$CONFIG_SYSCONFDIR@" | \
+	  sed "s@<CONFIG_SYSCONFDIR_DSC>@$(CONFIG_SYSCONFDIR_DSC)@" | \
+	  sed "s@<OAAS_CERTPATH>@$(OAAS_CERTPATH)@" | \
+	  sed "s@<OAAS_KEYPATH>@$(OAAS_KEYPATH)@" | \
+	  sed "s@<OAAS_THUMBPRINT>@$(OAAS_THUMBPRINT)@" | \
+	  sed "s@<OMI_LIB_SCRIPTS>@$$CONFIG_LIBDIR/Scripts@" | \
+	  sed "s@<PYTHON_PID_DIR>@$(PYTHON_PID_DIR)@" | \
+	  sed "s@<DSC_NAMESPACE>@$(DSC_NAMESPACE)@" | \
+	  sed "s@<DSC_SCRIPT_PATH>@$(DSC_SCRIPT_PATH)@" | \
+	  sed "s@<DSC_HOST_BASE_PATH>@$(DSC_HOST_BASE_PATH)@" | \
+	  sed "s@<DSC_MODULES_PATH>@$(DSC_MODULES_PATH)@" > intermediate/Scripts/python3/`basename $$f`; \
+	  chmod a+x intermediate/Scripts/python3/`basename $$f`; \
+	done
 	if [ -f ../dsc.version ]; then cp -f ../dsc.version build/dsc.version; else cp -f build/Makefile.version build/dsc.version; fi
 
 
 dsc100: lcm100 providers
 	mkdir -p intermediate/Scripts
+	mkdir -p intermediate/Scripts/python3
 	mkdir -p intermediate/Modules
 	.  omi-1.0.8/output_openssl_1.0.0/config.mak; \
 	for f in LCM/scripts/*.py LCM/scripts/*.sh Providers/Scripts/*.py Providers/Scripts/*.sh; do \
@@ -141,10 +162,29 @@ dsc100: lcm100 providers
 	  sed "s@<DSC_MODULES_PATH>@$(DSC_MODULES_PATH)@" > intermediate/Scripts/`basename $$f`; \
 	  chmod a+x intermediate/Scripts/`basename $$f`; \
 	done
+	for f in LCM/scripts/python3/*.py LCM/scripts/python3/*.sh; do \
+	  cat $$f | \
+	  sed "s@<CONFIG_BINDIR>@$$CONFIG_BINDIR@" | \
+	  sed "s@<CONFIG_LIBDIR>@$$CONFIG_LIBDIR@" | \
+	  sed "s@<CONFIG_LOCALSTATEDIR>@$$CONFIG_LOCALSTATEDIR@" | \
+	  sed "s@<CONFIG_SYSCONFDIR>@$$CONFIG_SYSCONFDIR@" | \
+	  sed "s@<CONFIG_SYSCONFDIR_DSC>@$(CONFIG_SYSCONFDIR_DSC)@" | \
+	  sed "s@<OAAS_CERTPATH>@$(OAAS_CERTPATH)@" | \
+	  sed "s@<OAAS_KEYPATH>@$(OAAS_KEYPATH)@" | \
+	  sed "s@<OAAS_THUMBPRINT>@$(OAAS_THUMBPRINT)@" | \
+	  sed "s@<OMI_LIB_SCRIPTS>@$$CONFIG_LIBDIR/Scripts@" | \
+	  sed "s@<PYTHON_PID_DIR>@$(PYTHON_PID_DIR)@" | \
+	  sed "s@<DSC_NAMESPACE>@$(DSC_NAMESPACE)@" | \
+	  sed "s@<DSC_SCRIPT_PATH>@$(DSC_SCRIPT_PATH)@" | \
+	  sed "s@<DSC_HOST_BASE_PATH>@$(DSC_HOST_BASE_PATH)@" | \
+	  sed "s@<DSC_MODULES_PATH>@$(DSC_MODULES_PATH)@" > intermediate/Scripts/python3/`basename $$f`; \
+	  chmod a+x intermediate/Scripts/python3/`basename $$f`; \
+	done
 	if [ -f ../dsc.version ]; then cp -f ../dsc.version build/dsc.version; else cp -f build/Makefile.version build/dsc.version; fi
 
 dsc110: lcm110 providers
 	mkdir -p intermediate/Scripts
+	mkdir -p intermediate/Scripts/python3
 	mkdir -p intermediate/Modules
 	.  omi-1.0.8/output_openssl_1.1.0/config.mak; \
 	for f in LCM/scripts/*.py LCM/scripts/*.sh Providers/Scripts/*.py Providers/Scripts/*.sh; do \
@@ -166,6 +206,24 @@ dsc110: lcm110 providers
 	  chmod a+x intermediate/Scripts/`basename $$f`; \
 	done
 
+	for f in LCM/scripts/python3/*.py LCM/scripts/python3/*.sh; do \
+	  cat $$f | \
+	  sed "s@<CONFIG_BINDIR>@$$CONFIG_BINDIR@" | \
+	  sed "s@<CONFIG_LIBDIR>@$$CONFIG_LIBDIR@" | \
+	  sed "s@<CONFIG_LOCALSTATEDIR>@$$CONFIG_LOCALSTATEDIR@" | \
+	  sed "s@<CONFIG_SYSCONFDIR>@$$CONFIG_SYSCONFDIR@" | \
+	  sed "s@<CONFIG_SYSCONFDIR_DSC>@$(CONFIG_SYSCONFDIR_DSC)@" | \
+	  sed "s@<OAAS_CERTPATH>@$(OAAS_CERTPATH)@" | \
+	  sed "s@<OAAS_KEYPATH>@$(OAAS_KEYPATH)@" | \
+	  sed "s@<OAAS_THUMBPRINT>@$(OAAS_THUMBPRINT)@" | \
+	  sed "s@<OMI_LIB_SCRIPTS>@$$CONFIG_LIBDIR/Scripts@" | \
+	  sed "s@<PYTHON_PID_DIR>@$(PYTHON_PID_DIR)@" | \
+	  sed "s@<DSC_NAMESPACE>@$(DSC_NAMESPACE)@" | \
+	  sed "s@<DSC_SCRIPT_PATH>@$(DSC_SCRIPT_PATH)@" | \
+	  sed "s@<DSC_HOST_BASE_PATH>@$(DSC_HOST_BASE_PATH)@" | \
+	  sed "s@<DSC_MODULES_PATH>@$(DSC_MODULES_PATH)@" > intermediate/Scripts/python3/`basename $$f`; \
+	  chmod a+x intermediate/Scripts/python3/`basename $$f`; \
+	done
 	if [ -f ../dsc.version ]; then cp -f ../dsc.version build/dsc.version; else cp -f build/Makefile.version build/dsc.version; fi
 
 
@@ -646,7 +704,7 @@ endif
 
 
 # To build DSC without making kits (i.e. the old style), run 'make local'
-local: 
+local:
 	rm -rf release/*.rpm release/*.deb
 	mkdir -p intermediate/Scripts
 	mkdir -p intermediate/Modules
@@ -679,5 +737,23 @@ providersreg:
 	  sed "s@<DSC_HOST_BASE_PATH>@$(DSC_HOST_BASE_PATH)@" | \
 	  sed "s@<DSC_MODULES_PATH>@$(CONFIG_DATADIR)/dsc/modules@" > intermediate/Scripts/`basename $$f`; \
 	  chmod a+x intermediate/Scripts/`basename $$f`; \
-	done 
+	done
+	for f in LCM/scripts/python3/*.py LCM/scripts/python3/*.sh; do \
+	  cat $$f | \
+	  sed "s@<CONFIG_BINDIR>@$$CONFIG_BINDIR@" | \
+	  sed "s@<CONFIG_LIBDIR>@$$CONFIG_LIBDIR@" | \
+	  sed "s@<CONFIG_LOCALSTATEDIR>@$$CONFIG_LOCALSTATEDIR@" | \
+	  sed "s@<CONFIG_SYSCONFDIR>@$$CONFIG_SYSCONFDIR@" | \
+	  sed "s@<CONFIG_SYSCONFDIR_DSC>@$(CONFIG_SYSCONFDIR_DSC)@" | \
+	  sed "s@<OAAS_CERTPATH>@$(OAAS_CERTPATH)@" | \
+	  sed "s@<OAAS_KEYPATH>@$(OAAS_KEYPATH)@" | \
+	  sed "s@<OAAS_THUMBPRINT>@$(OAAS_THUMBPRINT)@" | \
+	  sed "s@<OMI_LIB_SCRIPTS>@$$CONFIG_LIBDIR/Scripts@" | \
+	  sed "s@<PYTHON_PID_DIR>@$(PYTHON_PID_DIR)@" | \
+	  sed "s@<DSC_NAMESPACE>@$(DSC_NAMESPACE)@" | \
+	  sed "s@<DSC_SCRIPT_PATH>@$(DSC_SCRIPT_PATH)@" | \
+	  sed "s@<DSC_HOST_BASE_PATH>@$(DSC_HOST_BASE_PATH)@" | \
+	  sed "s@<DSC_MODULES_PATH>@$(DSC_MODULES_PATH)@" > intermediate/Scripts/python3/`basename $$f`; \
+	  chmod a+x intermediate/Scripts/python3/`basename $$f`; \
+	done
 	$(MAKE) -C Providers reg

--- a/Providers/Scripts/3.x/Scripts/nxOMSPlugin.py
+++ b/Providers/Scripts/3.x/Scripts/nxOMSPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #============================================================================
 # Copyright (C) Microsoft Corporation, All rights reserved.
 #============================================================================
@@ -109,10 +109,10 @@ def init_vars(Plugins, WorkspaceID):
 
     global MULTI_HOMED
     global CONF_PATH
-    mh_conf_dir = os.path.join(ETC_OMSAGENT_DIR, WorkspaceID, CONF_PATH_SUFFIX)
+    mh_conf_dir = os.path.join(ETC_OMSAGENT_DIR, WorkspaceID.decode(), CONF_PATH_SUFFIX)
     MULTI_HOMED = os.path.isdir(mh_conf_dir)
     if MULTI_HOMED and WorkspaceID: # only log this if WorkspaceID is not None or empty
-        LG().Log('INFO', 'OMSAgent is multi-homed and resource is updating workspace ' + WorkspaceID)
+        LG().Log('INFO', 'OMSAgent is multi-homed and resource is updating workspace ' + WorkspaceID.decode())
         CONF_PATH = mh_conf_dir
 
 
@@ -389,7 +389,7 @@ def copy_all_files(src, dest, is_exec):
                 shutil.copy(full_src_file, dest)
                 if is_exec:
                     mode = os.stat(full_dest_file).st_mode
-                    mode |= 0555
+                    mode |= 0o555
                     os.chmod(full_dest_file, mode)
     except:
         LG().Log('ERROR', 'copy_all_files failed for src: ' + src + ' dest: '
@@ -421,7 +421,7 @@ def check_all_files(src, dest, is_exec):
                     return False
                 if is_exec:
                     mode = os.stat(full_dest_file).st_mode
-                    if mode & 0555 != 0555:
+                    if mode & 0o555 != 0o555:
                         return False
             else:
                 return False

--- a/Providers/Scripts/client.py
+++ b/Providers/Scripts/client.py
@@ -176,6 +176,7 @@ try:
         else:
             trace (ScriptsDir + '/3.x')
             os.chdir (ScriptsDir + '/3.x')
+            sys.path.append(ScriptsDir + '/3.x/Scripts')
         from Scripts import *
         
         if __name__ == '__main__':

--- a/configure
+++ b/configure
@@ -67,7 +67,7 @@ do
 	    BUILD_OMS=BUILD_OMS
 	    DSC_MODULES_PATH="/opt/microsoft/omsconfig/modules"
 	    DSC_SCRIPT_PATH="/opt/microsoft/omsconfig/Scripts"
-		DSC_HOST_BASE_PATH="/opt/dsc"
+	    DSC_HOST_BASE_PATH="/opt/dsc"
 	    DSC_PATH_MODIFIER="/omsconfig"
 	    ;;
 	

--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -13,7 +13,6 @@ SHLIB_EXT: 'so'
 /opt/microsoft/${{SHORT_NAME}}/mof/MSFT_DSCMetaConfiguration.mof; LCM/dsc/mof/MSFT_DSCMetaConfiguration.mof; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/${{SHORT_NAME}}/mof/MSFT_LogResource.registration.mof; LCM/dsc/mof/MSFT_LogResource.registration.mof; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/${{SHORT_NAME}}/mof/MSFT_LogResource.schema.mof; LCM/dsc/mof/MSFT_LogResource.schema.mof; 755; ${{RUN_AS_USER}}; root
-
 /etc/opt/omi/conf/${{SHORT_NAME}}/dsc.conf; Providers/Extras/Scripts/base_dsc.conf; 755; ${{RUN_AS_USER}}; root
 
 /opt/microsoft/${{SHORT_NAME}}/Scripts/client.py; intermediate/Scripts/client.py; 755; ${{RUN_AS_USER}}; root
@@ -38,6 +37,30 @@ SHLIB_EXT: 'so'
 /opt/microsoft/${{SHORT_NAME}}/Scripts/StatusReport.sh; intermediate/Scripts/StatusReport.sh; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/${{SHORT_NAME}}/Scripts/helperlib.py; intermediate/Scripts/helperlib.py; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/${{SHORT_NAME}}/Scripts/ImportGPGKey.sh; intermediate/Scripts/ImportGPGKey.sh; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/${{SHORT_NAME}}/Scripts/calcPythonPath.sh; intermediate/Scripts/calcPythonPath.sh; 755; ${{RUN_AS_USER}}; root
+
+/opt/microsoft/${{SHORT_NAME}}/Scripts/python3/client.py; intermediate/Scripts/client.py; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/${{SHORT_NAME}}/Scripts/python3/protocol.py; intermediate/Scripts/protocol.py; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/${{SHORT_NAME}}/Scripts/python3/nxDSCLog.py; intermediate/Scripts/nxDSCLog.py; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/${{SHORT_NAME}}/Scripts/python3/zipfile2.6.py; intermediate/Scripts/zipfile2.6.py; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/${{SHORT_NAME}}/Scripts/python3/OmsConfigHostHelpers.py; intermediate/Scripts/python3/OmsConfigHostHelpers.py; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/${{SHORT_NAME}}/Scripts/python3/StartDscConfiguration.py; intermediate/Scripts/python3/StartDscConfiguration.py; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/${{SHORT_NAME}}/Scripts/python3/TestDscConfiguration.py; intermediate/Scripts/python3/TestDscConfiguration.py; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/${{SHORT_NAME}}/Scripts/python3/GetDscConfiguration.py; intermediate/Scripts/python3/GetDscConfiguration.py; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/${{SHORT_NAME}}/Scripts/python3/PerformInventory.py; intermediate/Scripts/python3/PerformInventory.py; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/${{SHORT_NAME}}/Scripts/python3/SetDscLocalConfigurationManager.py; intermediate/Scripts/python3/SetDscLocalConfigurationManager.py; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/${{SHORT_NAME}}/Scripts/python3/GetDscLocalConfigurationManager.py; intermediate/Scripts/python3/GetDscLocalConfigurationManager.py; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/${{SHORT_NAME}}/Scripts/python3/PerformRequiredConfigurationChecks.py; intermediate/Scripts/python3/PerformRequiredConfigurationChecks.py; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/${{SHORT_NAME}}/Scripts/python3/OperationStatusUtility.py; intermediate/Scripts/python3/OperationStatusUtility.py; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/${{SHORT_NAME}}/Scripts/python3/RestoreConfiguration.py; intermediate/Scripts/python3/RestoreConfiguration.py; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/${{SHORT_NAME}}/Scripts/python3/InstallModule.py; intermediate/Scripts/python3/InstallModule.py; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/${{SHORT_NAME}}/Scripts/python3/RemoveModule.py; intermediate/Scripts/python3/RemoveModule.py; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/${{SHORT_NAME}}/Scripts/python3/RegenerateInitFiles.py; intermediate/Scripts/python3/RegenerateInitFiles.py; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/${{SHORT_NAME}}/Scripts/python3/RegisterHelper.sh; intermediate/Scripts/python3/RegisterHelper.sh; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/${{SHORT_NAME}}/Scripts/python3/Register.py; intermediate/Scripts/python3/Register.py; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/${{SHORT_NAME}}/Scripts/python3/StatusReport.sh; intermediate/Scripts/python3/StatusReport.sh; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/${{SHORT_NAME}}/Scripts/python3/helperlib.py; intermediate/Scripts/helperlib.py; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/${{SHORT_NAME}}/Scripts/python3/ImportGPGKey.sh; intermediate/Scripts/python3/ImportGPGKey.sh; 755; ${{RUN_AS_USER}}; root
 
 #if BUILD_OMS == 1
 
@@ -57,6 +80,7 @@ SHLIB_EXT: 'so'
 /opt/microsoft/omsconfig/Scripts/NPMAgentBinaryCap.sh; intermediate/Scripts/NPMAgentBinaryCap.sh; 755; root; root
 /opt/microsoft/omsconfig/Scripts/OMSAuditdPlugin.sh; intermediate/Scripts/OMSAuditdPlugin.sh; 755; root; root
 /opt/microsoft/omsconfig/Scripts/OMS_MetaConfigHelper.py; intermediate/Scripts/OMS_MetaConfigHelper.py; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/omsconfig/Scripts/python3/OMS_MetaConfigHelper.py; intermediate/Scripts/python3/OMS_MetaConfigHelper.py; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nx_1.0.zip; release/nx_1.0.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSPerfCounter_2.2.zip; release/nxOMSPerfCounter_2.2.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSSyslog_2.5.zip; release/nxOMSSyslog_2.5.zip; 755; ${{RUN_AS_USER}}; root
@@ -104,6 +128,7 @@ SHLIB_EXT: 'so'
 /opt/microsoft/${{SHORT_NAME}}/module_packages;           755; ${{RUN_AS_USER}}; root
 /opt/microsoft/${{SHORT_NAME}}/keys;                      755; ${{RUN_AS_USER}}; root
 /opt/microsoft/${{SHORT_NAME}}/Scripts;                   755; ${{RUN_AS_USER}}; root
+/opt/microsoft/${{SHORT_NAME}}/Scripts/python3;                 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/${{SHORT_NAME}}/Scripts/2.4x-2.5x;         755; ${{RUN_AS_USER}}; root
 /opt/microsoft/${{SHORT_NAME}}/Scripts/2.4x-2.5x/Scripts; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/${{SHORT_NAME}}/Scripts/2.6x-2.7x;         755; ${{RUN_AS_USER}}; root
@@ -168,7 +193,7 @@ if [ "$base64hmac" != "C9eHLPTYnXyrYXLzmMsya2FWfCFNRlaq75stOI2wbLw=" ]; then
     PREREQ_ERROR=1
     exit 1
 fi
-#else 
+#else
 
 # test for availablity of gpg
 which gpg 1> /dev/null 2> /dev/null
@@ -176,21 +201,33 @@ if [ $? -ne 0 ]; then
     echo "Error: gpg needs to be installed and available in PATH"
     PREREQ_ERROR=1
 fi
-       
+
 if [ $PREREQ_ERROR -eq 1 ]; then
     exit 1
 fi
-
 #endif
 
 %Preinstall_200
-echo "Checking for ctypes python module..."
-python -c "import ctypes" 1> /dev/null 2> /dev/null
-cmdline_ctypes=$?
-if [ $cmdline_ctypes -ne 0 ]; then    
-    echo "Error: Python does not support ctypes on this system.  Please install the ctypes module for Python or upgrade to a newer version of python that comes with the ctypes module."
-    echo "Please remove the omi package and try again after installing the ctypes module or upgrading Python.  You can check if the ctypes module is installed by starting python and running the command: 'import ctypes'"
-    exit 1
+# pythonVersion check must be repeated for each section
+if  [ ! "$(python2 --version 2>&1 | grep 'not found')" ]; then
+  echo "Using python2"
+  pythonVersion="python2"
+elif [ ! "$(python3 --version 2>&1 | grep 'not found')" ]; then
+  echo "Using python3"
+  pythonVersion="python3"
+else
+  echo "Python not found."
+fi
+# Only check for ctypes if python2 is installed
+if [ "$pythonVersion" = "python2" ]; then
+   echo "Checking for ctypes python module..."
+   python -c "import ctypes" 1> /dev/null 2> /dev/null
+   cmdline_ctypes=$?
+   if [ $cmdline_ctypes -ne 0 ]; then
+      echo "Error: Python does not support ctypes on this system.  Please install the ctypes module for Python or upgrade to a newer version of python that comes with the ctypes module."
+      echo "Please remove the omi package and try again after installing the ctypes module or upgrading Python.  You can check if the ctypes module is installed by starting python and running the command: 'import ctypes'"
+      exit 1
+   fi
 fi
 
 %Preinstall_300
@@ -267,7 +304,6 @@ cp -f /opt/microsoft/${{SHORT_NAME}}/etc/*.reg $OMI_REGISTER_DIR/root-oms
 cp -f /opt/microsoft/${{SHORT_NAME}}/etc/omsconfig.reg $OMI_REGISTER_DIR/root-oms
 ln -fs /opt/microsoft/${{SHORT_NAME}}/lib/libomsconfig.so $OMI_HOME/lib/libomsconfig.so
 ln -fs /opt/microsoft/${{SHORT_NAME}}/bin/OMSConsistencyInvoker $OMI_HOME/bin/OMSConsistencyInvoker
-
 #else
 
 # Make OMI listen on the standard DSC port
@@ -302,35 +338,76 @@ chown -R ${{RUN_AS_USER}} /opt/microsoft/omsagent/plugin
 # If this is ever changed/removed, coordinate with nxOMSAuditdPlugin author/maintainer(s)
 chown -R ${{RUN_AS_USER}} /opt/microsoft/omsconfig/Scripts
 
+# pythonVersion check must be repeated for each section
+if  [ ! "$(python2 --version 2>&1 | grep 'not found')" ]; then
+  echo "Using python2"
+  pythonVersion="python2"
+elif [ ! "$(python3 --version 2>&1 | grep 'not found')" ]; then
+  echo "Using python3"
+  pythonVersion="python3"
+else
+  echo "Python not found."
+fi
+
 # Set up built-in resource modules for OMS DSC
-su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nx_1.0.zip 0"
-su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSPerfCounter_2.2.zip 0"
-su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSSyslog_2.5.zip 0"
-su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSSudoCustomLog_2.7.zip 0"
-su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSKeyMgmt_1.0.zip 0"
-su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxFileInventory_1.3.zip 0"
-su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSGenerateInventoryMof_1.4.zip 0"
+if [ "$pythonVersion" = "python3" ]; then
+	echo "Running python3, python version is ", $pythonVersion
+	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/python3/InstallModule.py /opt/microsoft/omsconfig/module_packages/nx_1.0.zip 0"
+	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/python3/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSPerfCounter_2.2.zip 0"
+	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/python3/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSSyslog_2.5.zip 0"
+	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/python3/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSSudoCustomLog_2.7.zip 0"
+	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/python3/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSKeyMgmt_1.0.zip 0"
+	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/python3/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxFileInventory_1.3.zip 0"
+  su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSGenerateInventoryMof_1.4.zip 0"
+else
+  echo "Running  python version is ", $pythonVersion
+	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nx_1.0.zip 0"
+	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSPerfCounter_2.2.zip 0"
+	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSSyslog_2.5.zip 0"
+	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSSudoCustomLog_2.7.zip 0"
+	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSKeyMgmt_1.0.zip 0"
+	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxFileInventory_1.3.zip 0"
+  su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSGenerateInventoryMof_1.4.zip 0"
+fi
 
 #if PFARCH == x86
-su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSAgentNPMConfig_2.2.zip 0"
-su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSAuditdPlugin_1.7.zip 0"
-su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSAutomationWorker_1.6.9.1.zip 0"
-su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSContainers_1.0.zip 0"
-su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSCustomLog_1.0.zip 0"
-su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSGenerateInventoryMof_1.3.zip 0"
-su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSPlugin_3.39.zip 0"
-su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSWLI_1.45.zip 0"
+if [ "$pythonVersion" = "python3" ]; then
+  echo "Running python3 python version is ", $pythonVersion
+	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/python3/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSAgentNPMConfig_2.2.zip 0"
+	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/python3/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSAuditdPlugin_1.7.zip 0"
+	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/python3/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSAutomationWorker_1.6.9.1.zip 0"
+	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/python3/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSContainers_1.0.zip 0"
+	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/python3/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSCustomLog_1.0.zip 0"
+	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/python3/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSGenerateInventoryMof_1.3.zip 0"
+	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/python3/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSPlugin_3.39.zip 0"
+	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/python3/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSWLI_1.45.zip 0"
+else
+  echo "Running python2 python version is ", $pythonVersion
+	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSAgentNPMConfig_2.2.zip 0"
+	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSAuditdPlugin_1.7.zip 0"
+	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSAutomationWorker_1.6.9.1.zip 0"
+	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSContainers_1.0.zip 0"
+	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSCustomLog_1.0.zip 0"
+	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSGenerateInventoryMof_1.3.zip 0"
+	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSPlugin_3.39.zip 0"
+	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSWLI_1.45.zip 0"
 #endif
 
 # Set up a built-in resource module for DIY DSC that was removed during OMS Agent update
 # This is a temporary workaround to prevent DIY DSC from breaking after the OMS Agent is updated from version 1.4.4-210 or below
 # This section can be removed when telemetry shows that customers no longer need to update from version 1.4.4-210 or below
 
-# Check if DIY DSC install module script is present on the machine 
+# Check if DIY DSC install module script is present on the machine
 if [ -f /opt/microsoft/dsc/Scripts/InstallModule.py ]; then
   # Check if nx module package is available in DIY DSC
   if [ -f /opt/microsoft/dsc/module_packages/nx_1.0.zip ]; then
-    /opt/microsoft/dsc/Scripts/InstallModule.py /opt/microsoft/dsc/module_packages/nx_1.0.zip 0
+    if [ "$pythonVersion" = "python3" ]; then
+      echo "Running python3"
+      /opt/microsoft/dsc/Scripts/python3/InstallModule.py /opt/microsoft/dsc/module_packages/nx_1.0.zip 0
+    else
+      echo "Running python2 in Check if DIY DSC install... python version is ", $pythonVersion
+      /opt/microsoft/dsc/Scripts/InstallModule.py /opt/microsoft/dsc/module_packages/nx_1.0.zip 0
+    fi
   fi
 fi
 
@@ -350,7 +427,14 @@ if [ -d "/etc/opt/omi/conf/omsconfig" ]; then chown -R omsagent:omiusers /etc/op
 #else
 
 # Set up built-in resource module for DIY DSC
-/opt/microsoft/dsc/Scripts/InstallModule.py /opt/microsoft/dsc/module_packages/nx_1.0.zip 0
+if [ "$pythonVersion" = "python3" ]; then
+  echo "Running python3"
+	/opt/microsoft/dsc/Scripts/python3/InstallModule.py /opt/microsoft/dsc/module_packages/nx_1.0.zip 0
+else
+  echo "Running python2 in set up built in python version is ", $pythonVersion
+	/opt/microsoft/dsc/Scripts/InstallModule.py /opt/microsoft/dsc/module_packages/nx_1.0.zip 0
+fi
+
 
 #endif
 
@@ -395,15 +479,15 @@ su - omsagent -c "/opt/microsoft/${{SHORT_NAME}}/Scripts/ImportGPGKey.sh /opt/mi
 su - omsagent -c "/opt/microsoft/${{SHORT_NAME}}/Scripts/ImportGPGKey.sh /opt/microsoft/${{SHORT_NAME}}/keys/dscgpgkey.asc keyring.gpg"
 
 
-# Set up a dsc cron job to run the ConsistencyInvoker every 30 minutes which is default freq, this is to fix dsc github issue no 322. 
-# It is a temporary workaround to create dsc DYI cron job as omsconfig upgrade removes dsc cron job. 
+# Set up a dsc cron job to run the ConsistencyInvoker every 30 minutes which is default freq, this is to fix dsc github issue no 322.
+# It is a temporary workaround to create dsc DYI cron job as omsconfig upgrade removes dsc cron job.
 
-# check if dsc consistency invoker is present on the machine 
-if [ -f /opt/omi/bin/ConsistencyInvoker ]; then 
+# check if dsc consistency invoker is present on the machine
+if [ -f /opt/omi/bin/ConsistencyInvoker ]; then
 
-  # check if we do not have dsc cron file on the box then create one. 
+  # check if we do not have dsc cron file on the box then create one.
   if [ ! -f /etc/cron.d/dsc ]; then
-           	echo "*/30 * * * * root /opt/omi/bin/ConsistencyInvoker" > /etc/cron.d/dsc
+    echo "*/30 * * * * root /opt/omi/bin/ConsistencyInvoker" > /etc/cron.d/dsc
   fi
 fi
 
@@ -420,7 +504,13 @@ mv /etc/crontabtmp /etc/crontab
 
 # If omsadmin.conf exists, let's apply the metaconfig
 if [ -f /etc/opt/microsoft/omsagent/conf/omsadmin.conf ]; then
-   su - omsagent -c "/opt/microsoft/omsconfig/Scripts/OMS_MetaConfigHelper.py"
+  if [ "$pythonVersion" = "python3" ]; then
+    echo "Running python3"
+    su - omsagent -c "/opt/microsoft/omsconfig/Scripts/python3/OMS_MetaConfigHelper.py"
+  else
+    echo "Running python2 if omsadmin.conf exists python version is ", $pythonVersion
+    su - omsagent -c "/opt/microsoft/omsconfig/Scripts/OMS_MetaConfigHelper.py"
+  fi
 fi
 
 cp -f /opt/microsoft/omsconfig/etc/Inventory.mof /etc/opt/omi/conf/omsconfig/configuration/Inventory.mof
@@ -438,12 +528,30 @@ rm -f /etc/opt/omi/conf/omsconfig/inventory_lock
 echo "Cleaned up existing dsc_hosts before uninstall..."
 
 %Preuninstall_999
+# pythonVersion check must be repeated for each section
+if  [ ! "$(python2 --version 2>&1 | grep 'not found')" ]; then
+  echo "Using python2"
+  pythonVersion="python2"
+elif [ ! "$(python3 --version 2>&1 | grep 'not found')" ]; then
+  echo "Using python3"
+  pythonVersion="python3"
+else
+  echo "Python not found"
+fi
 # if this is a package removal, not an upgrade, remove the modules
 if [ "$1" = "0" -o "$1" = "remove" -o "$1" = "purge" ]; then
-    # Remove all DSC specific data
-    for module in `ls /opt/microsoft/${{SHORT_NAME}}/modules`; do
-        /opt/microsoft/${{SHORT_NAME}}/Scripts/RemoveModule.py $module
-    done
+  # Remove all DSC specific data
+  if [ "$pythonVersion" = "python3" ]; then
+     echo "Running python3"
+     for module in `ls /opt/microsoft/${{SHORT_NAME}}/modules`; do
+       /opt/microsoft/${{SHORT_NAME}}/Scripts/python3/RemoveModule.py $module
+     done
+   else
+     echo "Running python2 in remove all DSC specific data python version is ", $pythonVersion
+     for module in `ls /opt/microsoft/${{SHORT_NAME}}/modules`; do
+       /opt/microsoft/${{SHORT_NAME}}/Scripts/RemoveModule.py $module
+     done
+  fi
 fi
 
 %Postuninstall_999
@@ -467,11 +575,11 @@ if [ "$1" = "0" -o "$1" = "remove" -o "$1" = "purge" ]; then
     rm -rf $OMI_REGISTER_DIR/root-Microsoft-DesiredStateConfiguration
     rm -rf $OMI_REGISTER_DIR/root-Microsoft-Windows-DesiredStateConfiguration
     rm -f $OMI_HOME/bin/ConsistencyInvoker
-    rm -f $OMI_LIB/libdsccore.so    
-    # Only to be removed for standalone DSC case 
+    rm -f $OMI_LIB/libdsccore.so
+    # Only to be removed for standalone DSC case
     rm -f /etc/cron.d/dsc
 #endif
-    
+
 fi
 
 #if BUILD_OMS == 1
@@ -504,4 +612,3 @@ ${{SHELL_HEADER}}
 ${{SHELL_HEADER}}
 %Postuninstall_0
 ${{SHELL_HEADER}}
-


### PR DESCRIPTION
This PR has all the required changes for supporting Python 3 for OMS Config.
This PR includes changes done by Michelle as well as a few later fixes added by me.

New scenario to be followed:
If the machine has python 2, the OMSconfig will run on python 2 and invoke the corresponding python2 version of resource Providers.
If the machine has only Python 3, the OMSconfig will run on python3 and will invoke the corresponding python3 version of the resource provider.


* Print args from child process

* Replaced octal 0 with 0o

* Converting workspaceID back to unicode.

* Got the subprocess call working

* Successful runthrough of installer.

* Dynamically pick correct python version to use.

* Modified python selection

* Added print statements in python provider to figure out why python3 is returning.

* Can find python2.

* Debugging PythonProviders.

* Python3 syntax change

* Reverting back to normal shebang.

* Adding python3 versions of scripts.

* Trying to add if statements to the script.

* Attempting to make installer work with python3

* PerformInventory prints new lines.

* Python 3 files print out normally.

* Small s typo.

* Removed extra print statements

* Adding 3 folder.

* First working /3/ generation!

* Some changes trying to get installer to work :(

* Working on getting python3 changes to appear in installer

* Successful installgit add installbuilder/datafiles/Base_DSC.data

* Fixed typo.

* Ensuring python2 works

* Installer and Test commands working! Hardcoded 3 file though.

* Repeated python logic in uninstall section.

* Fixing python3 scripts.

* Added python3 call to WebPullClient.c

* Removed some logs and dy default use determinePython

* Somehow this got deleted?

* Somehow this got deleted?

* Added support for other versions to opy.

* EVERYTHING IS WORKING I THINK

* Cleaned up logs.

* Cleaning up some more.

* Removing extra print statements

* Fixing Python3 logic.

* Fixing small typo.

* Renamed folder directory.

* Applying python2 cli changes and removing redundant code.

* remove my path.

* Changed filepath,

* Implemented changes needed for python3. Merged with previous iteration of this file to restore argParser

* changed ordering of python in installer.

* Fixed directory in RemoveModule

* PR review refarding codecs

* Updated ConsistencyInvoker.c to invoke based on python version

* Fixes after initial round of loacl testing

* Update PythonProvider.cpp

* Update Base_DSC.data

* Ensured we call onlu python 2 or python3

As path variable "python" can be changed(aliased) by the user to point ot any version of python (2 or 3) we should always stick to calling python2 or python 3 explictly.

* added logs in consistency invoker

* Update Base_DSC.data

* Update ConsistencyInvoker.c

* Update ConsistencyInvoker.c

Co-authored-by: Michelle Yang <zomgitsmichelle@gmail.com>
Co-authored-by: Ubuntu <micy@micy-ubuntu-dev.xpvrgeto3bvehnlzuvlnfwgx3e.cbnx.internal.cloudapp.net>
Co-authored-by: root <root@micy-ubuntu-dev.xpvrgeto3bvehnlzuvlnfwgx3e.cbnx.internal.cloudapp.net>
Co-authored-by: Michelle Yang <micy@microsoft.com>
Co-authored-by: Ubuntu <micy@micy-editing.jhkjurelowvevlqkcsdya2aiwb.ax.internal.cloudapp.net>
Co-authored-by: Michelle Yang <xmichelleyang@users.noreply.github.com>