### PR TITLE
bugfix: allow hybrid worker groups with spaces

### DIFF
--- a/Providers/nxOMSAutomationWorker/automationworker/3.x/worker/jrdsclient.py
+++ b/Providers/nxOMSAutomationWorker/automationworker/3.x/worker/jrdsclient.py
@@ -8,6 +8,7 @@
 from datetime import datetime
 import time
 import traceback
+import urllib.parse
 
 
 import configuration3 as configuration
@@ -69,8 +70,9 @@ class JRDSClient(object):
                 }
             ]
         """
+        encoded_hybrid_worker_group_name = urllib.parse.quote(self.HybridWorkerGroupName)
         url = self.base_uri + "/automationAccounts/" + self.account_id + \
-              "/Sandboxes/GetSandboxActions?HybridWorkerGroupName=" + self.HybridWorkerGroupName + \
+              "/Sandboxes/GetSandboxActions?HybridWorkerGroupName=" + encoded_hybrid_worker_group_name + \
               "&api-version=" + self.protocol_version
         response = self.issue_request(lambda u: self.httpClient.get(u), url)
 

--- a/Providers/nxOMSAutomationWorker/automationworker/worker/jrdsclient.py
+++ b/Providers/nxOMSAutomationWorker/automationworker/worker/jrdsclient.py
@@ -7,6 +7,7 @@
 from datetime import datetime
 import time
 import traceback
+import urllib.parse
 
 
 import configuration
@@ -68,8 +69,9 @@ class JRDSClient:
                 }
             ]
         """
+        encoded_hybrid_worker_group_name = urllib.parse.quote(self.HybridWorkerGroupName)
         url = self.base_uri + "/automationAccounts/" + self.account_id + \
-              "/Sandboxes/GetSandboxActions?HybridWorkerGroupName=" + self.HybridWorkerGroupName + \
+              "/Sandboxes/GetSandboxActions?HybridWorkerGroupName=" + encoded_hybrid_worker_group_name + \
               "&api-version=" + self.protocol_version
         response = self.issue_request(lambda u: self.httpClient.get(u), url)
 


### PR DESCRIPTION
When there are spaces in the hybrid worker group name this library doesn't encode spaces and the `Sandboxes/GetSandboxAction` API returns a HTTP 400 because the name is not correctly encoded. This PR fixes it so it encodes the hybrid worker group with spaces with `%20`.