### PR TITLE
Perf Counter empty list explicitly typed fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -406,7 +406,7 @@ nxMySQL:
 
 nxOMSPerfCounter:
 	rm -rf output/staging; \
-        VERSION="2.2"; \
+        VERSION="2.3"; \
         PROVIDERS="nxOMSPerfCounter"; \
         STAGINGDIR="output/staging/$@/DSCResources"; \
         cat Providers/Modules/$@.psd1 | sed "s@<MODULE_VERSION>@$${VERSION}@" > intermediate/Modules/$@.psd1; \

--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSPerfCounter.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSPerfCounter.py
@@ -67,7 +67,7 @@ def init_vars(WorkspaceID, HeartbeatIntervalSeconds, PerfCounterObject):
             if len(perf['PerformanceCounter'].value):
                 for perf_counter in perf['PerformanceCounter'].value:
                     new_perfs.append(perf_counter.encode('ascii', 'ignore'))
-                perf['PerformanceCounter'] = new_perfs
+            perf['PerformanceCounter'] = new_perfs
             if perf['InstanceName'].value is None:
                 perf['InstanceName'] = ''
             else:

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSPerfCounter.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSPerfCounter.py
@@ -68,7 +68,7 @@ def init_vars(WorkspaceID, HeartbeatIntervalSeconds, PerfCounterObject):
             if len(perf['PerformanceCounter'].value):
                 for perf_counter in perf['PerformanceCounter'].value:
                     new_perfs.append(perf_counter.encode('ascii', 'ignore'))
-                perf['PerformanceCounter'] = new_perfs
+            perf['PerformanceCounter'] = new_perfs
             if perf['InstanceName'].value is None:
                 perf['InstanceName'] = ''
             else:

--- a/Providers/Scripts/3.x/Scripts/nxOMSPerfCounter.py
+++ b/Providers/Scripts/3.x/Scripts/nxOMSPerfCounter.py
@@ -67,7 +67,7 @@ def init_vars(WorkspaceID, HeartbeatIntervalSeconds, PerfCounterObject):
             if len(perf['PerformanceCounter'].value):
                 for perf_counter in perf['PerformanceCounter'].value:
                     new_perfs.append(perf_counter)
-                perf['PerformanceCounter'] = new_perfs
+            perf['PerformanceCounter'] = new_perfs
             if perf['InstanceName'].value is None:
                 perf['InstanceName'] = ''
             else:

--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -82,7 +82,7 @@ SHLIB_EXT: 'so'
 /opt/microsoft/omsconfig/Scripts/OMS_MetaConfigHelper.py; intermediate/Scripts/OMS_MetaConfigHelper.py; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/Scripts/python3/OMS_MetaConfigHelper.py; intermediate/Scripts/python3/OMS_MetaConfigHelper.py; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nx_1.0.zip; release/nx_1.0.zip; 755; ${{RUN_AS_USER}}; root
-/opt/microsoft/omsconfig/module_packages/nxOMSPerfCounter_2.2.zip; release/nxOMSPerfCounter_2.2.zip; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/omsconfig/module_packages/nxOMSPerfCounter_2.3.zip; release/nxOMSPerfCounter_2.3.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSSyslog_2.5.zip; release/nxOMSSyslog_2.5.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSSudoCustomLog_2.7.zip; release/nxOMSSudoCustomLog_2.7.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSKeyMgmt_1.0.zip; release/nxOMSKeyMgmt_1.0.zip; 755; ${{RUN_AS_USER}}; root
@@ -353,7 +353,7 @@ fi
 if [ "$pythonVersion" = "python3" ]; then
 	echo "Running python3, python version is ", $pythonVersion
 	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/python3/InstallModule.py /opt/microsoft/omsconfig/module_packages/nx_1.0.zip 0"
-	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/python3/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSPerfCounter_2.2.zip 0"
+	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/python3/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSPerfCounter_2.3.zip 0"
 	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/python3/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSSyslog_2.5.zip 0"
 	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/python3/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSSudoCustomLog_2.7.zip 0"
 	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/python3/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSKeyMgmt_1.0.zip 0"
@@ -362,7 +362,7 @@ if [ "$pythonVersion" = "python3" ]; then
 else
   echo "Running  python version is ", $pythonVersion
 	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nx_1.0.zip 0"
-	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSPerfCounter_2.2.zip 0"
+	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSPerfCounter_2.3.zip 0"
 	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSSyslog_2.5.zip 0"
 	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSSudoCustomLog_2.7.zip 0"
 	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSKeyMgmt_1.0.zip 0"


### PR DESCRIPTION
In certain scenarios, the PerformanceCounter list (if empty) is explicitly typed as `MI_STRINGA`, which then causes parsing issues when trying to read the empty list. This fix changes empty lists to be not explicitly typed when initializing the variables.