### PR TITLE
Set StickyBit to npm_state folder

### DIFF
--- a/Providers/Modules/NPM/Plugin/plugin/in_npmd_server.rb
+++ b/Providers/Modules/NPM/Plugin/plugin/in_npmd_server.rb
@@ -211,6 +211,7 @@ module Fluent
                 unless File.directory?(_dirname)
                     # This is setting up the npm_state directory
                     FileUtils.mkdir_p(_dirname)
+                    FileUtils.chmod "+t", _dirname
                 end
                 if File.exists?(@location_unix_endpoint)
                     File.unlink(@location_unix_endpoint)


### PR DESCRIPTION
**Problem:**

/var/opt/microsoft/omsagent/npm_state folder is created by NPM Plugin via omsagent.

Then, folder is being created with 777 permissions just like any other omsagent log folders. So, level of permissions cannot be decreased for npm_state folder alone.

So, anyone can edit the contents of the folder.

To avoid this problem, sticky bit can be set on npm_state folder.

Sticky bit - If enabled, only the creator of the folder OR root user can edit the folder.

Hence, fix is that sticky bit is enabled on npm_state folder so that only "omsagent" user can edit the contents of the folder OR root user (which is obvious).
