### PR TITLE
Update nxOMSAgentNPMConfig module to 3.7 version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -588,7 +588,7 @@ nxFileInventory:
 
 nxOMSAgentNPMConfig:
 	rm -rf output/staging; \
-	VERSION="3.6"; \
+	VERSION="3.7"; \
 	PROVIDERS="nxOMSAgentNPMConfig"; \
 	STAGINGDIR="output/staging/$@/DSCResources"; \
 	cat Providers/Modules/$@.psd1 | sed "s@<MODULE_VERSION>@$${VERSION}@" > intermediate/Modules/$@.psd1; \


### PR DESCRIPTION
This PR is to update:

nxOMSAgentNPMConfig DSC module version to 3.7 with the changes merged to npm_crossplat branch till 15th October 2020.

Following is the last PR till which changes are available in this new binary:

https://msazure.visualstudio.com/One/_git/Mgmt-LogAnalytics-NPMD/pullrequest/3598431