### PR TITLE
Update nxOMSAgentNPMConfig DSC module to 4.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -660,7 +660,7 @@ nxFileInventory:
 
 nxOMSAgentNPMConfig:
 	rm -rf output/staging; \
-	VERSION="4.5"; \
+	VERSION="4.6"; \
 	PROVIDERS="nxOMSAgentNPMConfig"; \
 	STAGINGDIR="output/staging/$@/DSCResources"; \
 	cat Providers/Modules/$@.psd1 | sed "s@<MODULE_VERSION>@$${VERSION}@" > intermediate/Modules/$@.psd1; \


### PR DESCRIPTION
Under this PR, 

1. Changes are made to update binaries to related to nxOMSAgentNPMConfig DSC module.

2. npmd_agent_x64 binary got updated to latest of NPMD repo.

         Following is the PR at NPMD side: 

           [Pull Request 9600476](https://msazure.visualstudio.com/One/_git/Mgmt-LogAnalytics-NPMD/pullrequest/9600476): Remove NPM

3. Updated nxOMSAgentNPMConfig DSC version number to 4.6 to reflect the changes.