### PR TITLE
Added suppression logic for deprecationWarning for the imp module for supporting OMSAgent on newer OS versions including Ubuntu 20.04

### DIFF
--- a/LCM/scripts/python3/GetDscConfiguration.py
+++ b/LCM/scripts/python3/GetDscConfiguration.py
@@ -8,7 +8,10 @@ import datetime
 import os
 import os.path
 from OmsConfigHostHelpers import write_omsconfig_host_telemetry, write_omsconfig_host_switch_event, write_omsconfig_host_log, stop_old_host_instances
-from imp                import load_source
+import warnings
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore",category=DeprecationWarning)
+    from imp        import load_source
 from os.path            import dirname, isfile, join, realpath
 from fcntl              import flock, LOCK_EX, LOCK_UN, LOCK_NB
 

--- a/LCM/scripts/python3/GetDscLocalConfigurationManager.py
+++ b/LCM/scripts/python3/GetDscLocalConfigurationManager.py
@@ -8,7 +8,10 @@ import datetime
 import os
 import os.path
 from OmsConfigHostHelpers import write_omsconfig_host_telemetry, write_omsconfig_host_switch_event, write_omsconfig_host_log, stop_old_host_instances
-from imp                import load_source
+import warnings
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore",category=DeprecationWarning)
+    from imp        import load_source
 from os.path            import dirname, isfile, join, realpath
 from fcntl              import flock, LOCK_EX, LOCK_UN, LOCK_NB
 

--- a/LCM/scripts/python3/InstallModule.py
+++ b/LCM/scripts/python3/InstallModule.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-import imp
+import warnings
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore",category=DeprecationWarning)
+    import imp
 import os
 import stat
 import shutil

--- a/LCM/scripts/python3/OMS_MetaConfigHelper.py
+++ b/LCM/scripts/python3/OMS_MetaConfigHelper.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 import os
 import sys
-import imp
 import subprocess
 from os.path import basename, dirname, join, realpath, split
 import warnings
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore",category=DeprecationWarning)
+    import imp
     from imp        import load_source
 from os.path            import dirname, isfile, join, realpath
 

--- a/LCM/scripts/python3/OMS_MetaConfigHelper.py
+++ b/LCM/scripts/python3/OMS_MetaConfigHelper.py
@@ -4,7 +4,10 @@ import sys
 import imp
 import subprocess
 from os.path import basename, dirname, join, realpath, split
-from imp                import load_source
+import warnings
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore",category=DeprecationWarning)
+    from imp        import load_source
 from os.path            import dirname, isfile, join, realpath
 
 pathToCurrentScript = realpath(__file__)

--- a/LCM/scripts/python3/OperationStatusUtility.py
+++ b/LCM/scripts/python3/OperationStatusUtility.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 from datetime   import datetime
 from errno      import EINVAL
-from imp        import load_source
+import warnings
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore",category=DeprecationWarning)
+    from imp        import load_source
 from json       import dump
 from os         import chmod, mkdir, stat
 from os.path    import dirname, join, isdir, isfile, realpath

--- a/LCM/scripts/python3/PerformInventory.py
+++ b/LCM/scripts/python3/PerformInventory.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 from fcntl                import flock, LOCK_EX, LOCK_UN, LOCK_NB
-from imp                  import load_source
+import warnings
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore",category=DeprecationWarning)
+    from imp        import load_source
 from os                   import listdir, system
 from os.path              import dirname, isfile, join, realpath
 from shutil               import move

--- a/LCM/scripts/python3/PerformRequiredConfigurationChecks.py
+++ b/LCM/scripts/python3/PerformRequiredConfigurationChecks.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-from imp        import load_source
+import warnings
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore",category=DeprecationWarning)
+    from imp        import load_source
 from os.path    import dirname, join, realpath, isfile
 from subprocess import PIPE, Popen
 from sys        import exc_info, exit, version_info

--- a/LCM/scripts/python3/RemoveModule.py
+++ b/LCM/scripts/python3/RemoveModule.py
@@ -4,7 +4,10 @@ import os
 import subprocess
 import shutil
 import platform
-import imp
+import warnings
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore",category=DeprecationWarning)
+    import imp
 from os.path import dirname, join, realpath
 
 pathToCurrentScript = realpath(__file__)

--- a/LCM/scripts/python3/RestoreConfiguration.py
+++ b/LCM/scripts/python3/RestoreConfiguration.py
@@ -2,7 +2,10 @@
 import fileinput
 import sys
 import subprocess
-from imp                  import load_source
+import warnings
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore",category=DeprecationWarning)
+    from imp                  import load_source
 from os.path              import dirname, isfile, join, realpath
 from fcntl                import flock, LOCK_EX, LOCK_UN, LOCK_NB
 from OmsConfigHostHelpers import write_omsconfig_host_telemetry, write_omsconfig_host_switch_event, write_omsconfig_host_log, stop_old_host_instances

--- a/LCM/scripts/python3/SetDscLocalConfigurationManager.py
+++ b/LCM/scripts/python3/SetDscLocalConfigurationManager.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-from imp                  import load_source
+import warnings
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore",category=DeprecationWarning)
+    from imp                  import load_source
 from os.path              import dirname, isfile, join, realpath
 from subprocess           import PIPE, Popen
 from sys                  import argv, exc_info, exit, version_info

--- a/LCM/scripts/python3/StartDscConfiguration.py
+++ b/LCM/scripts/python3/StartDscConfiguration.py
@@ -3,7 +3,10 @@
 # Standard library imports
 from subprocess           import Popen, PIPE
 from sys                  import argv
-from imp                  import load_source
+import warnings
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore",category=DeprecationWarning)
+    from imp                  import load_source
 from os.path              import dirname, isfile, join, realpath
 from fcntl                import flock, LOCK_EX, LOCK_UN, LOCK_NB
 from OmsConfigHostHelpers import write_omsconfig_host_telemetry, write_omsconfig_host_switch_event, write_omsconfig_host_log, stop_old_host_instances

--- a/LCM/scripts/python3/TestDscConfiguration.py
+++ b/LCM/scripts/python3/TestDscConfiguration.py
@@ -3,7 +3,10 @@ import fileinput
 import sys
 import subprocess
 from OmsConfigHostHelpers import write_omsconfig_host_telemetry, write_omsconfig_host_switch_event, write_omsconfig_host_log, stop_old_host_instances
-from imp                  import load_source
+import warnings
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore",category=DeprecationWarning)
+    from imp                  import load_source
 from os.path              import dirname, isfile, join, realpath
 from time                 import sleep
 from fcntl                import flock, LOCK_EX, LOCK_UN, LOCK_NB


### PR DESCRIPTION
For Python 3.8 (comes as default on Ubuntu 20.04) the depreciated mosules print the depreciation warning to STDERR. This may result in a OMSAgent extension failure.

To support the OMSagent on these new Operating systems, these set of changes will supress the depreciation warning for imp module.

In the long term we may need to shift to import lib as this module will be removed.

Deprecation Documentation:https://www.python.org/dev/peps/pep-0594/#id112
Warning Documentation:https://docs.python.org/3.1/library/warnings.html