### PR TITLE
Bug fix for Python 2.6

### DIFF
--- a/LCM/scripts/OMS_MetaConfigHelper.py
+++ b/LCM/scripts/OMS_MetaConfigHelper.py
@@ -257,7 +257,8 @@ if "omsconfig" in helperlib.DSC_SCRIPT_PATH:
 else:
     set_metaconfig_success_string = "ReturnValue=0"
 
-if ((exit_code == 0) and (stderr.decode(encoding = 'UTF-8') == '') and (set_metaconfig_success_string in str(stdout))):
+# This file is only for python 2 
+if ((exit_code == 0) and (stderr == '' or (sys.version_info >= (3, 0) and stderr.decode(encoding = 'UTF-8') == '') and (set_metaconfig_success_string in str(stdout))):
     printVerboseMessage('Successfully configured omsconfig.')
 else:
     if exit_code == 0:


### PR DESCRIPTION
The stderr.decode wouldn't work in python 2.6 and would lead to an exception. Fixed this problem.

The OMSConfig was still working as expected, just it wouldn't print out the success message saying: 'Successfully configured omsconfig.'