### PR TITLE
Fixed issues with python 2.6

### DIFF
--- a/LCM/scripts/GetDscConfiguration.py
+++ b/LCM/scripts/GetDscConfiguration.py
@@ -31,7 +31,7 @@ dsc_host_output_path = join(dsc_host_base_path, 'output')
 dsc_host_lock_path = join(dsc_host_base_path, 'dsc_host_lock')
 dsc_host_switch_path = join(dsc_host_base_path, 'dsc_host_ready')
 
-LG().Log("DEBUG", "Starting script logic for " + argv[0]+ " runing with python " + str(sys.version_info.major))
+LG().Log("DEBUG", "Starting script logic for " + argv[0]+ " runing with python " + str(sys.version_info))
 
 if ("omsconfig" in helperlib.DSC_SCRIPT_PATH):
     write_omsconfig_host_switch_event(pathToCurrentScript, isfile(dsc_host_switch_path))
@@ -100,5 +100,5 @@ else:
 print(stdout)
 print(stderr)
 
-LG().Log("DEBUG", "End of script logic for " +  argv[0] + " runing with python " + str(sys.version_info.major))
+LG().Log("DEBUG", "End of script logic for " +  argv[0] + " runing with python " + str(sys.version_info))
 

--- a/LCM/scripts/GetDscLocalConfigurationManager.py
+++ b/LCM/scripts/GetDscLocalConfigurationManager.py
@@ -30,7 +30,7 @@ dsc_host_output_path = join(dsc_host_base_path, 'output')
 dsc_host_lock_path = join(dsc_host_base_path, 'dsc_host_lock')
 dsc_host_switch_path = join(dsc_host_base_path, 'dsc_host_ready')
 
-LG().Log("DEBUG", "Starting script logic for " + argv[0]+ " runing with python " + str(sys.version_info.major))
+LG().Log("DEBUG", "Starting script logic for " + argv[0]+ " runing with python " + str(sys.version_info))
 
 if ("omsconfig" in helperlib.DSC_SCRIPT_PATH):
     write_omsconfig_host_switch_event(pathToCurrentScript, isfile(dsc_host_switch_path))
@@ -99,5 +99,5 @@ else:
 print(stdout)
 print(stderr)
 
-LG().Log("DEBUG", "End of script logic for " +  argv[0] + " runing with python " + str(sys.version_info.major))
+LG().Log("DEBUG", "End of script logic for " +  argv[0] + " runing with python " + str(sys.version_info))
 

--- a/LCM/scripts/PerformRequiredConfigurationChecks.py
+++ b/LCM/scripts/PerformRequiredConfigurationChecks.py
@@ -116,6 +116,6 @@ def run_perform_required_configuration_checks():
     print(stdout)
 
 if __name__ == "__main__":
-    LG().Log("DEBUG", "Starting Main method for " + argv[0] + " runing with python " + str(sys.version_info.major))
+    LG().Log("DEBUG", "Starting Main method for " + argv[0] + " runing with python " + str(sys.version_info))
     main()
-    LG().Log("DEBUG", "End of Main method for " +  argv[0] + " runing with python " + str(sys.version_info.major))
+    LG().Log("DEBUG", "End of Main method for " +  argv[0] + " runing with python " + str(sys.version_info))

--- a/LCM/scripts/Register.py
+++ b/LCM/scripts/Register.py
@@ -29,7 +29,7 @@ DSCLogPath = join(pathToCommonScriptsFolder, 'nxDSCLog.py')
 nxDSCLog = load_source('nxDSCLog', DSCLogPath)
 LG = nxDSCLog.DSCLog
 
-LG().Log("DEBUG", "Starting script logic for " + argv[0]+ " runing with python " + str(sys.version_info.major))
+LG().Log("DEBUG", "Starting script logic for " + argv[0]+ " runing with python " + str(sys.version_info))
 
 # Apply a DSC meta configuration based on a template
 Variables = dict()
@@ -231,4 +231,4 @@ os.system("<DSC_SCRIPT_PATH>/SetDscLocalConfigurationManager.py -configurationmo
 
 shutil.rmtree(tempdir)
 
-LG().Log("DEBUG", "End of script logic for " +  argv[0] + " runing with python " + str(sys.version_info.major))
+LG().Log("DEBUG", "End of script logic for " +  argv[0] + " runing with python " + str(sys.version_info))

--- a/LCM/scripts/RemoveModule.py
+++ b/LCM/scripts/RemoveModule.py
@@ -203,6 +203,6 @@ def main(args):
     shutil.rmtree(modulePath)
 
 if __name__ == "__main__":
-    LG().Log("DEBUG", "Starting Main method for " + argv[0] + " runing with python " + str(sys.version_info.major))
+    LG().Log("DEBUG", "Starting Main method for " + argv[0] + " runing with python " + str(sys.version_info))
     main(sys.argv[1:])
-    LG().Log("DEBUG", "End of Main method for " +  argv[0] + " runing with python " + str(sys.version_info.major))
+    LG().Log("DEBUG", "End of Main method for " +  argv[0] + " runing with python " + str(sys.version_info))

--- a/LCM/scripts/RestoreConfiguration.py
+++ b/LCM/scripts/RestoreConfiguration.py
@@ -27,7 +27,7 @@ dsc_host_output_path = join(dsc_host_base_path, 'output')
 dsc_host_lock_path = join(dsc_host_base_path, 'dsc_host_lock')
 dsc_host_switch_path = join(dsc_host_base_path, 'dsc_host_ready')
 
-LG().Log("DEBUG", "Starting script logic for " + argv[0]+ " runing with python " + str(sys.version_info.major))
+LG().Log("DEBUG", "Starting script logic for " + argv[0]+ " runing with python " + str(sys.version_info))
 
 if ("omsconfig" in helperlib.DSC_SCRIPT_PATH):
     write_omsconfig_host_switch_event(pathToCurrentScript, isfile(dsc_host_switch_path))
@@ -94,4 +94,4 @@ else:
 print(stdout)
 print(stderr)
 
-LG().Log("DEBUG", "End of script logic for " +  argv[0] + " runing with python " + str(sys.version_info.major))
+LG().Log("DEBUG", "End of script logic for " +  argv[0] + " runing with python " + str(sys.version_info))

--- a/LCM/scripts/SetDscLocalConfigurationManager.py
+++ b/LCM/scripts/SetDscLocalConfigurationManager.py
@@ -176,6 +176,6 @@ def signal_handler(signalNumber, frame):
 if __name__ == "__main__":
     # register the SIGTERM handler
     signal.signal(signal.SIGTERM, signal_handler)
-    LG().Log("DEBUG", "Starting Main method for " + argv[0] + " runing with python " + str(sys.version_info.major))
+    LG().Log("DEBUG", "Starting Main method for " + argv[0] + " runing with python " + str(sys.version_info))
     main(argv)
-    LG().Log("DEBUG", "End of Main method for " +  argv[0] + " runing with python " + str(sys.version_info.major))
+    LG().Log("DEBUG", "End of Main method for " +  argv[0] + " runing with python " + str(sys.version_info))

--- a/LCM/scripts/StartDscConfiguration.py
+++ b/LCM/scripts/StartDscConfiguration.py
@@ -213,6 +213,6 @@ def main(argv):
     print(stdout)
     print(stderr)
 
-LG().Log("DEBUG", "Starting Main method for " + argv[0] + " runing with python " + str(sys.version_info.major))
+LG().Log("DEBUG", "Starting Main method for " + argv[0] + " runing with python " + str(sys.version_info))
 main(argv[1:])
-LG().Log("DEBUG", "End of Main method for " +  argv[0] + " runing with python " + str(sys.version_info.major))
+LG().Log("DEBUG", "End of Main method for " +  argv[0] + " runing with python " + str(sys.version_info))

--- a/LCM/scripts/TestDscConfiguration.py
+++ b/LCM/scripts/TestDscConfiguration.py
@@ -25,7 +25,7 @@ dsc_host_output_path = join(dsc_host_base_path, 'output')
 dsc_host_lock_path = join(dsc_host_base_path, 'dsc_host_lock')
 dsc_host_switch_path = join(dsc_host_base_path, 'dsc_host_ready')
 
-LG().Log("DEBUG", "Starting script logic for " + argv[0]+ " runing with python " + str(sys.version_info.major))
+LG().Log("DEBUG", "Starting script logic for " + argv[0]+ " runing with python " + str(sys.version_info))
 
 if ("omsconfig" in helperlib.DSC_SCRIPT_PATH):
     write_omsconfig_host_switch_event(pathToCurrentScript, isfile(dsc_host_switch_path))
@@ -102,4 +102,4 @@ else:
 print(stdout)
 print(stderr)
 
-LG().Log("DEBUG", "End of script logic for " +  argv[0] + " runing with python " + str(sys.version_info.major))
+LG().Log("DEBUG", "End of script logic for " +  argv[0] + " runing with python " + str(sys.version_info))

--- a/LCM/scripts/python3/GetDscConfiguration.py
+++ b/LCM/scripts/python3/GetDscConfiguration.py
@@ -33,7 +33,7 @@ dsc_host_output_path = join(dsc_host_base_path, 'output')
 dsc_host_lock_path = join(dsc_host_base_path, 'dsc_host_lock')
 dsc_host_switch_path = join(dsc_host_base_path, 'dsc_host_ready')
 
-LG().Log("DEBUG", "Starting script logic for " + argv[0]+ " runing with python " + str(sys.version_info.major))
+LG().Log("DEBUG", "Starting script logic for " + argv[0]+ " runing with python " + str(sys.version_info))
 
 if ("omsconfig" in helperlib.DSC_SCRIPT_PATH):
     write_omsconfig_host_switch_event(pathToCurrentScript, isfile(dsc_host_switch_path))
@@ -106,4 +106,4 @@ stderr = stderr.decode() if isinstance(stderr, bytes) else stderr
 print(stdout)
 print(stderr)
 
-LG().Log("DEBUG", "End of script logic for " +  argv[0] + " runing with python " + str(sys.version_info.major))
+LG().Log("DEBUG", "End of script logic for " +  argv[0] + " runing with python " + str(sys.version_info))

--- a/LCM/scripts/python3/GetDscLocalConfigurationManager.py
+++ b/LCM/scripts/python3/GetDscLocalConfigurationManager.py
@@ -33,7 +33,7 @@ dsc_host_output_path = join(dsc_host_base_path, 'output')
 dsc_host_lock_path = join(dsc_host_base_path, 'dsc_host_lock')
 dsc_host_switch_path = join(dsc_host_base_path, 'dsc_host_ready')
 
-LG().Log("DEBUG", "Starting script logic for " + argv[0]+ " runing with python " + str(sys.version_info.major))
+LG().Log("DEBUG", "Starting script logic for " + argv[0]+ " runing with python " + str(sys.version_info))
 
 if ("omsconfig" in helperlib.DSC_SCRIPT_PATH):
     write_omsconfig_host_switch_event(pathToCurrentScript, isfile(dsc_host_switch_path))
@@ -105,4 +105,4 @@ stderr = stderr.decode() if isinstance(stderr, bytes) else stderr
 print(stdout)
 print(stderr)
 
-LG().Log("DEBUG", "End of script logic for " +  argv[0] + " runing with python " + str(sys.version_info.major))
+LG().Log("DEBUG", "End of script logic for " +  argv[0] + " runing with python " + str(sys.version_info))

--- a/LCM/scripts/python3/PerformRequiredConfigurationChecks.py
+++ b/LCM/scripts/python3/PerformRequiredConfigurationChecks.py
@@ -120,6 +120,6 @@ def run_perform_required_configuration_checks():
     print(stdout)
 
 if __name__ == "__main__":
-    LG().Log("DEBUG", "Starting Main method for " + argv[0] + " runing with python " + str(sys.version_info.major))
+    LG().Log("DEBUG", "Starting Main method for " + argv[0] + " runing with python " + str(sys.version_info))
     main()
-    LG().Log("DEBUG", "End of Main method for " +  argv[0] + " runing with python " + str(sys.version_info.major))
+    LG().Log("DEBUG", "End of Main method for " +  argv[0] + " runing with python " + str(sys.version_info))

--- a/LCM/scripts/python3/Register.py
+++ b/LCM/scripts/python3/Register.py
@@ -32,7 +32,7 @@ OPTIONS (case insensitive):
  --Help
 """)
 
-LG().Log("DEBUG", "Starting script logic for " + argv[0]+ " runing with python " + str(sys.version_info.major))
+LG().Log("DEBUG", "Starting script logic for " + argv[0]+ " runing with python " + str(sys.version_info))
 
 # Apply a DSC meta configuration based on a template
 Variables = dict()
@@ -233,4 +233,4 @@ if RegenerateCert == True:
 os.system("<DSC_SCRIPT_PATH>/python3/SetDscLocalConfigurationManager.py -configurationmof " + meta_path)
 
 shutil.rmtree(tempdir)
-LG().Log("DEBUG", "End of script logic for " +  argv[0] + " runing with python " + str(sys.version_info.major))
+LG().Log("DEBUG", "End of script logic for " +  argv[0] + " runing with python " + str(sys.version_info))

--- a/LCM/scripts/python3/RemoveModule.py
+++ b/LCM/scripts/python3/RemoveModule.py
@@ -210,7 +210,7 @@ def main(args):
     shutil.rmtree(modulePath)
 
 if __name__ == "__main__":
-    LG().Log("DEBUG", "Starting Main method for " + argv[0] + " runing with python " + str(sys.version_info.major))
+    LG().Log("DEBUG", "Starting Main method for " + argv[0] + " runing with python " + str(sys.version_info))
     main(sys.argv[1:])
-    LG().Log("DEBUG", "End of Main method for " +  argv[0] + " runing with python " + str(sys.version_info.major))
+    LG().Log("DEBUG", "End of Main method for " +  argv[0] + " runing with python " + str(sys.version_info))
 

--- a/LCM/scripts/python3/RestoreConfiguration.py
+++ b/LCM/scripts/python3/RestoreConfiguration.py
@@ -29,7 +29,7 @@ dsc_host_output_path = join(dsc_host_base_path, 'output')
 dsc_host_lock_path = join(dsc_host_base_path, 'dsc_host_lock')
 dsc_host_switch_path = join(dsc_host_base_path, 'dsc_host_ready')
 
-LG().Log("DEBUG", "Starting script logic for " + argv[0]+ " runing with python " + str(sys.version_info.major))
+LG().Log("DEBUG", "Starting script logic for " + argv[0]+ " runing with python " + str(sys.version_info))
 
 if ("omsconfig" in helperlib.DSC_SCRIPT_PATH):
     write_omsconfig_host_switch_event(pathToCurrentScript, isfile(dsc_host_switch_path))
@@ -98,4 +98,4 @@ stderr = stderr.decode() if isinstance(stderr, bytes) else stderr
 print(stdout)
 print(stderr)
 
-LG().Log("DEBUG", "End of script logic for " +  argv[0] + " runing with python " + str(sys.version_info.major))
+LG().Log("DEBUG", "End of script logic for " +  argv[0] + " runing with python " + str(sys.version_info))

--- a/LCM/scripts/python3/SetDscLocalConfigurationManager.py
+++ b/LCM/scripts/python3/SetDscLocalConfigurationManager.py
@@ -164,6 +164,6 @@ def apply_meta_config(args):
         fileHandle.close()
 
 if __name__ == "__main__":
-    LG().Log("DEBUG", "Starting Main method for " + argv[0] + " runing with python " + str(sys.version_info.major))
+    LG().Log("DEBUG", "Starting Main method for " + argv[0] + " runing with python " + str(sys.version_info))
     main(argv)
-    LG().Log("DEBUG", "End of Main method for " +  argv[0] + " runing with python " + str(sys.version_info.major))
+    LG().Log("DEBUG", "End of Main method for " +  argv[0] + " runing with python " + str(sys.version_info))

--- a/LCM/scripts/python3/StartDscConfiguration.py
+++ b/LCM/scripts/python3/StartDscConfiguration.py
@@ -221,6 +221,6 @@ def main(argv):
     print(stdout)   
     print(stderr)
 
-LG().Log("DEBUG", "Starting Main method for " + argv[0] + " runing with python " + str(sys.version_info.major))
+LG().Log("DEBUG", "Starting Main method for " + argv[0] + " runing with python " + str(sys.version_info))
 main(argv[1:])
-LG().Log("DEBUG", "End of Main method for " +  argv[0] + " runing with python " + str(sys.version_info.major))
+LG().Log("DEBUG", "End of Main method for " +  argv[0] + " runing with python " + str(sys.version_info))

--- a/LCM/scripts/python3/TestDscConfiguration.py
+++ b/LCM/scripts/python3/TestDscConfiguration.py
@@ -29,7 +29,7 @@ dsc_host_output_path = join(dsc_host_base_path, 'output')
 dsc_host_lock_path = join(dsc_host_base_path, 'dsc_host_lock')
 dsc_host_switch_path = join(dsc_host_base_path, 'dsc_host_ready')
 
-LG().Log("DEBUG", "Starting script logic for " + argv[0]+ " runing with python " + str(sys.version_info.major))
+LG().Log("DEBUG", "Starting script logic for " + argv[0]+ " runing with python " + str(sys.version_info))
 
 if ("omsconfig" in helperlib.DSC_SCRIPT_PATH):
     write_omsconfig_host_switch_event(pathToCurrentScript, isfile(dsc_host_switch_path))
@@ -109,4 +109,4 @@ stderr = stderr.decode() if isinstance(stderr, bytes) else stderr
 print(stdout)
 print(stderr)
 
-LG().Log("DEBUG", "End of script logic for " +  argv[0] + " runing with python " + str(sys.version_info.major))
+LG().Log("DEBUG", "End of script logic for " +  argv[0] + " runing with python " + str(sys.version_info))

--- a/Providers/Scripts/3.x/Scripts/nxService.py
+++ b/Providers/Scripts/3.x/Scripts/nxService.py
@@ -553,7 +553,8 @@ def GetSystemdState(sc):
     (process_stdout, process_stderr, retval) = Process(
         [systemctl_path, "status", sc.Name])
     if retval is 0:
-        if '(running)' in process_stdout:
+        process_stdout_str = process_stdout.decode() if isinstance(process_stdout, bytes) else process_stdout
+        if '(running)' in process_stdout_str:
             return "running"
     return "stopped"
 
@@ -602,7 +603,8 @@ def GetUpstartState(sc):
                  " failed: " + process_stderr)
         return ""
 
-    if (sc.Name + " start") in process_stdout:
+    process_stdout_str = process_stdout.decode() if isinstance(process_stdout, bytes) else process_stdout
+    if (sc.Name + " start") in process_stdout_str:
         return "running"
     else:
         return "stopped"
@@ -678,7 +680,8 @@ def GetUpstartEnabled(sc):
             (process_stdout, process_stderr, retval) = Process(
                 ['chkconfig', sc.Name, ''])  # try init style
             if retval is 0:
-                if 'off' not in process_stdout:
+                process_stdout_str = process_stdout.decode() if isinstance(process_stdout, bytes) else process_stdout
+                if 'off' not in process_stdout_str:
                     return True
             return False
         if start_on_exists and start_on_is_enabled:
@@ -855,7 +858,8 @@ def ServiceExistsInSystemd(sc):
     (process_stdout, process_stderr, retval) = Process(
         [systemctl_path, "status", sc.Name])
     if retval is not 0:
-        if "Loaded: loaded" in process_stdout:
+        process_stdout_str = process_stdout.decode() if isinstance(process_stdout, bytes) else process_stdout
+        if "Loaded: loaded" in process_stdout_str:
             return True
         else:
             return False
@@ -926,13 +930,14 @@ def ModifySystemdService(sc):
     (process_stdout, process_stderr, retval) = Process(
         [systemctl_path, "status", sc.Name + '.service'])
     # retval may be non zero even if service exists for 'status'.
-    if 'No such file or directory' in process_stdout:
+    process_stdout_str = process_stdout.decode() if isinstance(process_stdout, bytes) else process_stdout
+    if 'No such file or directory' in process_stdout_str:
         Print("Error: " + systemctl_path + " status " + sc.Name +
               " failed: " + process_stderr, file=sys.stderr)
         LG().Log('ERROR', "Error: " + systemctl_path +
                  " status " + sc.Name + " failed: " + process_stderr)
         return [-1]
-    if 'Active: active' in process_stdout:
+    if 'Active: active' in process_stdout_str:
         Print("Running", file=sys.stderr)
         LG().Log('INFO', "Running")
         if sc.State and sc.State != "running":
@@ -1132,7 +1137,8 @@ def ModifyInitService(sc):
                     LG().Log('ERROR', "Error: " + check_enabled_program +
                              " -f " + sc.Name + " defaults failed: " + process_stderr)
                     return [-1]
-                if 'already exist' in process_stdout:  # we need to remove them first
+                process_stdout_str = process_stdout.decode() if isinstance(process_stdout, bytes) else process_stdout
+                if 'already exist' in process_stdout_str:  # we need to remove them first
                     (process_stdout, process_stderr, retval) = Process(
                         [check_enabled_program, "-f", sc.Name, "remove"])
                     if retval is not 0:
@@ -1190,7 +1196,8 @@ def ModifyInitService(sc):
                     LG().Log('ERROR', "Error: " + check_enabled_program +
                              " -f " + sc.Name + " defaults failed: " + process_stderr)
                     return [-1]
-                if 'already exist' in process_stdout:  # we need to remove them first
+                process_stdout_str = process_stdout.decode() if isinstance(process_stdout, bytes) else process_stdout
+                if 'already exist' in process_stdout_str:  # we need to remove them first
                     (process_stdout, process_stderr, retval) = Process(
                         [check_enabled_program, "-f", sc.Name, "remove"])
                     if retval is not 0:


### PR DESCRIPTION
sys.version_info.major doesn't work for python 2.6 but works for 2.7

So decided to log sys.version_info which works for all python versions.

Currently released package 1.2.0-0 will break for centOS and redhat6 during logging for any script. This will fix the issue.

The plan is to release a patch maybe with version 1.2.1-0 and make it the latest. 

Also merged the branch that had fix for https://github.com/microsoft/PowerShell-DSC-for-Linux/issues/797

