### PR TITLE
Update nxOMSAgentNPMConfig module to 3.8 version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -588,7 +588,7 @@ nxFileInventory:
 
 nxOMSAgentNPMConfig:
 	rm -rf output/staging; \
-	VERSION="3.7"; \
+	VERSION="3.8"; \
 	PROVIDERS="nxOMSAgentNPMConfig"; \
 	STAGINGDIR="output/staging/$@/DSCResources"; \
 	cat Providers/Modules/$@.psd1 | sed "s@<MODULE_VERSION>@$${VERSION}@" > intermediate/Modules/$@.psd1; \


### PR DESCRIPTION
This PR is to update nxOMSAgentNPMConfig DSC module with NPMDAgent binary that has latest changes merged to npm_crossplat branch till 23Nov 2020.

Following is the last PR whose changes are available in NPMDAgent binary bundled now:

https://msazure.visualstudio.com/One/_git/Mgmt-LogAnalytics-NPMD/pullrequest/3777789