### PR TITLE
Update nxOMSAgentNPMConfig DSC module version to 3.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -588,7 +588,7 @@ nxFileInventory:
 
 nxOMSAgentNPMConfig:
 	rm -rf output/staging; \
-	VERSION="3.8"; \
+	VERSION="3.9"; \
 	PROVIDERS="nxOMSAgentNPMConfig"; \
 	STAGINGDIR="output/staging/$@/DSCResources"; \
 	cat Providers/Modules/$@.psd1 | sed "s@<MODULE_VERSION>@$${VERSION}@" > intermediate/Modules/$@.psd1; \


### PR DESCRIPTION
This PR is to update:

1. npmd_agent_x64 binary in nxOMSAgentNPMConfig DSC module.
2. Changes from npm_crossplat branch are taken till 11th Dec 2020.

**Last PR merged to npm_crossplat branch:** 

Pull Request 3849122: ignore timedrift property in data as well submitting operation
https://msazure.visualstudio.com/One/_git/Mgmt-LogAnalytics-NPMD/pullrequest/3849122