### PR TITLE
Deglobalize Subprocess Monkey Patch ...

### DIFF
--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxAvailableUpdates.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxAvailableUpdates.py
@@ -281,7 +281,7 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             cmd = kwargs.get("args")
             if cmd is None:
                 cmd = popenargs[0]
-            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+            raise CalledProcessError(retcode, cmd, output=output)
         return output
 
     # Exception classes used by this module.
@@ -296,12 +296,9 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             return "Command '%s' returned non-zero exit status %d" \
                    % (self.cmd, self.returncode)
 
-    subprocess.check_output = check_output
-    subprocess.CalledProcessError = CalledProcessError
     try:
-        output = subprocess.check_output(
-            no_output, cmd, stderr=subprocess.STDOUT, shell=True)
-    except subprocess.CalledProcessError, e:
+        output = check_output(no_output, cmd, stderr=subprocess.STDOUT, shell=True)
+    except CalledProcessError, e:
         if chk_err:
             LG().Log('DEBUG', "CalledProcessError.  Error Code is " + str(e.returncode), file=sys.stdout)
             LG().Log('DEBUG', "CalledProcessError.  Command string was " + e.cmd, file=sys.stdout)

--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxComputer.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxComputer.py
@@ -109,7 +109,7 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             cmd = kwargs.get("args")
             if cmd is None:
                 cmd = popenargs[0]
-            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+            raise CalledProcessError(retcode, cmd, output=output)
         return output
 
     # Exception classes used by this module.
@@ -123,12 +123,9 @@ def RunGetOutput(cmd, no_output, chk_err=True):
         def __str__(self):
             return "Command '%s' returned non-zero exit status %d" % (self.cmd, self.returncode)
 
-    subprocess.check_output = check_output
-    subprocess.CalledProcessError = CalledProcessError
     try:
-        output = subprocess.check_output(
-            no_output, cmd, stderr=subprocess.STDOUT, shell=True)
-    except subprocess.CalledProcessError, e:
+        output = check_output(no_output, cmd, stderr=subprocess.STDOUT, shell=True)
+    except CalledProcessError, e:
         if chk_err:
             Print('CalledProcessError.  Error Code is ' +
                   str(e.returncode), file=sys.stdout)

--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxFirewall.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxFirewall.py
@@ -252,7 +252,7 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             cmd = kwargs.get("args")
             if cmd is None:
                 cmd = popenargs[0]
-            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+            raise CalledProcessError(retcode, cmd, output=output)
         return output
 
     # Exception classes used by this module.
@@ -267,13 +267,10 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             return "Command '%s' returned non-zero exit status %d" \
             % (self.cmd, self.returncode)
 
-    subprocess.check_output = check_output
-    subprocess.CalledProcessError = CalledProcessError
     output = ''
     try:
-        output = subprocess.check_output(
-            no_output, cmd, stderr=subprocess.STDOUT, shell=True)
-    except subprocess.CalledProcessError, e:
+        output = check_output(no_output, cmd, stderr=subprocess.STDOUT, shell=True)
+    except CalledProcessError, e:
         if chk_err:
             Print('CalledProcessError.  Error Code is ' +
                   str(e.returncode), file=sys.stdout)

--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxMySqlDatabase.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxMySqlDatabase.py
@@ -148,7 +148,7 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             cmd = kwargs.get("args")
             if cmd is None:
                 cmd = popenargs[0]
-            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+            raise CalledProcessError(retcode, cmd, output=output)
         return output
 
     # Exception classes used by this module.
@@ -163,12 +163,9 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             return "Command '%s' returned non-zero exit status %d" \
                    % (self.cmd, self.returncode)
 
-    subprocess.check_output = check_output
-    subprocess.CalledProcessError = CalledProcessError
     try:
-        output = subprocess.check_output(
-            no_output, cmd, stderr=subprocess.STDOUT, shell=True)
-    except subprocess.CalledProcessError, e:
+        output = check_output(no_output, cmd, stderr=subprocess.STDOUT, shell=True)
+    except CalledProcessError, e:
         if chk_err:
             Print('CalledProcessError.  Error Code is ' +
                   str(e.returncode), file=sys.stdout)

--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxMySqlGrant.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxMySqlGrant.py
@@ -166,7 +166,7 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             cmd = kwargs.get("args")
             if cmd is None:
                 cmd = popenargs[0]
-            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+            raise CalledProcessError(retcode, cmd, output=output)
         return output
 
     # Exception classes used by this module.
@@ -181,12 +181,9 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             return "Command '%s' returned non-zero exit status %d" \
                    % (self.cmd, self.returncode)
 
-    subprocess.check_output = check_output
-    subprocess.CalledProcessError = CalledProcessError
     try:
-        output = subprocess.check_output(
-            no_output, cmd, stderr=subprocess.STDOUT, shell=True)
-    except subprocess.CalledProcessError, e:
+        output = check_output(no_output, cmd, stderr=subprocess.STDOUT, shell=True)
+    except CalledProcessError, e:
         if chk_err:
             Print('CalledProcessError.  Error Code is ' +
                   str(e.returncode), file=sys.stdout)

--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxMySqlUser.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxMySqlUser.py
@@ -159,7 +159,7 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             cmd = kwargs.get("args")
             if cmd is None:
                 cmd = popenargs[0]
-            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+            raise CalledProcessError(retcode, cmd, output=output)
         return output
 
     # Exception classes used by this module.
@@ -174,12 +174,9 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             return "Command '%s' returned non-zero exit status %d" \
                    % (self.cmd, self.returncode)
 
-    subprocess.check_output = check_output
-    subprocess.CalledProcessError = CalledProcessError
     try:
-        output = subprocess.check_output(
-            no_output, cmd, stderr=subprocess.STDOUT, shell=True)
-    except subprocess.CalledProcessError, e:
+        output = check_output(no_output, cmd, stderr=subprocess.STDOUT, shell=True)
+    except CalledProcessError, e:
         if chk_err:
             Print('CalledProcessError.  Error Code is ' +
                   str(e.returncode), file=sys.stdout)

--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSKeyMgmt.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSKeyMgmt.py
@@ -266,7 +266,7 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             cmd = kwargs.get("args")
             if cmd is None:
                 cmd = popenargs[0]
-            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+            raise CalledProcessError(retcode, cmd, output=output)
         return output
 
     # Exception classes used by this module.
@@ -281,12 +281,9 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             return "Command '%s' returned non-zero exit status %d" \
                    % (self.cmd, self.returncode)
 
-    subprocess.check_output = check_output
-    subprocess.CalledProcessError = CalledProcessError
     try:
-        output = subprocess.check_output(
-            no_output, cmd, stderr=subprocess.STDOUT, shell=True)
-    except subprocess.CalledProcessError, e:
+        output = check_output(no_output, cmd, stderr=subprocess.STDOUT, shell=True)
+    except CalledProcessError, e:
         if chk_err:
             Print('CalledProcessError.  Error Code is ' +
                   str(e.returncode), file=sys.stdout)

--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxPackage.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxPackage.py
@@ -731,7 +731,7 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             cmd = kwargs.get("args")
             if cmd is None:
                 cmd = popenargs[0]
-            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+            raise CalledProcessError(retcode, cmd, output=output)
         return output
 
     # Exception classes used by this module.
@@ -748,12 +748,9 @@ def RunGetOutput(cmd, no_output, chk_err=True):
     def noop():
         pass
 
-    subprocess.check_output = check_output
-    subprocess.CalledProcessError = CalledProcessError
     try:
-        output = subprocess.check_output(
-            no_output, cmd, stderr=subprocess.STDOUT, shell=True)
-    except subprocess.CalledProcessError, e:
+        output = check_output(no_output, cmd, stderr=subprocess.STDOUT, shell=True)
+    except CalledProcessError, e:
         if chk_err:
             Print("CalledProcessError.  Error Code is " +
                   str(e.returncode), file=sys.stdout)

--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxService.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxService.py
@@ -195,7 +195,7 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             cmd = kwargs.get("args")
             if cmd is None:
                 cmd = popenargs[0]
-            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+            raise CalledProcessError(retcode, cmd, output=output)
         return output
 
     # Exception classes used by this module.
@@ -210,12 +210,9 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             return "Command '%s' returned non-zero exit status %d" \
                    % (self.cmd, self.returncode)
 
-    subprocess.check_output = check_output
-    subprocess.CalledProcessError = CalledProcessError
     try:
-        output = subprocess.check_output(
-            no_output, cmd, stderr=subprocess.STDOUT, shell=True)
-    except subprocess.CalledProcessError, e:
+        output = check_output(no_output, cmd, stderr=subprocess.STDOUT, shell=True)
+    except CalledProcessError, e:
         if chk_err:
             Print('CalledProcessError.  Error Code is ' +
                   str(e.returncode), file=sys.stderr)
@@ -266,7 +263,7 @@ def RunGetOutputNoStderr(cmd, no_output, chk_err=True):
             cmd = kwargs.get("args")
             if cmd is None:
                 cmd = popenargs[0]
-            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+            raise CalledProcessError(retcode, cmd, output=output)
         return output
 
     # Exception classes used by this module.
@@ -281,13 +278,10 @@ def RunGetOutputNoStderr(cmd, no_output, chk_err=True):
             return "Command '%s' returned non-zero exit status %d" \
                    % (self.cmd, self.returncode)
 
-    subprocess.check_output = check_output
-    subprocess.CalledProcessError = CalledProcessError
     devnull = open('/dev/null','w')
     try:
-        output = subprocess.check_output(
-            no_output, cmd, stderr=devnull, shell=True)
-    except subprocess.CalledProcessError, e:
+        output = check_output(no_output, cmd, stderr=devnull, shell=True)
+    except CalledProcessError, e:
         if chk_err:
             Print('CalledProcessError.  Error Code is ' +
                   str(e.returncode), file=sys.stderr)

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxAvailableUpdates.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxAvailableUpdates.py
@@ -281,7 +281,7 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             cmd = kwargs.get("args")
             if cmd is None:
                 cmd = popenargs[0]
-            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+            raise CalledProcessError(retcode, cmd, output=output)
         return output
 
     # Exception classes used by this module.
@@ -296,12 +296,9 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             return "Command '%s' returned non-zero exit status %d" \
                    % (self.cmd, self.returncode)
 
-    subprocess.check_output = check_output
-    subprocess.CalledProcessError = CalledProcessError
     try:
-        output = subprocess.check_output(
-            no_output, cmd, stderr=subprocess.STDOUT, shell=True)
-    except subprocess.CalledProcessError, e:
+        output = check_output(no_output, cmd, stderr=subprocess.STDOUT, shell=True)
+    except CalledProcessError, e:
         if chk_err:
             LG().Log('DEBUG', "CalledProcessError.  Error Code is " + str(e.returncode), file=sys.stdout)
             LG().Log('DEBUG', "CalledProcessError.  Command string was " + e.cmd, file=sys.stdout)

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxComputer.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxComputer.py
@@ -113,7 +113,7 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             cmd = kwargs.get("args")
             if cmd is None:
                 cmd = popenargs[0]
-            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+            raise CalledProcessError(retcode, cmd, output=output)
         return output
 
     # Exception classes used by this module.
@@ -127,12 +127,9 @@ def RunGetOutput(cmd, no_output, chk_err=True):
         def __str__(self):
             return "Command '%s' returned non-zero exit status %d" % (self.cmd, self.returncode)
 
-    subprocess.check_output = check_output
-    subprocess.CalledProcessError = CalledProcessError
     try:
-        output = subprocess.check_output(
-            no_output, cmd, stderr=subprocess.STDOUT, shell=True)
-    except subprocess.CalledProcessError, e:
+        output = check_output(no_output, cmd, stderr=subprocess.STDOUT, shell=True)
+    except CalledProcessError, e:
         if chk_err:
             print('CalledProcessError.  Error Code is ' +
                   str(e.returncode), file=sys.stdout)

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxFirewall.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxFirewall.py
@@ -254,7 +254,7 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             cmd = kwargs.get("args")
             if cmd is None:
                 cmd = popenargs[0]
-            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+            raise CalledProcessError(retcode, cmd, output=output)
         return output
 
     # Exception classes used by this module.
@@ -269,13 +269,10 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             return "Command '%s' returned non-zero exit status %d" \
             % (self.cmd, self.returncode)
 
-    subprocess.check_output = check_output
-    subprocess.CalledProcessError = CalledProcessError
     output = ''
     try:
-        output = subprocess.check_output(
-            no_output, cmd, stderr=subprocess.STDOUT, shell=True)
-    except subprocess.CalledProcessError, e:
+        output = check_output(no_output, cmd, stderr=subprocess.STDOUT, shell=True)
+    except CalledProcessError, e:
         if chk_err:
             print('CalledProcessError.  Error Code is ' +
                   str(e.returncode), file=sys.stdout)

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxMySqlDatabase.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxMySqlDatabase.py
@@ -146,7 +146,7 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             cmd = kwargs.get("args")
             if cmd is None:
                 cmd = popenargs[0]
-            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+            raise CalledProcessError(retcode, cmd, output=output)
         return output
 
     # Exception classes used by this module.
@@ -161,12 +161,9 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             return "Command '%s' returned non-zero exit status %d" \
                    % (self.cmd, self.returncode)
 
-    subprocess.check_output = check_output
-    subprocess.CalledProcessError = CalledProcessError
     try:
-        output = subprocess.check_output(
-            no_output, cmd, stderr=subprocess.STDOUT, shell=True)
-    except subprocess.CalledProcessError, e:
+        output = check_output(no_output, cmd, stderr=subprocess.STDOUT, shell=True)
+    except CalledProcessError, e:
         if chk_err:
             print('CalledProcessError.  Error Code is ' +
                   str(e.returncode), file=sys.stdout)

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxMySqlGrant.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxMySqlGrant.py
@@ -164,7 +164,7 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             cmd = kwargs.get("args")
             if cmd is None:
                 cmd = popenargs[0]
-            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+            raise CalledProcessError(retcode, cmd, output=output)
         return output
 
     # Exception classes used by this module.
@@ -179,12 +179,9 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             return "Command '%s' returned non-zero exit status %d" \
                    % (self.cmd, self.returncode)
 
-    subprocess.check_output = check_output
-    subprocess.CalledProcessError = CalledProcessError
     try:
-        output = subprocess.check_output(
-            no_output, cmd, stderr=subprocess.STDOUT, shell=True)
-    except subprocess.CalledProcessError, e:
+        output = check_output(no_output, cmd, stderr=subprocess.STDOUT, shell=True)
+    except CalledProcessError, e:
         if chk_err:
             print('CalledProcessError.  Error Code is ' +
                   str(e.returncode), file=sys.stdout)

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxMySqlUser.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxMySqlUser.py
@@ -157,7 +157,7 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             cmd = kwargs.get("args")
             if cmd is None:
                 cmd = popenargs[0]
-            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+            raise CalledProcessError(retcode, cmd, output=output)
         return output
 
     # Exception classes used by this module.
@@ -172,12 +172,9 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             return "Command '%s' returned non-zero exit status %d" \
                    % (self.cmd, self.returncode)
 
-    subprocess.check_output = check_output
-    subprocess.CalledProcessError = CalledProcessError
     try:
-        output = subprocess.check_output(
-            no_output, cmd, stderr=subprocess.STDOUT, shell=True)
-    except subprocess.CalledProcessError, e:
+        output = check_output(no_output, cmd, stderr=subprocess.STDOUT, shell=True)
+    except CalledProcessError, e:
         if chk_err:
             print('CalledProcessError.  Error Code is ' +
                   str(e.returncode), file=sys.stdout)

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSKeyMgmt.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSKeyMgmt.py
@@ -271,7 +271,7 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             cmd=kwargs.get("args")
             if cmd is None:
                 cmd=popenargs[0]
-            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+            raise CalledProcessError(retcode, cmd, output=output)
         return output
 
     # Exception classes used by this module.
@@ -288,12 +288,9 @@ def RunGetOutput(cmd, no_output, chk_err=True):
     def noop():
         pass
 
-    subprocess.check_output=check_output
-    subprocess.CalledProcessError=CalledProcessError
     try:
-        output=subprocess.check_output(
-            no_output, cmd, stderr=subprocess.STDOUT, shell=True)
-    except subprocess.CalledProcessError, e:
+        output = check_output(no_output, cmd, stderr=subprocess.STDOUT, shell=True)
+    except CalledProcessError, e:
         if chk_err:
             print("CalledProcessError.  Error Code is " +
                   str(e.returncode), file=sys.stdout)

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxPackage.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxPackage.py
@@ -737,7 +737,7 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             cmd = kwargs.get("args")
             if cmd is None:
                 cmd = popenargs[0]
-            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+            raise CalledProcessError(retcode, cmd, output=output)
         return output
 
     # Exception classes used by this module.
@@ -754,12 +754,9 @@ def RunGetOutput(cmd, no_output, chk_err=True):
     def noop():
         pass
 
-    subprocess.check_output = check_output
-    subprocess.CalledProcessError = CalledProcessError
     try:
-        output = subprocess.check_output(
-            no_output, cmd, stderr=subprocess.STDOUT, shell=True)
-    except subprocess.CalledProcessError, e:
+        output = check_output(no_output, cmd, stderr=subprocess.STDOUT, shell=True)
+    except CalledProcessError, e:
         if chk_err:
             print("CalledProcessError.  Error Code is " +
                   str(e.returncode), file=sys.stdout)

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxService.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxService.py
@@ -204,7 +204,7 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             cmd = kwargs.get("args")
             if cmd is None:
                 cmd = popenargs[0]
-            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+            raise CalledProcessError(retcode, cmd, output=output)
         return output
 
     # Exception classes used by this module.
@@ -219,12 +219,9 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             return "Command '%s' returned non-zero exit status %d" \
                    % (self.cmd, self.returncode)
 
-    subprocess.check_output = check_output
-    subprocess.CalledProcessError = CalledProcessError
     try:
-        output = subprocess.check_output(
-            no_output, cmd, stderr=subprocess.STDOUT, shell=True)
-    except subprocess.CalledProcessError, e:
+        output = check_output(no_output, cmd, stderr=subprocess.STDOUT, shell=True)
+    except CalledProcessError, e:
         if chk_err:
             Print('CalledProcessError.  Error Code is ' +
                   str(e.returncode), file=sys.stderr)
@@ -276,7 +273,7 @@ def RunGetOutputNoStderr(cmd, no_output, chk_err=True):
             cmd = kwargs.get("args")
             if cmd is None:
                 cmd = popenargs[0]
-            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+            raise CalledProcessError(retcode, cmd, output=output)
         return output
 
     # Exception classes used by this module.
@@ -291,13 +288,10 @@ def RunGetOutputNoStderr(cmd, no_output, chk_err=True):
             return "Command '%s' returned non-zero exit status %d" \
                    % (self.cmd, self.returncode)
 
-    subprocess.check_output = check_output
-    subprocess.CalledProcessError = CalledProcessError
     devnull = open('/dev/null','w')
     try:
-        output = subprocess.check_output(
-            no_output, cmd, stderr=devnull, shell=True)
-    except subprocess.CalledProcessError, e:
+        output = check_output(no_output, cmd, stderr=devnull, shell=True)
+    except CalledProcessError, e:
         if chk_err:
             Print('CalledProcessError.  Error Code is ' +
                   str(e.returncode), file=sys.stderr)

--- a/Providers/Scripts/3.x/Scripts/nxAvailableUpdates.py
+++ b/Providers/Scripts/3.x/Scripts/nxAvailableUpdates.py
@@ -278,7 +278,7 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             cmd = kwargs.get("args")
             if cmd is None:
                 cmd = popenargs[0]
-            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+            raise CalledProcessError(retcode, cmd, output=output)
         return output
 
     # Exception classes used by this module.
@@ -293,15 +293,12 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             return "Command '%s' returned non-zero exit status %d" \
                    % (self.cmd, self.returncode)
 
-    subprocess.check_output = check_output
-    subprocess.CalledProcessError = CalledProcessError
     output=b''
     try:
-        output = subprocess.check_output(
-            no_output, cmd, stderr=subprocess.STDOUT, shell=True)
+        output = check_output(no_output, cmd, stderr=subprocess.STDOUT, shell=True)
         if output is None:
             output=b''
-    except subprocess.CalledProcessError as e:
+    except CalledProcessError as e:
         if chk_err:
             print('CalledProcessError.  Error Code is ' +
                   str(e.returncode), file=sys.stderr)

--- a/Providers/Scripts/3.x/Scripts/nxComputer.py
+++ b/Providers/Scripts/3.x/Scripts/nxComputer.py
@@ -110,7 +110,7 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             cmd = kwargs.get("args")
             if cmd is None:
                 cmd = popenargs[0]
-            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+            raise CalledProcessError(retcode, cmd, output=output)
         return output
 
     # Exception classes used by this module.
@@ -124,15 +124,12 @@ def RunGetOutput(cmd, no_output, chk_err=True):
         def __str__(self):
             return "Command '%s' returned non-zero exit status %d" % (self.cmd, self.returncode)
 
-    subprocess.check_output = check_output
-    subprocess.CalledProcessError = CalledProcessError
     output=b''
     try:
-        output = subprocess.check_output(
-            no_output, cmd, stderr=subprocess.STDOUT, shell=True)
+        output = check_output(no_output, cmd, stderr=subprocess.STDOUT, shell=True)
         if output is None:
             output=b''
-    except subprocess.CalledProcessError as e:
+    except CalledProcessError as e:
         if chk_err:
             print('CalledProcessError.  Error Code is ' +
                   str(e.returncode), file=sys.stdout)

--- a/Providers/Scripts/3.x/Scripts/nxFirewall.py
+++ b/Providers/Scripts/3.x/Scripts/nxFirewall.py
@@ -253,7 +253,7 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             cmd = kwargs.get("args")
             if cmd is None:
                 cmd = popenargs[0]
-            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+            raise CalledProcessError(retcode, cmd, output=output)
         return output
 
     # Exception classes used by this module.
@@ -268,13 +268,10 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             return "Command '%s' returned non-zero exit status %d" \
             % (self.cmd, self.returncode)
 
-    subprocess.check_output = check_output
-    subprocess.CalledProcessError = CalledProcessError
     output = ''
     try:
-        output = subprocess.check_output(
-            no_output, cmd, stderr=subprocess.STDOUT, shell=True)
-    except subprocess.CalledProcessError as e:
+        output = check_output(no_output, cmd, stderr=subprocess.STDOUT, shell=True)
+    except CalledProcessError as e:
         if chk_err:
             print('CalledProcessError.  Error Code is ' +
                   str(e.returncode), file=sys.stdout)

--- a/Providers/Scripts/3.x/Scripts/nxMySqlDatabase.py
+++ b/Providers/Scripts/3.x/Scripts/nxMySqlDatabase.py
@@ -143,7 +143,7 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             cmd = kwargs.get("args")
             if cmd is None:
                 cmd = popenargs[0]
-            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+            raise CalledProcessError(retcode, cmd, output=output)
         return output
 
     # Exception classes used by this module.
@@ -158,15 +158,12 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             return "Command '%s' returned non-zero exit status %d" \
                    % (self.cmd, self.returncode)
 
-    subprocess.check_output = check_output
-    subprocess.CalledProcessError = CalledProcessError
     output=b''
     try:
-        output = subprocess.check_output(
-            no_output, cmd, stderr=subprocess.STDOUT, shell=True)
+        output = check_output(no_output, cmd, stderr=subprocess.STDOUT, shell=True)
         if output is None:
             output=b''
-    except subprocess.CalledProcessError as e:
+    except CalledProcessError as e:
         if chk_err:
             print('CalledProcessError.  Error Code is ' +
                   str(e.returncode), file=sys.stdout)

--- a/Providers/Scripts/3.x/Scripts/nxMySqlGrant.py
+++ b/Providers/Scripts/3.x/Scripts/nxMySqlGrant.py
@@ -161,7 +161,7 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             cmd = kwargs.get("args")
             if cmd is None:
                 cmd = popenargs[0]
-            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+            raise CalledProcessError(retcode, cmd, output=output)
         return output
 
     # Exception classes used by this module.
@@ -176,15 +176,12 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             return "Command '%s' returned non-zero exit status %d" \
                    % (self.cmd, self.returncode)
 
-    subprocess.check_output = check_output
-    subprocess.CalledProcessError = CalledProcessError
     output=b''
     try:
-        output = subprocess.check_output(
-            no_output, cmd, stderr=subprocess.STDOUT, shell=True)
+        output = check_output(no_output, cmd, stderr=subprocess.STDOUT, shell=True)
         if output is None:
             output=b''
-    except subprocess.CalledProcessError as e:
+    except CalledProcessError as e:
         if chk_err:
             print('CalledProcessError.  Error Code is ' +
                   str(e.returncode), file=sys.stdout)

--- a/Providers/Scripts/3.x/Scripts/nxMySqlUser.py
+++ b/Providers/Scripts/3.x/Scripts/nxMySqlUser.py
@@ -154,7 +154,7 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             cmd = kwargs.get("args")
             if cmd is None:
                 cmd = popenargs[0]
-            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+            raise CalledProcessError(retcode, cmd, output=output)
         return output
 
     # Exception classes used by this module.
@@ -169,15 +169,12 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             return "Command '%s' returned non-zero exit status %d" \
                    % (self.cmd, self.returncode)
 
-    subprocess.check_output = check_output
-    subprocess.CalledProcessError = CalledProcessError
     output=b''
     try:
-        output = subprocess.check_output(
-            no_output, cmd, stderr=subprocess.STDOUT, shell=True)
+        output = check_output(no_output, cmd, stderr=subprocess.STDOUT, shell=True)
         if output is None:
             output=b''
-    except subprocess.CalledProcessError as e:
+    except CalledProcessError as e:
         if chk_err:
             print('CalledProcessError.  Error Code is ' +
                   str(e.returncode), file=sys.stdout)

--- a/Providers/Scripts/3.x/Scripts/nxOMSKeyMgmt.py
+++ b/Providers/Scripts/3.x/Scripts/nxOMSKeyMgmt.py
@@ -265,7 +265,7 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             cmd = kwargs.get("args")
             if cmd is None:
                 cmd = popenargs[0]
-            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+            raise CalledProcessError(retcode, cmd, output=output)
         return output
 
     # Exception classes used by this module.
@@ -280,15 +280,12 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             return "Command '%s' returned non-zero exit status %d" \
                    % (self.cmd, self.returncode)
 
-    subprocess.check_output = check_output
-    subprocess.CalledProcessError = CalledProcessError
     output=b''
     try:
-        output = subprocess.check_output(
-            no_output, cmd, stderr=subprocess.STDOUT, shell=True)
+        output = check_output(no_output, cmd, stderr=subprocess.STDOUT, shell=True)
         if output is None:
             output=b''
-    except subprocess.CalledProcessError as e:
+    except CalledProcessError as e:
         if chk_err:
             print('CalledProcessError.  Error Code is ' +
                   str(e.returncode), file=sys.stdout)

--- a/Providers/Scripts/3.x/Scripts/nxPackage.py
+++ b/Providers/Scripts/3.x/Scripts/nxPackage.py
@@ -724,7 +724,7 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             cmd = kwargs.get("args")
             if cmd is None:
                 cmd = popenargs[0]
-            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+            raise CalledProcessError(retcode, cmd, output=output)
         return output
 
     # Exception classes used by this module.
@@ -741,15 +741,12 @@ def RunGetOutput(cmd, no_output, chk_err=True):
     def noop():
         pass
 
-    subprocess.check_output = check_output
-    subprocess.CalledProcessError = CalledProcessError
     output = b''
     try:
-        output = subprocess.check_output(
-            no_output, cmd, stderr=subprocess.STDOUT, shell=True)
+        output = check_output(no_output, cmd, stderr=subprocess.STDOUT, shell=True)
         if output is None:
             output = b''
-    except subprocess.CalledProcessError as e:
+    except CalledProcessError as e:
         if chk_err:
             print('CalledProcessError.  Error Code is ' +
                   str(e.returncode), file=sys.stdout)

--- a/Providers/Scripts/3.x/Scripts/nxService.py
+++ b/Providers/Scripts/3.x/Scripts/nxService.py
@@ -198,7 +198,7 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             cmd = kwargs.get("args")
             if cmd is None:
                 cmd = popenargs[0]
-            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+            raise CalledProcessError(retcode, cmd, output=output)
         return output
 
     # Exception classes used by this module.
@@ -213,15 +213,12 @@ def RunGetOutput(cmd, no_output, chk_err=True):
             return "Command '%s' returned non-zero exit status %d" \
                    % (self.cmd, self.returncode)
 
-    subprocess.check_output = check_output
-    subprocess.CalledProcessError = CalledProcessError
     output = b''
     try:
-        output = subprocess.check_output(
-            no_output, cmd, stderr=subprocess.STDOUT, shell=True)
+        output = check_output(no_output, cmd, stderr=subprocess.STDOUT, shell=True)
         if output is None:
             output = b''
-    except subprocess.CalledProcessError as e:
+    except CalledProcessError as e:
         if chk_err:
             Print('CalledProcessError.  Error Code is ' +
                   str(e.returncode), file=sys.stderr)
@@ -272,7 +269,7 @@ def RunGetOutputNoStderr(cmd, no_output, chk_err=True):
             cmd = kwargs.get("args")
             if cmd is None:
                 cmd = popenargs[0]
-            raise subprocess.CalledProcessError(retcode, cmd, output=output)
+            raise CalledProcessError(retcode, cmd, output=output)
         return output
 
     # Exception classes used by this module.
@@ -287,15 +284,12 @@ def RunGetOutputNoStderr(cmd, no_output, chk_err=True):
             return "Command '%s' returned non-zero exit status %d" \
                    % (self.cmd, self.returncode)
 
-    subprocess.check_output = check_output
-    subprocess.CalledProcessError = CalledProcessError
     output = b''
     try:
-        output = subprocess.check_output(
-            no_output, cmd, stderr=subprocess.DEVNULL, shell=True)
+        output = check_output(no_output, cmd, stderr=subprocess.DEVNULL, shell=True)
         if output is None:
             output = b''
-    except subprocess.CalledProcessError as e:
+    except CalledProcessError as e:
         if chk_err:
             Print('CalledProcessError.  Error Code is ' +
                   str(e.returncode), file=sys.stderr)


### PR DESCRIPTION
ICM 206330504

These modules are possibly not even used anymore and the true owner is unclear.

Original author monkey patched `subprocess` module even though they were just using the methods locally. Due to the `readdir` syscall ([used for `glob`](https://github.com/microsoft/PowerShell-DSC-for-Linux/blob/ae83029118ffdc1e2c1fe31d51dc398fa2079dbe/LCM/scripts/python3/RegenerateInitFiles.py#L13)) implementation-specific iteration sequence, sometimes `__all__` list in `__init__.py` generated at install time by omsconfig for each versioned Scripts directory will have `nxService` before `nxOMSPlugin`, which means the call to `platform.architecture()` will fail on Python 3.8+ since the function uses `subprocess.check_output`, which has been monkey-patched with some broken implementation (different signature). There may be even more modules that fail due to use of stdlib functions that rely on `subprocess.check_output`, but not ones that are put in the MOF for this specific test machine.