### PR TITLE
Update nxOMSAgentNPMConfig DSC module to 3.6 version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -588,7 +588,7 @@ nxFileInventory:
 
 nxOMSAgentNPMConfig:
 	rm -rf output/staging; \
-	VERSION="3.5"; \
+	VERSION="3.6"; \
 	PROVIDERS="nxOMSAgentNPMConfig"; \
 	STAGINGDIR="output/staging/$@/DSCResources"; \
 	cat Providers/Modules/$@.psd1 | sed "s@<MODULE_VERSION>@$${VERSION}@" > intermediate/Modules/$@.psd1; \


### PR DESCRIPTION
This PR contains changes:

1. Update NPMDAgent binary with CRM changes and fixes pushed in to npm_crossplat branch till 17th September 2020.

Following is the last PR changes of npm_crossplat branch that's available in current NPMDAgent binary going out for Linux deployment package:

Pull Request 3526642: Setting Hop Roles for CMv2/CRM

https://msazure.visualstudio.com/One/_git/Mgmt-LogAnalytics-NPMD/pullrequest/3526642

