### PR TITLE
Properly sort CustomLog objects before comparison

### DIFF
--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSSudoCustomLog.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxOMSSudoCustomLog.py
@@ -125,22 +125,22 @@ def Test(EnableCustomLogConfiguration, Ensure, CustomLogObjects):
             return [0]
         elif CurrentCustomLogObjects is None or CustomLogObjects is None:
             return [-1]
-        
-        CustomLogObjects.sort()
+
+        CustomLogObjects = sorted(CustomLogObjects, key = lambda d : d['LogName'])
         for customlog in CustomLogObjects:
             customlog['FilePath'].sort()
 
-        CurrentCustomLogObjects.sort()
+        CurrentCustomLogObjects = sorted(CurrentCustomLogObjects, key = lambda d : d['LogName'])
         for customlog in CurrentCustomLogObjects:
             customlog['FilePath'].sort()
 
         if CustomLogObjects != CurrentCustomLogObjects:
             return [-1]
-       
+
         if Ensure == "Absent":
             return [-1]
-        
-    return [0] 
+
+    return [0]
 
 def Get(EnableCustomLogConfiguration, Ensure, CustomLogObjects):
     CurrentCustomLogObjects = ReadConf()

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSSudoCustomLog.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxOMSSudoCustomLog.py
@@ -125,22 +125,22 @@ def Test(EnableCustomLogConfiguration, Ensure, CustomLogObjects):
             return [0]
         elif CurrentCustomLogObjects is None or CustomLogObjects is None:
             return [-1]
-        
-        CustomLogObjects.sort()
+
+        CustomLogObjects = sorted(CustomLogObjects, key = lambda d : d['LogName'])
         for customlog in CustomLogObjects:
             customlog['FilePath'].sort()
 
-        CurrentCustomLogObjects.sort()
+        CurrentCustomLogObjects = sorted(CurrentCustomLogObjects, key = lambda d : d['LogName'])
         for customlog in CurrentCustomLogObjects:
             customlog['FilePath'].sort()
 
         if CustomLogObjects != CurrentCustomLogObjects:
             return [-1]
-       
+
         if Ensure == "Absent":
             return [-1]
-         
-    return [0] 
+
+    return [0]
 
 def Get(EnableCustomLogConfiguration, Ensure, CustomLogObjects):
     CurrentCustomLogObjects = ReadConf()

--- a/Providers/Scripts/3.x/Scripts/nxOMSSudoCustomLog.py
+++ b/Providers/Scripts/3.x/Scripts/nxOMSSudoCustomLog.py
@@ -122,22 +122,22 @@ def Test(EnableCustomLogConfiguration, Ensure, CustomLogObjects):
             return [0]
         elif CurrentCustomLogObjects is None or CustomLogObjects is None:
             return [-1]
-        
-        sorted(CustomLogObjects, key = lambda p:p['LogName'])
+
+        CustomLogObjects = sorted(CustomLogObjects, key = lambda d : d['LogName'])
         for customlog in CustomLogObjects:
             customlog['FilePath'].sort()
 
-        sorted(CurrentCustomLogObjects, key = lambda p:p['LogName'])
+        CurrentCustomLogObjects = sorted(CurrentCustomLogObjects, key = lambda d : d['LogName'])
         for customlog in CurrentCustomLogObjects:
             customlog['FilePath'].sort()
 
         if CustomLogObjects != CurrentCustomLogObjects:
             return [-1]
-       
+
         if Ensure == "Absent":
             return [-1]
-        
-    return [0] 
+
+    return [0]
 
 def Get(EnableCustomLogConfiguration, Ensure, CustomLogObjects):
     CurrentCustomLogObjects = ReadConf()


### PR DESCRIPTION
The current sorting logic doesn't properly sort before comparing current and goal-state CL configuration. This can lead to module TEST continually returning non-zero, which leads to SET being called and restarting the agent every 15 minutes.

ICM 289557097