### PR TITLE
Mcafee Endpoint : Changing timeformat to be generic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -541,7 +541,7 @@ nxOMSGenerateInventoryMof:
 
 nxOMSPlugin:
 	rm -rf output/staging; \
-	VERSION="3.70"; \
+	VERSION="3.71"; \
 	PROVIDERS="nxOMSPlugin"; \
 	STAGINGDIR="output/staging/$@/DSCResources"; \
 	cat Providers/Modules/$@.psd1 | sed "s@<MODULE_VERSION>@$${VERSION}@" > intermediate/Modules/$@.psd1; \

--- a/Providers/Modules/Plugins/Antimalware/plugin/collectmcafeeinfo.rb
+++ b/Providers/Modules/Plugins/Antimalware/plugin/collectmcafeeinfo.rb
@@ -11,13 +11,16 @@ class McAfee
 
 	attr_accessor :detectedPath , :mcafeeName , :mcafeeVersion 
     def self.findMcAfeePath()
+		puts "findMcAfeePath"
         paths = ['/opt/McAfee/ens/tp/bin/mfetpcli','/opt/isec/ens/threatprevention/bin/isecav']   
         for path in paths 
             if File.file?(path)
-                @detectedPath = path
+				@detectedPath = path
                 detectioncmd = `#{path} --version 2>&1`.lines.map(&:chomp)
+				puts "findMcAfeePath detectioncmd : #{detectioncmd} "
 				@mcafeeName = detectioncmd[0]
                 @mcafeeVersion = detectioncmd[1].split(" : ")[1]
+				puts "findMcAfeePath detectedPath : #{@detectedPath} , mcafeeName : #{@mcafeeName} , mcafeeVersion : #{@mcafeeVersion} "
 				break
             end
         end
@@ -25,22 +28,30 @@ class McAfee
 
     def self.detect()  
         begin
+			puts "detect : Starting"
             findMcAfeePath()
             if !File.file?(@detectedPath)
-                return false
+				puts "detect : File not found : Returing False"
+				return false
             end                             
-            if ( @mcafeeName == nil || @mcafeeName != "McAfee Endpoint Security for Linux Threat Prevention")                   
-                return false
+            if ( @mcafeeName == nil || @mcafeeName != "Trellix Endpoint Security for Linux Threat Prevention")                   
+                puts "detect : mcafee nil or nor ESLTP : Returing False"
+				return false
             elsif ( @mcafeeVersion == nil || @mcafeeVersion.split(".")[0].to_i  < 10)                   
-                return false
+                puts "detect : mcafee less than 10 : Returing False"
+				return false
             end
-            return true
-        rescue => e                
+            puts "detect : mcafee nil or nor ESLTP : Returing True"
+			return true
+
+        rescue => e
+			puts "detect : Exception #{e} : Returing False"                
             return false            
         end
     end
 
 	def self.getprotectionstatus()		 
+		puts "getprotectionstatus : Starting"
 		ret = {}
 		
 		mcafeeName = @mcafeeName
@@ -247,10 +258,13 @@ class McAfee
     	ret["Tool"] = mcafeeName
 		ret["AMProductVersion"] = (mcafeeVersion.nil? || mcafeeVersion.empty? || mcafeeVersion == "NA")? "McAfee version not found" : mcafeeVersion
 		return ret
+		puts "getprotectionstatus : Ending"
+		
 	end
 
 	def self.parseMcAfeeDateTime(datearray , mcafeeVersion)
 		begin
+			puts "parseMcAfeeDateTime : Starting"
 			mcafeeVersionSplit = mcafeeVersion.to_s.split(".")
 			if (mcafeeVersionSplit[1].to_i > 6) || (mcafeeVersionSplit[1].to_i == 6 && mcafeeVersionSplit[2].to_i >=6 )
 				return parseMcAfeeDateTimeForSixPointSixVersionAndNewer(datearray)
@@ -264,16 +278,19 @@ class McAfee
 	end
 
 	def self.parseMcAfeeDateTimeSixPointFiveVersionAndOlder(datearray)
+		puts "parseMcAfeeDateTimeSixPointFiveVersionAndOlder : Starting"
 		$l = datearray.length
 		scandate = 'NA'
 		scanstatus = 'NA'		
 		if $l >= 4
 			if(!datearray[$l-3].include? "AM") && (!datearray[$l-3].include? "PM")
-				scandate = datearray[$l-4] + " " + datearray[$l-3] + " " + datearray[$l-2]						
-				scandate = Time.strptime(scandate, '%d/%m/%y %H:%M:%S %Z')
+				scandatestring = datearray[$l-4] + " " + datearray[$l-3] + " " + datearray[$l-2]						
+				scandateparsed = Time.parse(scandatestring)
+				scandate = scandateparsed.utc.strftime('%m/%d/%Y %H:%M:%S')
 			elsif $l >= 8
-				scandate = datearray[$l-7] + " " + datearray[$l-6] + " " + datearray[$l-5] + " " + datearray[$l-4] + " " + datearray[$l-3] + " " + datearray[$l-2]				
-				scandate = Time.strptime(scandate, '%d %b %Y %I:%M:%S %p %Z')
+				scandatestring = datearray[$l-7] + " " + datearray[$l-6] + " " + datearray[$l-5] + " " + datearray[$l-4] + " " + datearray[$l-3] + " " + datearray[$l-2]				
+				scandateparsed = Time.parse(scandatestring)
+				scandate = scandateparsed.utc.strftime('%m/%d/%Y %H:%M:%S')
 			end
 			if $l >= 5 && (!datearray[4].include? "Not")
 				scanstatus = datearray[4]
@@ -282,17 +299,23 @@ class McAfee
 				scanstatus = datearray[9]
 			end
 		end
-		return scandate, scanstatus
+		return Time.Parse(scandate), scanstatus
 	end
 
-	def self.parseMcAfeeDateTimeForSixPointSixVersionAndNewer(datearray)		
-		$l = datearray.length
-		scandate = 'NA'
-		scanstatus = 'NA'
-		scandate = datearray[$l-6] + " " + datearray[$l-5] + " " + datearray[$l-4] + " " + datearray[$l-3] + " " + datearray[$l-2] + " " + datearray[$l-1]
-		scandate = Time.strptime(scandate, '%a %b %d %H:%M:%S %Y')
-		scandate.utc.strftime("%d/%m/%y %H:%M:%S %Z")
-		scanstatus = datearray[9]
-		return scandate, scanstatus
+	def self.parseMcAfeeDateTimeForSixPointSixVersionAndNewer(datearray)
+		begin
+			puts "parseMcAfeeDateTimeForSixPointSixVersionAndNewer : Starting"		
+			puts datearray
+			$l = datearray.length
+			scandate = 'NA'
+			scanstatus = 'NA'
+			scandatestring = datearray[$l-6] + " " + datearray[$l-5] + " " + datearray[$l-4] + " " + datearray[$l-3] + " " + datearray[$l-2] + " " + datearray[$l-1]
+			puts "scandatestring : #{scandatestring}" 
+			scandateparsed = Time.parse(scandatestring)
+			scandateparsed.utc.strftime('%m/%d/%Y %H:%M:%S')
+			scanstatus = datearray[9]
+			puts "scandate : #{scandate.class} , scanstatus : #{scanstatus}  " 
+			return scandateparsed, scanstatus
+		end
 	end
 end

--- a/Providers/Modules/Plugins/Antimalware/plugin/collectmcafeeinfo.rb
+++ b/Providers/Modules/Plugins/Antimalware/plugin/collectmcafeeinfo.rb
@@ -285,6 +285,7 @@ class McAfee
 		return scandate, scanstatus
 	end
 
+	# function to handle version 10.6.6 and above for mcafee
 	def self.parseMcAfeeDateTimeForSixPointSixVersionAndNewer(taskcmd, datearray)
 		begin
 			$l = datearray.length

--- a/Providers/Modules/Plugins/Antimalware/plugin/collectmcafeeinfo.rb
+++ b/Providers/Modules/Plugins/Antimalware/plugin/collectmcafeeinfo.rb
@@ -11,16 +11,13 @@ class McAfee
 
 	attr_accessor :detectedPath , :mcafeeName , :mcafeeVersion 
     def self.findMcAfeePath()
-		puts "findMcAfeePath"
         paths = ['/opt/McAfee/ens/tp/bin/mfetpcli','/opt/isec/ens/threatprevention/bin/isecav']   
         for path in paths 
             if File.file?(path)
 				@detectedPath = path
                 detectioncmd = `#{path} --version 2>&1`.lines.map(&:chomp)
-				puts "findMcAfeePath detectioncmd : #{detectioncmd} "
 				@mcafeeName = detectioncmd[0]
                 @mcafeeVersion = detectioncmd[1].split(" : ")[1]
-				puts "findMcAfeePath detectedPath : #{@detectedPath} , mcafeeName : #{@mcafeeName} , mcafeeVersion : #{@mcafeeVersion} "
 				break
             end
         end
@@ -28,30 +25,22 @@ class McAfee
 
     def self.detect()  
         begin
-			puts "detect : Starting"
-            findMcAfeePath()
+			findMcAfeePath()
             if !File.file?(@detectedPath)
-				puts "detect : File not found : Returing False"
 				return false
             end                             
-            if ( @mcafeeName == nil || @mcafeeName != "Trellix Endpoint Security for Linux Threat Prevention")                   
-                puts "detect : mcafee nil or nor ESLTP : Returing False"
+            if (@mcafeeName == nil)	
 				return false
-            elsif ( @mcafeeVersion == nil || @mcafeeVersion.split(".")[0].to_i  < 10)                   
-                puts "detect : mcafee less than 10 : Returing False"
-				return false
+            elsif (@mcafeeVersion == nil || @mcafeeVersion.split(".")[0].to_i  < 10)                   
+            	return false
             end
-            puts "detect : mcafee nil or nor ESLTP : Returing True"
-			return true
-
+            return true
         rescue => e
-			puts "detect : Exception #{e} : Returing False"                
-            return false            
+			return false            
         end
     end
 
-	def self.getprotectionstatus()		 
-		puts "getprotectionstatus : Starting"
+	def self.getprotectionstatus() 
 		ret = {}
 		
 		mcafeeName = @mcafeeName
@@ -104,7 +93,7 @@ class McAfee
 						else
 							quickscanarray = taskcmd[$i].split(" ")
 							quickscanStatus = 'NA'
-							quickscan, quickscanStatus = parseMcAfeeDateTime(quickscanarray , @mcafeeVersion)
+							quickscan, quickscanStatus = parseMcAfeeDateTime(taskcmd[$i], quickscanarray , @mcafeeVersion)
 							if quickscan == "NA"
 								protectionStatusDetailsArray.push("Fail to parse quickscan date: " + taskcmd[$i])
 							end
@@ -119,7 +108,7 @@ class McAfee
 						else		
 							fullscanarray = taskcmd[$i].split(" ")
 							fullscanStatus = 'NA'
-							fullscan, fullscanStatus = parseMcAfeeDateTime(fullscanarray, @mcafeeVersion)						
+							fullscan, fullscanStatus = parseMcAfeeDateTime(taskcmd[$i], fullscanarray, @mcafeeVersion)						
 							if fullscan == "NA"
 								protectionStatusDetailsArray.push("Fail to parse fullscan date: " + taskcmd[$i])
 							end
@@ -133,7 +122,7 @@ class McAfee
 						else
 							datengupdatearray = taskcmd[$i].split(" ")
 							datengupdateStatus = 'NA'
-							datengupdate, datengupdateStatus = parseMcAfeeDateTime(datengupdatearray, @mcafeeVersion)
+							datengupdate, datengupdateStatus = parseMcAfeeDateTime(taskcmd[$i], datengupdatearray, @mcafeeVersion)
 							if datengupdate == "NA"
 								protectionStatusDetailsArray.push("Fail to parse DAT Engine update date: " + taskcmd[$i])
 							end
@@ -258,16 +247,13 @@ class McAfee
     	ret["Tool"] = mcafeeName
 		ret["AMProductVersion"] = (mcafeeVersion.nil? || mcafeeVersion.empty? || mcafeeVersion == "NA")? "McAfee version not found" : mcafeeVersion
 		return ret
-		puts "getprotectionstatus : Ending"
-		
 	end
 
-	def self.parseMcAfeeDateTime(datearray , mcafeeVersion)
+	def self.parseMcAfeeDateTime(taskcmd, datearray , mcafeeVersion)
 		begin
-			puts "parseMcAfeeDateTime : Starting"
 			mcafeeVersionSplit = mcafeeVersion.to_s.split(".")
 			if (mcafeeVersionSplit[1].to_i > 6) || (mcafeeVersionSplit[1].to_i == 6 && mcafeeVersionSplit[2].to_i >=6 )
-				return parseMcAfeeDateTimeForSixPointSixVersionAndNewer(datearray)
+				return parseMcAfeeDateTimeForSixPointSixVersionAndNewer(taskcmd, datearray)
 			else
 				return parseMcAfeeDateTimeSixPointFiveVersionAndOlder(datearray) 
 			end
@@ -278,19 +264,16 @@ class McAfee
 	end
 
 	def self.parseMcAfeeDateTimeSixPointFiveVersionAndOlder(datearray)
-		puts "parseMcAfeeDateTimeSixPointFiveVersionAndOlder : Starting"
 		$l = datearray.length
 		scandate = 'NA'
 		scanstatus = 'NA'		
 		if $l >= 4
 			if(!datearray[$l-3].include? "AM") && (!datearray[$l-3].include? "PM")
-				scandatestring = datearray[$l-4] + " " + datearray[$l-3] + " " + datearray[$l-2]						
-				scandateparsed = Time.parse(scandatestring)
-				scandate = scandateparsed.utc.strftime('%m/%d/%Y %H:%M:%S')
+				scandate = datearray[$l-4] + " " + datearray[$l-3] + " " + datearray[$l-2]						
+				scandate = Time.strptime(scandate, '%d/%m/%y %H:%M:%S %Z')
 			elsif $l >= 8
-				scandatestring = datearray[$l-7] + " " + datearray[$l-6] + " " + datearray[$l-5] + " " + datearray[$l-4] + " " + datearray[$l-3] + " " + datearray[$l-2]				
-				scandateparsed = Time.parse(scandatestring)
-				scandate = scandateparsed.utc.strftime('%m/%d/%Y %H:%M:%S')
+				scandate = datearray[$l-7] + " " + datearray[$l-6] + " " + datearray[$l-5] + " " + datearray[$l-4] + " " + datearray[$l-3] + " " + datearray[$l-2]				
+				scandate = Time.strptime(scandate, '%d %b %Y %I:%M:%S %p %Z')
 			end
 			if $l >= 5 && (!datearray[4].include? "Not")
 				scanstatus = datearray[4]
@@ -299,23 +282,20 @@ class McAfee
 				scanstatus = datearray[9]
 			end
 		end
-		return Time.Parse(scandate), scanstatus
+		return scandate, scanstatus
 	end
 
-	def self.parseMcAfeeDateTimeForSixPointSixVersionAndNewer(datearray)
+	def self.parseMcAfeeDateTimeForSixPointSixVersionAndNewer(taskcmd, datearray)
 		begin
-			puts "parseMcAfeeDateTimeForSixPointSixVersionAndNewer : Starting"		
-			puts datearray
 			$l = datearray.length
 			scandate = 'NA'
 			scanstatus = 'NA'
+			regularexpressionforscanstatus = /\b(Not Started|Running|Completed|Aborted)\b/
 			scandatestring = datearray[$l-6] + " " + datearray[$l-5] + " " + datearray[$l-4] + " " + datearray[$l-3] + " " + datearray[$l-2] + " " + datearray[$l-1]
-			puts "scandatestring : #{scandatestring}" 
 			scandateparsed = Time.parse(scandatestring)
 			scandateparsed.utc.strftime('%m/%d/%Y %H:%M:%S')
-			scanstatus = datearray[9]
-			puts "scandate : #{scandate.class} , scanstatus : #{scanstatus}  " 
-			return scandateparsed, scanstatus
+			scanstatus = (regularexpressionforscanstatus.match(taskcmd))
+			return scandateparsed, scanstatus.to_s
 		end
 	end
 end

--- a/installbuilder/datafiles/Base_DSC.data
+++ b/installbuilder/datafiles/Base_DSC.data
@@ -102,7 +102,7 @@ SHLIB_EXT: 'so'
 /opt/microsoft/omsconfig/module_packages/nxOMSContainers_1.0.zip; release/nxOMSContainers_1.0.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSCustomLog_1.0.zip; release/nxOMSCustomLog_1.0.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSGenerateInventoryMof_1.5.zip; release/nxOMSGenerateInventoryMof_1.5.zip; 755; ${{RUN_AS_USER}}; root
-/opt/microsoft/omsconfig/module_packages/nxOMSPlugin_3.70.zip; release/nxOMSPlugin_3.70.zip; 755; ${{RUN_AS_USER}}; root
+/opt/microsoft/omsconfig/module_packages/nxOMSPlugin_3.71.zip; release/nxOMSPlugin_3.71.zip; 755; ${{RUN_AS_USER}}; root
 /opt/microsoft/omsconfig/module_packages/nxOMSWLI_1.46.zip; release/nxOMSWLI_1.46.zip; 755; ${{RUN_AS_USER}}; root
 #endif
 
@@ -418,7 +418,7 @@ if [ "$pythonVersion" = "python3" ]; then
 	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/python3/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSContainers_1.0.zip 0"
 	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/python3/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSCustomLog_1.0.zip 0"
 	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/python3/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSGenerateInventoryMof_1.5.zip 0"
-	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/python3/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSPlugin_3.70.zip 0"
+	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/python3/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSPlugin_3.71.zip 0"
 	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/python3/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSWLI_1.46.zip 0"
 else
   echo "Running python2 python version is ", $pythonVersion
@@ -428,7 +428,7 @@ else
 	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSContainers_1.0.zip 0"
 	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSCustomLog_1.0.zip 0"
 	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSGenerateInventoryMof_1.5.zip 0"
-	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSPlugin_3.70.zip 0"
+	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSPlugin_3.71.zip 0"
 	su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSWLI_1.46.zip 0"
 #endif
 


### PR DESCRIPTION
* Changed Timformat class to not being spcific to particular timeformat but to be able to parse time format from inbuilt classes.

scandateparsed = Time.parse(scandatestring)
scandateparsed.utc.strftime('%m/%d/%Y %H:%M:%S')

* scan status as array populating successfully
* Tested for all different date formats and formats specified by customer : Not breaking , but GMT is not getting converted. 
This should be fine as we cacualte for 7 days scan and diffeternt GMT/IST to UTC dffer by 4-8 hours which should not be concerning. 
* As mcafee can only be installed 10 times I am testing it on Ubuntu 20.x vrsion only.


* https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/0ee9d577-9bc4-4a32-a4e8-c29981025378/resourceGroups/alimaye-am-rg/providers/Microsoft.Compute/virtualMachines/alimaye-omsagent-test-2/vmLogAnalytics 

![image](https://github.com/microsoft/PowerShell-DSC-for-Linux/assets/100320430/18164dba-aa9c-4332-a07e-f538e444f308)
