### PR TITLE
Change in Classification from "Security" to "Security Updates"

### DIFF
--- a/Providers/Scripts/2.4x-2.5x/Scripts/nxAvailableUpdates.py
+++ b/Providers/Scripts/2.4x-2.5x/Scripts/nxAvailableUpdates.py
@@ -107,7 +107,7 @@ def GetAptUpdates(Name):
         d['Architecture'] = pkg[3]
         d['Version'] = pkg[1]
         if d['Name'] in security_patch_list:
-            d['Classification'] = "Security"
+            d['Classification'] = "Security Updates"
         else:
             d['Classification'] = "Others"
         d['Repository'] = pkg[2]
@@ -283,7 +283,7 @@ def get_yum_updates_list(yum_pkg_info_list, security_updates, Name):
             d['Version'] = '0:' + d['Version']
         d['Version'] = d['Version'].replace('(none)', '0')  # Handle the Epoch '(none)'.
         if str(d['Name']).strip() + "." + str(d['Architecture']).strip() in security_updates:
-           d['Classification'] = "Security"
+           d['Classification'] = "Security Updates"
         else:
            d['Classification'] = "Others"
         d['Repository'] = yum_pkg_info.group(5)
@@ -353,7 +353,7 @@ def GetZypperUpdates(Name):
         d['Architecture'] = pkg[5].strip()
         d['Version'] = "0:" + pkg[4].strip()
         if d['Name'] in packages_from_patch_data:
-           d['Classification'] = "Security"
+           d['Classification'] = "Security Updates"
         else:
            d['Classification'] = "Others"
         d['Repository'] = pkg[1].strip()

--- a/Providers/Scripts/2.6x-2.7x/Scripts/nxAvailableUpdates.py
+++ b/Providers/Scripts/2.6x-2.7x/Scripts/nxAvailableUpdates.py
@@ -107,7 +107,7 @@ def GetAptUpdates(Name):
         d['Architecture'] = pkg[3]
         d['Version'] = pkg[1]
         if d['Name'] in security_patch_list:
-            d['Classification'] = "Security"
+            d['Classification'] = "Security Updates"
         else:
             d['Classification'] = "Others"
         d['Repository'] = pkg[2]
@@ -284,7 +284,7 @@ def get_yum_updates_list(yum_pkg_info_list, security_updates, Name):
             d['Version'] = '0:' + d['Version']
         d['Version'] = d['Version'].replace('(none)', '0')  # Handle the Epoch '(none)'.
         if str(d['Name']).strip() + "." + str(d['Architecture']).strip() in security_updates:
-           d['Classification'] = "Security"
+           d['Classification'] = "Security Updates"
         else:
            d['Classification'] = "Others"
         d['Repository'] = yum_pkg_info.group(5)
@@ -355,7 +355,7 @@ def GetZypperUpdates(Name):
         d['Architecture'] = pkg[5].strip()
         d['Version'] = "0:" + pkg[4].strip()
         if d['Name'] in packages_from_patch_data:
-           d['Classification'] = "Security"
+           d['Classification'] = "Security Updates"
         else:
            d['Classification'] = "Others"
         d['Repository'] = pkg[1].strip()

--- a/Providers/Scripts/3.x/Scripts/nxAvailableUpdates.py
+++ b/Providers/Scripts/3.x/Scripts/nxAvailableUpdates.py
@@ -105,7 +105,7 @@ def GetAptUpdates(Name):
         d['Architecture'] = pkg[3]
         d['Version'] = pkg[1]
         if d['Name'] in security_patch_list:
-            d['Classification'] = "Security"
+            d['Classification'] = "Security Updates"
         else:
             d['Classification'] = "Others"
         d['Repository'] = pkg[2]
@@ -281,7 +281,7 @@ def get_yum_updates_list(yum_pkg_info_list, security_updates, Name):
             d['Version'] = '0:' + d['Version']
         d['Version'] = d['Version'].replace('(none)', '0')  # Handle the Epoch '(none)'.
         if str(d['Name']).strip() + "." + str(d['Architecture']).strip() in security_updates:
-           d['Classification'] = "Security"
+           d['Classification'] = "Security Updates"
         else:
            d['Classification'] = "Others"
         d['Repository'] = yum_pkg_info.group(5)
@@ -351,7 +351,7 @@ def GetZypperUpdates(Name):
             continue
         d['Architecture'] = pkg[5].strip()
         if d['Name'] in packages_from_patch_data:
-           d['Classification'] = "Security"
+           d['Classification'] = "Security Updates"
         else:
            d['Classification'] = "Others"
         d['Version'] = "0:" + pkg[4].strip()


### PR DESCRIPTION
Initially, Added classification name as "Security" which as being converted anyway as "Security Updates" in ruby file. This change is to send correct name from the assessment code itself.