### PR TITLE
MSRC 67460: Fix file ownership for NPM files

### DIFF
--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -500,6 +500,7 @@ chown root:root /opt/microsoft/${{SHORT_NAME}}/Scripts/OMSServiceStatAll.sh
 chown root:root /opt/microsoft/${{SHORT_NAME}}/Scripts/OMSYumUpdates.sh
 chown root:root /opt/microsoft/${{SHORT_NAME}}/Scripts/OMSZypperUpdates.sh
 chown root:root /opt/microsoft/${{SHORT_NAME}}/Scripts/OMSAptUpdates.sh
+chown root:root /opt/microsoft/${{SHORT_NAME}}/Scripts/NPMAgentBinaryCap.sh
 # Reset file ownership at /opt/microsoft/omsagent/plugin 
 chown root:root /opt/microsoft/omsagent/plugin/tailfilereader.rb
 


### PR DESCRIPTION
Make user and group as root for `Scripts/NPMAgentBinaryCap.sh`