### PR TITLE
Fixed case where comparing stdout bytes to a string issue #797

### DIFF
--- a/Providers/Scripts/3.x/Scripts/nxService.py
+++ b/Providers/Scripts/3.x/Scripts/nxService.py
@@ -553,7 +553,8 @@ def GetSystemdState(sc):
     (process_stdout, process_stderr, retval) = Process(
         [systemctl_path, "status", sc.Name])
     if retval is 0:
-        if '(running)' in process_stdout:
+        process_stdout_str = process_stdout.decode() if isinstance(process_stdout, bytes) else process_stdout
+        if '(running)' in process_stdout_str:
             return "running"
     return "stopped"
 
@@ -602,7 +603,8 @@ def GetUpstartState(sc):
                  " failed: " + process_stderr)
         return ""
 
-    if (sc.Name + " start") in process_stdout:
+    process_stdout_str = process_stdout.decode() if isinstance(process_stdout, bytes) else process_stdout
+    if (sc.Name + " start") in process_stdout_str:
         return "running"
     else:
         return "stopped"
@@ -678,7 +680,8 @@ def GetUpstartEnabled(sc):
             (process_stdout, process_stderr, retval) = Process(
                 ['chkconfig', sc.Name, ''])  # try init style
             if retval is 0:
-                if 'off' not in process_stdout:
+                process_stdout_str = process_stdout.decode() if isinstance(process_stdout, bytes) else process_stdout
+                if 'off' not in process_stdout_str:
                     return True
             return False
         if start_on_exists and start_on_is_enabled:
@@ -855,7 +858,8 @@ def ServiceExistsInSystemd(sc):
     (process_stdout, process_stderr, retval) = Process(
         [systemctl_path, "status", sc.Name])
     if retval is not 0:
-        if "Loaded: loaded" in process_stdout:
+        process_stdout_str = process_stdout.decode() if isinstance(process_stdout, bytes) else process_stdout
+        if "Loaded: loaded" in process_stdout_str:
             return True
         else:
             return False
@@ -926,13 +930,14 @@ def ModifySystemdService(sc):
     (process_stdout, process_stderr, retval) = Process(
         [systemctl_path, "status", sc.Name + '.service'])
     # retval may be non zero even if service exists for 'status'.
-    if 'No such file or directory' in process_stdout:
+    process_stdout_str = process_stdout.decode() if isinstance(process_stdout, bytes) else process_stdout
+    if 'No such file or directory' in process_stdout_str:
         Print("Error: " + systemctl_path + " status " + sc.Name +
               " failed: " + process_stderr, file=sys.stderr)
         LG().Log('ERROR', "Error: " + systemctl_path +
                  " status " + sc.Name + " failed: " + process_stderr)
         return [-1]
-    if 'Active: active' in process_stdout:
+    if 'Active: active' in process_stdout_str:
         Print("Running", file=sys.stderr)
         LG().Log('INFO', "Running")
         if sc.State and sc.State != "running":
@@ -1132,7 +1137,8 @@ def ModifyInitService(sc):
                     LG().Log('ERROR', "Error: " + check_enabled_program +
                              " -f " + sc.Name + " defaults failed: " + process_stderr)
                     return [-1]
-                if 'already exist' in process_stdout:  # we need to remove them first
+                process_stdout_str = process_stdout.decode() if isinstance(process_stdout, bytes) else process_stdout
+                if 'already exist' in process_stdout_str:  # we need to remove them first
                     (process_stdout, process_stderr, retval) = Process(
                         [check_enabled_program, "-f", sc.Name, "remove"])
                     if retval is not 0:
@@ -1190,7 +1196,8 @@ def ModifyInitService(sc):
                     LG().Log('ERROR', "Error: " + check_enabled_program +
                              " -f " + sc.Name + " defaults failed: " + process_stderr)
                     return [-1]
-                if 'already exist' in process_stdout:  # we need to remove them first
+                process_stdout_str = process_stdout.decode() if isinstance(process_stdout, bytes) else process_stdout
+                if 'already exist' in process_stdout_str:  # we need to remove them first
                     (process_stdout, process_stderr, retval) = Process(
                         [check_enabled_program, "-f", sc.Name, "remove"])
                     if retval is not 0:


### PR DESCRIPTION
<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-IN style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>



Incident ID or link | https://github.com/microsoft/PowerShell-DSC-for-Linux/issues/797
-- | --
Issue summary | Configurations   with nxService resource where the service falls under servicemd fails for   Python3 during get_marshall()
Impact | All distros   running on python 3 will not be able to use configurations which try to set   service that falls under servicemd for nxService resource.      The service will not crash but fail gracefully.
Root cause | The reason the   get_mashall() is failing is because of a comparison  between string and stdout. For python 3   stdout can be in bytes.      Issue in line: https://github.com/microsoft/PowerShell-DSC-for-Linux/blob/v1.2.0-0/Providers/Scripts/3.x/Scripts/nxService.py#L858
Reason for not getting caught before release | This scenario was   not covered as a part of test suite or manual tests.      Manual tests were only done for major scenarios and not for corner cases.



</div>

<!--EndFragment-->
</body>

</html>
